### PR TITLE
feature(cli) documentation by e2e testing

### DIFF
--- a/engine/examples/commandline/README.md
+++ b/engine/examples/commandline/README.md
@@ -47,7 +47,7 @@ That is in the usage examples bellow replace `stronghold` with `cargo run --`
 (note however that by default the snapshots will still be saved under the
 `~/.engine` directory).
 
-### Examples
+## Examples
 By default, `stronghold` will store its snapshots under the `~/.engine`
 directory. The location can be overridden by setting the `STRONGHOLD`
 environment variable.
@@ -59,7 +59,7 @@ stronghold encrypt --pass foo --plain "secret text"
 (Note that if you haven't/don't want to install the executable you can still
 run this as: `cargo run -- encrypt --pass foo --plain "secret text"`.)
 
-### Usage
+## Usage
 ```
 Engine POC CLI 1.0
 Tensor Programming <tensordeveloper@gmail.com>
@@ -82,4 +82,71 @@ SUBCOMMANDS:
     revoke             Revoke a record by id
     snapshot           load from an existing snapshot
     take_ownership     Take ownership of an existing chain.
+```
+
+### encrypt
+```
+stronghold-encrypt 
+
+USAGE:
+    stronghold encrypt --plain <plaintext> --pass <password>
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+OPTIONS:
+    -w, --pass <password>      the password you want to use to encrypt/decrypt the snapshot.
+    -p, --plain <plaintext>    a plaintext value that you want to encrypt.
+```
+
+### read
+```
+stronghold-read 
+read an associated record by id
+
+USAGE:
+    stronghold read --pass <password> --id <id>
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+OPTIONS:
+    -i, --id <id>            the id of the record you want to read.
+    -w, --pass <password>    the password for the snapshot.
+```
+
+### list
+```
+stronghold-list 
+Lists the ids of the records inside of your main snapshot
+
+USAGE:
+    stronghold list [FLAGS] --pass <password>
+
+FLAGS:
+    -A, --all        include revoked records
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+OPTIONS:
+    -w, --pass <password>    the password for the snapshot.
+```
+
+### revoke
+```
+stronghold-revoke 
+Revoke a record by id
+
+USAGE:
+    stronghold revoke --pass <password> --id <id>
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+OPTIONS:
+    -i, --id <id>            the id of the entry
+    -w, --pass <password>    the password for the snapshot.
 ```

--- a/engine/examples/commandline/README.md
+++ b/engine/examples/commandline/README.md
@@ -56,15 +56,56 @@ Create a new chain by encrypting some data and get back the unique identifier
 of the newly created encrypted record containing our plain-text data:
 ```shell
 > stronghold encrypt --pass foo --plain secret text
-A2KVI4V0MTJf74KNqq5DAaCpMcK5hkx6
+zCeX9poxiirzBpiJGVE7wDReo5sYgyeS
 ```
 (Note that if you haven't/don't want to install the executable you can still
 run this as: `cargo run -- encrypt --pass foo --plain "secret text"`.)
 
 To read and decrypt the record we use the `read` command:
 ```shell
-> stronghold read --pass foo --id A2KVI4V0MTJf74KNqq5DAaCpMcK5hkx6
+> stronghold read --pass foo --id zCeX9poxiirzBpiJGVE7wDReo5sYgyeS
 Plain: "secret text"
+```
+
+In order to make the following examples less trivial, we create another entry:
+```shell
+> stronghold encrypt --pass foo --plain another secret is 42
+GxOmjt1Y7fBdZEYPf56dz-CAKq8RGo-7
+```
+And now we can list the two records we currently have stored:
+```shell
+> stronghold list --pass foo
+Id: zCeX9poxiirzBpiJGVE7wDReo5sYgyeS, Hint: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+Id: GxOmjt1Y7fBdZEYPf56dz-CAKq8RGo-7, Hint: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+```
+
+When we grow tired of keeping the record we can `revoke` it:
+```shell
+> stronghold revoke --pass foo --id zCeX9poxiirzBpiJGVE7wDReo5sYgyeS
+```
+And running the `list` command again we see that it has disappeared:
+```shell
+> stronghold list --pass foo
+Id: GxOmjt1Y7fBdZEYPf56dz-CAKq8RGo-7, Hint: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+```
+But! The record is not actually removed until a garbage collection of the
+chain has taken place.
+Here's how you can see all records stored (not only the valid/unrevoked
+records):
+```shell
+> stronghold list --pass foo --all
+Id: zCeX9poxiirzBpiJGVE7wDReo5sYgyeS
+Id: GxOmjt1Y7fBdZEYPf56dz-CAKq8RGo-7
+```
+So let's make sure it's actually removed:
+```shell
+> stronghold garbage_collect --pass foo
+Id: GxOmjt1Y7fBdZEYPf56dz-CAKq8RGo-7, Hint: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+```
+And check that it has in fact been removed:
+```shell
+> stronghold list --pass foo --all
+Id: GxOmjt1Y7fBdZEYPf56dz-CAKq8RGo-7
 ```
 ## Usage
 ```

--- a/engine/examples/commandline/README.md
+++ b/engine/examples/commandline/README.md
@@ -27,12 +27,12 @@ discarded in this process.
 ## Installation
 Build and install using [cargo](https://doc.rust-lang.org/cargo/):
 ```shell
