### PR TITLE
feat(stronghold) add constructor to set snapshot path

### DIFF
--- a/stronghold/src/lib.rs
+++ b/stronghold/src/lib.rs
@@ -19,6 +19,7 @@ mod account;
 
 /// Stronghold Storage Module
 mod storage; // storage will be saving records with accounts as jsons
+pub use storage::Id;
 use storage::Storage;
 
 use account::{Account, SubAccount};

--- a/stronghold/src/lib.rs
+++ b/stronghold/src/lib.rs
@@ -19,7 +19,6 @@ mod account;
 
 /// Stronghold Storage Module
 mod storage; // storage will be saving records with accounts as jsons
-pub use storage::Id;
 use storage::Storage;
 pub use storage::{Base64Decodable, Id};
 

--- a/stronghold/src/lib.rs
+++ b/stronghold/src/lib.rs
@@ -23,8 +23,7 @@ use storage::Storage;
 
 use account::{Account, SubAccount};
 use bee_signing_ext::{binary::ed25519, Signature, Verifier};
-use std::path::Path;
-use std::str;
+use std::{path::Path, str};
 
 /// Stronghold doc com
 pub struct Stronghold {

--- a/stronghold/src/lib.rs
+++ b/stronghold/src/lib.rs
@@ -21,6 +21,7 @@ mod account;
 mod storage; // storage will be saving records with accounts as jsons
 pub use storage::Id;
 use storage::Storage;
+pub use storage::{Base64Decodable, Id};
 
 use account::{Account, SubAccount};
 use bee_signing_ext::{binary::ed25519, Signature, Verifier};
@@ -259,7 +260,7 @@ impl Stronghold {
     }
 
     // Removes record from storage by record id
-    fn record_remove(&self, record_id: storage::Id, snapshot_password: &str) {
+    pub fn record_remove(&self, record_id: storage::Id, snapshot_password: &str) {
         self.storage.revoke(record_id, snapshot_password);
         self.storage.garbage_collect_vault(snapshot_password);
     }

--- a/stronghold/src/lib.rs
+++ b/stronghold/src/lib.rs
@@ -31,7 +31,7 @@ pub struct Stronghold {
 }
 
 impl Stronghold {
-    fn new<P: AsRef<Path>>(snapshot_path: P) -> Self {
+    pub fn new<P: AsRef<Path>>(snapshot_path: P) -> Self {
         Self {
             storage: Storage::new(snapshot_path),
         }

--- a/stronghold/src/lib.rs
+++ b/stronghold/src/lib.rs
@@ -19,7 +19,7 @@ mod account;
 
 /// Stronghold Storage Module
 mod storage; // storage will be saving records with accounts as jsons
-use storage::{snapshot_dir, Storage};
+use storage::Storage;
 pub use storage::{Base64Decodable, Id};
 
 use account::{Account, SubAccount};
@@ -27,16 +27,9 @@ use bee_signing_ext::{binary::ed25519, Signature, Verifier};
 use std::{path::Path, str};
 
 /// Stronghold doc com
+#[derive(Default)]
 pub struct Stronghold {
     storage: Storage,
-}
-
-impl Default for Stronghold {
-    fn default() -> Self {
-        Self {
-            storage: Storage::new(snapshot_dir().expect("failed to get snapshot dir")),
-        }
-    }
 }
 
 impl Stronghold {

--- a/stronghold/src/lib.rs
+++ b/stronghold/src/lib.rs
@@ -19,7 +19,7 @@ mod account;
 
 /// Stronghold Storage Module
 mod storage; // storage will be saving records with accounts as jsons
-use storage::Storage;
+use storage::{snapshot_dir, Storage};
 pub use storage::{Base64Decodable, Id};
 
 use account::{Account, SubAccount};
@@ -29,6 +29,14 @@ use std::{path::Path, str};
 /// Stronghold doc com
 pub struct Stronghold {
     storage: Storage,
+}
+
+impl Default for Stronghold {
+    fn default() -> Self {
+        Self {
+            storage: Storage::new(snapshot_dir().expect("failed to get snapshot dir")),
+        }
+    }
 }
 
 impl Stronghold {

--- a/stronghold/src/storage/mod.rs
+++ b/stronghold/src/storage/mod.rs
@@ -28,6 +28,7 @@ mod state;
 
 use client::Client;
 use provider::Provider;
+pub use snap::snapshot_dir;
 use snap::{deserialize_from_snapshot, serialize_to_snapshot};
 
 use engine::vault;

--- a/stronghold/src/storage/mod.rs
+++ b/stronghold/src/storage/mod.rs
@@ -43,7 +43,9 @@ pub struct Storage {
 impl Default for Storage {
     fn default() -> Self {
         Self {
-            snapshot_path: snapshot_dir().expect("failed to get snapshot dir"),
+            snapshot_path: snapshot_dir()
+                .expect("failed to get snapshot dir")
+                .join("backup.snapshot"),
         }
     }
 }

--- a/stronghold/src/storage/mod.rs
+++ b/stronghold/src/storage/mod.rs
@@ -28,8 +28,7 @@ mod state;
 
 use client::Client;
 use provider::Provider;
-pub use snap::snapshot_dir;
-use snap::{deserialize_from_snapshot, serialize_to_snapshot};
+use snap::{deserialize_from_snapshot, serialize_to_snapshot, snapshot_dir};
 
 use engine::vault;
 
@@ -39,6 +38,14 @@ use std::path::{Path, PathBuf};
 
 pub struct Storage {
     snapshot_path: PathBuf,
+}
+
+impl Default for Storage {
+    fn default() -> Self {
+        Self {
+            snapshot_path: snapshot_dir().expect("failed to get snapshot dir"),
+        }
+    }
 }
 
 impl Storage {

--- a/stronghold/src/storage/snap.rs
+++ b/stronghold/src/storage/snap.rs
@@ -11,7 +11,7 @@
 
 use engine::snapshot;
 
-use snapshot::{decrypt_snapshot, encrypt_snapshot, snapshot_dir};
+use snapshot::{decrypt_snapshot, encrypt_snapshot};
 
 use std::{fs::OpenOptions, path::PathBuf};
 
@@ -19,13 +19,6 @@ use super::{
     client::{Client, Snapshot},
     provider::Provider,
 };
-
-// get the snapshot path.
-pub(in crate) fn get_snapshot_path() -> PathBuf {
-    let path = snapshot_dir().expect("Unable to get the snapshot directory");
-
-    path.join("backup.snapshot")
-}
 
 // deserialize the snapshot data from the snapshot file.
 pub(in crate) fn deserialize_from_snapshot(snapshot: &PathBuf, pass: &str) -> Client<Provider> {

--- a/stronghold/src/storage/snap.rs
+++ b/stronghold/src/storage/snap.rs
@@ -11,6 +11,7 @@
 
 use engine::snapshot;
 
+pub use snapshot::snapshot_dir;
 use snapshot::{decrypt_snapshot, encrypt_snapshot};
 
 use std::{fs::OpenOptions, path::PathBuf};


### PR DESCRIPTION
# Description of change

Adds a constructor to the `Stronghold` struct so it's possible to set the snapshot path. This is crucial for systems such as Android, where the current `$HOME/.engine/snapshots` path doesn't exist.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- [x] Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Wasn't tested since we don't have unit tests yet, but I've made the same change on the wallet lib and it works there.

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
