### PR TITLE
fix(account) id generation private key path

### DIFF
--- a/stronghold/src/account/mod.rs
+++ b/stronghold/src/account/mod.rs
@@ -37,7 +37,7 @@ pub(in crate) fn generate_id(bip39_mnemonic: &str, bip39_passphrase: &Option<Str
         seed = dummy_mnemonic_to_ed25_seed(bip39_mnemonic, "");
     }
     let privkey =
-        ed25519::Ed25519PrivateKey::generate_from_seed(&seed, "M/44H/4218H/0H/0H").expect("Error deriving seed");
+        ed25519::Ed25519PrivateKey::generate_from_seed(&seed, "m/44H/4218H/0H/0H").expect("Error deriving seed");
     let address = dummy_derive_into_address(privkey);
 
     // Account ID generation: 2/2 : Hash generated address in order to get ID


### PR DESCRIPTION
# Description of change

Fixes the path provided to `ed25519PrivateKey::generate_from_seed` (should be lowercased `m` as specified [here](https://github.com/wusyong/slip10/blob/496a52bde4e8943a554ca92e2794721fbb307b7d/src/path.rs#L13)).

## Type of change

- [x] Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

I wrote a dummy test to see if it isn't panicking anymore.

```rust
#[cfg(test)]
mod tests {
    #[test]
    fn id_generation() {
        // Mnemonic generation
        let bip39_mnemonic = bip39::Mnemonic::new(bip39::MnemonicType::Words24, bip39::Language::English);
        println!("{:?}", bip39_mnemonic.phrase());

        // ID generation
        let id = super::generate_id(&bip39_mnemonic.phrase(), &None);
    }
}
```

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