-cargo install --path .
+> cargo install --path .
 ```
 By default this will install the `stronghold` executable under the user's cargo
 directory: `~/.cargo/bin/stronghold`, so make sure it's in your `PATH`:
 ```shell
-export PATH=~/.cargo/bin:$PATH
+> export PATH=~/.cargo/bin:$PATH
 ```
 and refer to your shell's manual to make the change permanent
 ([bash](https://www.gnu.org/software/bash/manual/html_node/Bash-Startup-Files.html#Bash-Startup-Files),
@@ -41,7 +41,7 @@ and refer to your shell's manual to make the change permanent
 If you only want to play around without installing anything you can run the
 commmandline interface directly:
 ```shell
-cargo run -- --help
+> cargo run -- --help
 ```
 That is in the usage examples bellow replace `stronghold` with `cargo run --`
 (note however that by default the snapshots will still be saved under the
@@ -52,13 +52,20 @@ By default, `stronghold` will store its snapshots under the `~/.engine`
 directory. The location can be overridden by setting the `STRONGHOLD`
 environment variable.
 
-Create a new chain by encrypting some data:
+Create a new chain by encrypting some data and get back the unique identifier
+of the newly created encrypted record containing our plain-text data:
 ```shell
-stronghold encrypt --pass foo --plain "secret text"
+> stronghold encrypt --pass foo --plain secret text
+A2KVI4V0MTJf74KNqq5DAaCpMcK5hkx6
 ```
 (Note that if you haven't/don't want to install the executable you can still
 run this as: `cargo run -- encrypt --pass foo --plain "secret text"`.)
 
+To read and decrypt the record we use the `read` command:
+```shell
+> stronghold read --pass foo --id A2KVI4V0MTJf74KNqq5DAaCpMcK5hkx6
+Plain: "secret text"
+```
 ## Usage
 ```
 Engine POC CLI 1.0

--- a/engine/examples/commandline/readme.sh
+++ b/engine/examples/commandline/readme.sh
@@ -5,6 +5,7 @@ set -o nounset -o pipefail -o errexit
 OUT=README.md
 
 DEFAULT_SNAPSHOT_DIR='~/.engine'
+TARGET="cargo run --"
 
 cat <<EOF > "$OUT"
 # A Stronghold commandline interface
