### PR TITLE
refactor(stronghold) remove subaccount

### DIFF
--- a/stronghold/src/account/mod.rs
+++ b/stronghold/src/account/mod.rs
@@ -23,6 +23,7 @@ use dummybip39::{dummy_derive_into_address, dummy_mnemonic_to_ed25_seed};
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Account {
     id: String,
+    index: usize,
     external: bool,
     created_at: u128,
     last_updated_on: u128,
@@ -49,7 +50,7 @@ fn generate_id(bip39_mnemonic: &str, bip39_passphrase: &Option<String>) -> Strin
 }
 
 impl Account {
-    pub fn new(bip39_passphrase: Option<String>) -> Account {
+    pub fn new(bip39_passphrase: Option<String>, index: usize) -> Account {
         // Mnemonic generation
         let bip39_mnemonic = bip39::Mnemonic::new(bip39::MnemonicType::Words24, bip39::Language::English);
 
@@ -58,6 +59,7 @@ impl Account {
 
         Account {
             id,
+            index,
             external: false,
             created_at: SystemTime::now()
                 .duration_since(UNIX_EPOCH)
@@ -75,6 +77,7 @@ impl Account {
     }
 
     pub fn import(
+        index: usize,
         created_at: u128,
         last_updated_on: u128,
         bip39_mnemonic: String,
@@ -85,6 +88,7 @@ impl Account {
         let id = generate_id(&bip39_mnemonic, &bip39_passphrase);
         Account {
             id,
+            index,
             external: true,
             created_at,
             last_updated_on,
@@ -122,6 +126,10 @@ impl Account {
 
     pub fn id(&self) -> &str {
         &self.id
+    }
+
+    pub fn index(&self) -> &usize {
+        &self.index
     }
 
     pub fn mnemonic(&self) -> &String {

--- a/stronghold/src/lib.rs
+++ b/stronghold/src/lib.rs
@@ -35,8 +35,7 @@ mod storage;
 use account::Account;
 use bee_signing_ext::{binary::ed25519, Signature, Verifier};
 use serde::{Deserialize, Serialize};
-use std::panic;
-use std::{collections::BTreeMap, path::Path, str};
+use std::{collections::BTreeMap, panic, path::Path, str};
 pub use storage::{Base64Decodable, Id as RecordId};
 use storage::{RecordHint, Storage};
 
@@ -219,11 +218,7 @@ impl Stronghold {
     /// ```no_run
     /// use stronghold::Stronghold;
     /// let stronghold = Stronghold::new("savings.snapshot", true, "password");
-    /// stronghold.account_list_ids(
-    ///     "c/7f5cf@faaf$e2c%c588d",
-    ///     None,
-    ///     None
-    /// );
+    /// stronghold.account_list_ids("c/7f5cf@faaf$e2c%c588d", None, None);
     /// ```
     pub fn account_list_ids(&self, snapshot_password: &str, skip: Option<usize>, limit: Option<usize>) -> Vec<String> {
         let (record_id, index) = self
@@ -517,13 +512,7 @@ impl Stronghold {
     /// let internal = false;
     /// let index = 0;
     /// let snapshot_password = "iKuwjMdnwI";
-    /// let signature = stronghold.signature_make(
-    ///     &message,
-    ///     &account_id,
-    ///     internal,
-    ///     index,
-    ///     snapshot_password,
-    /// );
+    /// let signature = stronghold.signature_make(&message, &account_id, internal, index, snapshot_password);
     /// ```
     pub fn signature_make(
         &self,
@@ -739,8 +728,8 @@ mod tests {
             assert_eq!(record_id, account_record_id_from_index);
 
             let accounts = stronghold.account_list("password", None, None).unwrap();
-            //println!("{}",serde_json::to_string(&accounts[0]).unwrap());
-            //todo: add more controls
+            // println!("{}",serde_json::to_string(&accounts[0]).unwrap());
+            // todo: add more controls
             assert_eq!(accounts.len(), 1);
             let (record_id, index) = stronghold.index_get("password", None, None).unwrap();
             assert_eq!(index.account_ids.len(), 1);
@@ -840,7 +829,7 @@ mod tests {
             println!("{}", data_read);
             assert_eq!(data_read, data_to_save);
 
-            let record_list = stronghold.record_list("password"); //todo: add skip limit and filter in order to avoid index and account records
+            let record_list = stronghold.record_list("password"); // todo: add skip limit and filter in order to avoid index and account records
             assert_eq!(record_list.len(), 2);
 
             stronghold.record_remove(record_id, "password");

--- a/stronghold/src/lib.rs
+++ b/stronghold/src/lib.rs
@@ -344,7 +344,7 @@ impl Stronghold {
         let (index_record_id, index) = self
             .index_get(snapshot_password, None, None)
             .expect("Index not initialized in snapshot file");
-        let account = Account::new(bip39_passphrase.clone());
+        let account = Account::new(bip39_passphrase);
         let record_id = self.account_save(&account, snapshot_password);
         (record_id, account)
     }


### PR DESCRIPTION
# Description of change

Removing the `SubAccount` struct to simplify the address generation interface.

## Type of change

- [x] Refactor

## How the change has been tested

Running unit tests.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
