### PR TITLE
Add a take ownership command example. 

### DIFF
--- a/parti/commandline/src/cli.yml
+++ b/parti/commandline/src/cli.yml
@@ -41,7 +41,7 @@ subcommands:
             short: w
             long: pass
             value_name: password
-            about: the password for the existing snapshot.
+            about: the password for the snapshot.
             required: true
             takes_value: true
   - read:
@@ -51,7 +51,7 @@ subcommands:
             short: w
             long: pass
             value_name: password
-            about: the password for the existing snapshot.
+            about: the password for the snapshot.
             required: true
             takes_value: true
         - id:
@@ -68,7 +68,7 @@ subcommands:
             short: w
             long: pass
             value_name: password
-            about: the password for the existing snapshot.
+            about: the password for the snapshot.
             required: true
             takes_value: true
         - id:
@@ -85,6 +85,16 @@ subcommands:
             short: w
             long: pass
             value_name: password
-            about: the password for the existing snapshot.
+            about: the password for the snapshot.
+            required: true
+            takes_value: true
+  - take_ownership:
+      about: Take ownership of an existing chain.
+      args:
+        - password:
+            short: w
+            long: pass
+            value_name: password
+            about: the password for the snapshot.
             required: true
             takes_value: true

--- a/parti/commandline/src/client.rs
+++ b/parti/commandline/src/client.rs
@@ -1,4 +1,4 @@
-use vault::{BoxProvider, DBView, DBWriter, Id, Key, RecordHint};
+use vault::{BoxProvider, DBView, DBWriter, Id, Key, ListResult, RecordHint};
 
 use crate::{
     connection::{send_until_success, CRequest, CResult},
@@ -34,7 +34,7 @@ pub struct Snapshot<P: BoxProvider> {
 
 impl<P: BoxProvider + Send + Sync + 'static> Client<P> {
     // create a new client
-    pub fn new(id: Id, key: Key<P>) -> Self {
+    pub fn new(key: Key<P>, id: Id) -> Self {
         Self {
             id,
             db: Vault::<P>::new(key),
@@ -101,6 +101,22 @@ impl<P: BoxProvider + Send + Sync + 'static> Client<P> {
         });
     }
 
+    // Take ownership of an existing chain.  Requires that the new owner knows the old key to unlock the data.
+    pub fn take_ownership(&self, old: Id) {
+        // load all of the data from the storage vault.
+        let ids = send_until_success(CRequest::List).list();
+        // use the key to unlock the data.
+        let db = DBView::load(self.db.key.clone(), ListResult::new(ids.into())).expect(line_error!());
+
+        let (to_write, to_delete) = db.writer(self.id).take_ownership(&old).expect(line_error!());
+        to_write.into_iter().for_each(|req| {
+            send_until_success(CRequest::Write(req));
+        });
+        to_delete.into_iter().for_each(|req| {
+            send_until_success(CRequest::Delete(req));
+        });
+    }
+
     // create a revoke transaction in the chain.
     pub fn revoke_record_by_id(&self, id: Id) {
         self.db.take(|db| {
@@ -130,7 +146,7 @@ impl<P: BoxProvider> Vault<P> {
         let retval = f(db);
 
         let req = send_until_success(CRequest::List).list();
-        *_db = Some(vault::DBView::load(self.key.clone(), req).expect(line_error!()));
+        *_db = Some(DBView::load(self.key.clone(), req).expect(line_error!()));
         retval
     }
 }

--- a/parti/commandline/src/main.rs
+++ b/parti/commandline/src/main.rs
@@ -143,6 +143,26 @@ fn garbage_collect_vault_command(matches: &ArgMatches) {
     }
 }
 
+// Take ownership of an existing chain. Requires that the new chain owner knows the old key to unlock the data.
+fn take_ownership_command(matches: &ArgMatches) {
+    if let Some(matches) = matches.subcommand_matches("take_ownership") {
+        if let Some(ref pass) = matches.value_of("password") {
+            let new_id = Id::random::<Provider>().expect("Unable to generate a new id");
+
+            let snapshot = get_snapshot_path();
+            let client: Client<Provider> = deserialize_from_snapshot(&snapshot, pass);
+            let new_client: Client<Provider> = Client::create_chain(client.db.key, new_id);
+
+            new_client.take_ownership(client.id);
+
+            println!("Old owner id: {:?}\nNew owner id: {:?}", client.id, new_client.id);
+
+            let snapshot = get_snapshot_path();
+            serialize_to_snapshot(&snapshot, pass, new_client);
+        }
+    }
+}
+
 fn main() {
     let yaml = load_yaml!("cli.yml");
     let matches = App::from(yaml).get_matches();
@@ -153,4 +173,5 @@ fn main() {
     list_command(&matches);
     revoke_command(&matches);
     garbage_collect_vault_command(&matches);
+    take_ownership_command(&matches);
 }

--- a/parti/commandline/src/snap.rs
+++ b/parti/commandline/src/snap.rs
@@ -29,7 +29,7 @@ pub(in crate) fn deserialize_from_snapshot(snapshot: &PathBuf, pass: &str) -> Cl
 
     let (id, key) = snap.offload();
 
-    Client::<Provider>::new(id, key)
+    Client::<Provider>::new(key, id)
 }
 
 // serialize the snapshot data into the snapshot file.

--- a/parti/vault/src/vault.rs
+++ b/parti/vault/src/vault.rs
@@ -39,7 +39,7 @@ pub struct DBWriter<P: BoxProvider> {
 impl<P: BoxProvider> DBView<P> {
     /// Opens a vault using a key. Accepts the `ids` of the records that you want to load.  
     pub fn load(key: Key<P>, ids: ListResult) -> crate::Result<Self> {
-        // get records based on the Ids
+        // get records based on the Ids and open them with the key.
         let records = ids.into_iter().filter_map(|id| Record::open(&key, &id));
 
         // build indices

--- a/parti/vault/src/vault/record.rs
+++ b/parti/vault/src/vault/record.rs
@@ -37,7 +37,7 @@ impl ChainRecord {
 
             if result.is_none() {
                 return Err(crate::Error::ChainError(String::from(
-                    "Chain does not contain a start transaction",
+                    "Chain does not contain an initial transaction",
                 )));
             }
 


### PR DESCRIPTION
# Description of change

Added a take ownership command example to the command line. This allows the user to replace the old client with a new client.  To take ownership of a data chain, the user must know the old key, since the CLI only handles one single client at a time, the key is just transferred automatically. 


## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)
- Documentation Fix

## How the change has been tested

Ran the CLI and the library test suite.  Also ran the fuzz client for the vault. New command is just `take_ownership` with a password flag to decrypt/encrypt the snapshot. 


## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