@@ -56,7 +57,7 @@ That is in the usage examples bellow replace \`stronghold\` with \`cargo run --\
 (note however that by default the snapshots will still be saved under the
 \`$DEFAULT_SNAPSHOT_DIR\` directory).
 
-### Examples
+## Examples
 By default, \`stronghold\` will store its snapshots under the \`$DEFAULT_SNAPSHOT_DIR\`
 directory. The location can be overridden by setting the \`STRONGHOLD\`
 environment variable.
@@ -68,12 +69,20 @@ stronghold encrypt --pass foo --plain "secret text"
 (Note that if you haven't/don't want to install the executable you can still
 run this as: \`cargo run -- encrypt --pass foo --plain "secret text"\`.)
 
-### Usage
+## Usage
 \`\`\`
 EOF
 
-cargo run -- --help >> "$OUT"
+$TARGET --help >> "$OUT"
 
 cat <<EOF >> "$OUT"
 \`\`\`
 EOF
+
+for CMD in "encrypt" "read" "list" "revoke"; do
+  echo >> "$OUT"
+  echo "### $CMD" >> "$OUT"
+  echo '```' >> "$OUT"
+  $TARGET "$CMD" --help 2>&1 >> "$OUT"
+  echo '```' >> "$OUT"
+done

--- a/engine/examples/commandline/readme.sh
+++ b/engine/examples/commandline/readme.sh
@@ -84,14 +84,47 @@ environment variable.
 Create a new chain by encrypting some data and get back the unique identifier
 of the newly created encrypted record containing our plain-text data:
 EOF
-ID=$(run_example encrypt --pass foo --plain "secret text")
+ID0=$(run_example encrypt --pass foo --plain "secret text")
 cat <<EOF >> "$OUT"
 (Note that if you haven't/don't want to install the executable you can still
 run this as: \`cargo run -- encrypt --pass foo --plain "secret text"\`.)
 
 To read and decrypt the record we use the \`read\` command:
 EOF
-run_example read --pass foo --id "$ID" > /dev/null
+run_example read --pass foo --id "$ID0" > /dev/null
+cat <<EOF >> "$OUT"
+
+In order to make the following examples less trivial, we create another entry:
+EOF
+ID1=$(run_example encrypt --pass foo --plain "another secret is 42")
+cat <<EOF >> "$OUT"
+And now we can list the two records we currently have stored:
+EOF
+run_example list --pass foo > /dev/null
+cat <<EOF >> "$OUT"
+
+When we grow tired of keeping the record we can \`revoke\` it:
+EOF
+run_example revoke --pass foo --id "$ID0" > /dev/null
+cat <<EOF >> "$OUT"
+And running the \`list\` command again we see that it has disappeared:
+EOF
+run_example list --pass foo > /dev/null
+cat <<EOF >> "$OUT"
+But! The record is not actually removed until a garbage collection of the
+chain has taken place.
+Here's how you can see all records stored (not only the valid/unrevoked
+records):
+EOF
+run_example list --pass foo --all > /dev/null
+cat <<EOF >> "$OUT"
+So let's make sure it's actually removed:
+EOF
+run_example garbage_collect --pass foo > /dev/null
+cat <<EOF >> "$OUT"
+And check that it has in fact been removed:
+EOF
+run_example list --pass foo --all > /dev/null
 
 cat <<EOF >> "$OUT"
 ## Usage

--- a/engine/examples/commandline/readme.sh
+++ b/engine/examples/commandline/readme.sh
@@ -1,3 +1,12 @@
+#!/bin/bash
+
+set -o nounset -o pipefail -o errexit
+
+OUT=README.md
+
+DEFAULT_SNAPSHOT_DIR='~/.engine'
+
+cat <<EOF > "$OUT"
 # A Stronghold commandline interface
 
 To show off the features of this set of libraries, an MVP command line tool was
@@ -26,60 +35,45 @@ discarded in this process.
 
 ## Installation
 Build and install using [cargo](https://doc.rust-lang.org/cargo/):
-```shell
+\`\`\`shell
 cargo install --path .
-```
-By default this will install the `stronghold` executable under the user's cargo
-directory: `~/.cargo/bin/stronghold`, so make sure it's in your `PATH`:
-```shell
-export PATH=~/.cargo/bin:$PATH
-```
+\`\`\`
+By default this will install the \`stronghold\` executable under the user's cargo
+directory: \`~/.cargo/bin/stronghold\`, so make sure it's in your \`PATH\`:
+\`\`\`shell
+export PATH=~/.cargo/bin:\$PATH
+\`\`\`
 and refer to your shell's manual to make the change permanent
 ([bash](https://www.gnu.org/software/bash/manual/html_node/Bash-Startup-Files.html#Bash-Startup-Files),
 [zsh](http://zsh.sourceforge.net/Doc/Release/Files.html#Startup_002fShutdown-Files)).
 
 If you only want to play around without installing anything you can run the
 commmandline interface directly:
-```shell
+\`\`\`shell
 cargo run -- --help
-```
-That is in the usage examples bellow replace `stronghold` with `cargo run --`
+\`\`\`
+That is in the usage examples bellow replace \`stronghold\` with \`cargo run --\`
 (note however that by default the snapshots will still be saved under the
-`~/.engine` directory).
+\`$DEFAULT_SNAPSHOT_DIR\` directory).
 
 ### Examples
-By default, `stronghold` will store its snapshots under the `~/.engine`
-directory. The location can be overridden by setting the `STRONGHOLD`
+By default, \`stronghold\` will store its snapshots under the \`$DEFAULT_SNAPSHOT_DIR\`
+directory. The location can be overridden by setting the \`STRONGHOLD\`
 environment variable.
 
 Create a new chain by encrypting some data:
-```shell
+\`\`\`shell
 stronghold encrypt --pass foo --plain "secret text"
-```
+\`\`\`
 (Note that if you haven't/don't want to install the executable you can still
-run this as: `cargo run -- encrypt --pass foo --plain "secret text"`.)
+run this as: \`cargo run -- encrypt --pass foo --plain "secret text"\`.)
 
 ### Usage
-```
-Engine POC CLI 1.0
-Tensor Programming <tensordeveloper@gmail.com>
-Encrypts data into the Engine Vault.  Creates snapshots and can load from snapshots.
+\`\`\`
+EOF
 
-USAGE:
-    stronghold [SUBCOMMAND]
+cargo run -- --help >> "$OUT"
 
-FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
-
-SUBCOMMANDS:
-    encrypt            
-    garbage_collect    Garbage collect the entire vault and remove revoked records.
-    help               Prints this message or the help of the given subcommand(s)
-    list               Lists the ids of the records inside of your main snapshot
-    purge              Revoke a record by id and perform a gargbage collect
-    read               read an associated record by id
-    revoke             Revoke a record by id
-    snapshot           load from an existing snapshot
-    take_ownership     Take ownership of an existing chain.
-```
+cat <<EOF >> "$OUT"
+\`\`\`
+EOF

--- a/engine/examples/commandline/src/cli.yml
+++ b/engine/examples/commandline/src/cli.yml
@@ -58,7 +58,7 @@ subcommands:
             short: i
             long: id
             value_name: id
-            about: the id of the record you want to revoke.
+            about: the id of the record you want to read.
             required: true
             takes_value: true
   - revoke:

--- a/engine/examples/commandline/src/cli.yml
+++ b/engine/examples/commandline/src/cli.yml
@@ -44,6 +44,12 @@ subcommands:
             about: the password for the snapshot.
             required: true
             takes_value: true
+        - all:
+            short: A
+            long: all
+            value_name: all
+            about: include revoked records
+            takes_value: false
   - read:
       about: read an associated record by id
       args:

--- a/engine/examples/commandline/src/cli.yml
+++ b/engine/examples/commandline/src/cli.yml
@@ -94,6 +94,23 @@ subcommands:
             about: the password for the snapshot.
             required: true
             takes_value: true
+  - purge:
+      about: Revoke a record by id and perform a gargbage collect
+      args:
+        - password:
+            short: w
+            long: pass
+            value_name: password
+            about: the password for the snapshot.
+            required: true
+            takes_value: true
+        - id:
+            short: i
+            long: id
+            value_name: id
+            about: the id of the entry
+            required: true
+            takes_value: true
   - take_ownership:
       about: Take ownership of an existing chain.
       args:

--- a/engine/examples/commandline/src/client.rs
+++ b/engine/examples/commandline/src/client.rs
@@ -65,9 +65,9 @@ impl<P: BoxProvider + Send + Sync + 'static> Client<P> {
     }
 
     // create a record in the vault.
-    pub fn create_record(&self, payload: Vec<u8>) {
+    pub fn create_record(&self, payload: Vec<u8>) -> Id {
         self.db.take(|db| {
-            let (_, req) = db
+            let (id, req) = db
                 .writer(self.id)
                 .write(&payload, RecordHint::new(b"").expect(line_error!()))
                 .expect(line_error!());
@@ -75,7 +75,9 @@ impl<P: BoxProvider + Send + Sync + 'static> Client<P> {
             req.into_iter().for_each(|req| {
                 send_until_success(CRequest::Write(req));
             });
-        });
+
+            id
+        })
     }
 
     // list the ids and hints of all of the records in the Vault.

--- a/engine/examples/commandline/src/client.rs
+++ b/engine/examples/commandline/src/client.rs
@@ -80,11 +80,18 @@ impl<P: BoxProvider + Send + Sync + 'static> Client<P> {
         })
     }
 
-    // list the ids and hints of all of the records in the Vault.
+    // list the ids and hints of all of valid records in the Vault.
     pub fn list_ids(&self) {
         self.db.take(|db| {
             db.records()
                 .for_each(|(id, hint)| println!("Id: {:?}, Hint: {:?}", id, hint));
+        });
+    }
+
+    // list the ids of all of the records in the Vault.
+    pub fn list_all_ids(&self) {
+        self.db.take(|db| {
+            db.all().for_each(|id| println!("Id: {:?}", id));
         });
     }
 

--- a/engine/examples/commandline/src/main.rs
+++ b/engine/examples/commandline/src/main.rs
@@ -83,7 +83,11 @@ fn list_command(matches: &ArgMatches) {
             let snapshot = get_snapshot_path();
             let client: Client<Provider> = deserialize_from_snapshot(&snapshot, pass);
 
-            client.list_ids();
+            if matches.is_present("all") {
+                client.list_all_ids();
+            } else {
+                client.list_ids();
+            }
 
             let snapshot = get_snapshot_path();
             serialize_to_snapshot(&snapshot, pass, client);

--- a/engine/snapshot/src/files.rs
+++ b/engine/snapshot/src/files.rs
@@ -16,7 +16,10 @@ use std::{
 
 /// get the home directory of the user's device
 pub fn home_dir() -> crate::Result<PathBuf> {
-    let home = dirs::home_dir().unwrap();
+    let home = match std::env::var("STRONGHOLD") {
+        Ok(h) => h.into(),
+        Err(_) => dirs::home_dir().unwrap(),
+    };
     let home_dir = home.join(format!(".{}", "engine"));
 
     verify_or_create(&home_dir)?;

--- a/engine/vault/src/vault.rs
+++ b/engine/vault/src/vault.rs
@@ -68,6 +68,14 @@ impl<P: BoxProvider> DBView<P> {
             .map(|d| (d.id, d.record_hint))
     }
 
+    /// Creates an iterator over all valid records ids.
+    pub fn all<'a>(&'a self) -> impl Iterator<Item = Id> + 'a {
+        self.chain
+            .all()
+            .filter_map(|e| e.typed::<DataTransaction>())
+            .map(|d| d.id)
+    }
+
     /// Check the balance of valid records compared to total records
     pub fn absolute_balance(&self) -> (usize, usize) {
         (self.valid.all().count(), self.chain.all().count())


### PR DESCRIPTION
# Description of change

Improve documentation of the command line interface by running an end-to-end user journey.

Also note that this PR introduces the use of the `STRONGHOLD` environment variable to select a vault. Comments on the suitability of this name are welcome: should it be `STRONGHOLD_SNAPSHOT_DIR`, `VAULT`, other ideas?

## Type of change

Choose a type of change, and delete any options that are not relevant.

- [X] Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Running the `readme.sh` script uses the actual CLI to generate the `README.md`, nothing up my sleeves.

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [X] I have followed the contribution guidelines for this project
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
