### PR TITLE
fix(ci): Use env files for setting env vars

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -33,11 +33,11 @@ jobs:
 
     - name: Get current date
       if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'
-      run: echo "::set-env name=CURRENT_DATE::$(date +'%Y-%m-%d')"
+      run: echo "CURRENT_DATE=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
 
     - name: Get current date
       if: matrix.os == 'windows-latest'
-      run: echo "::set-env name=CURRENT_DATE::$(Get-Date -Format "yyyy-MM-dd")"
+      run: echo "CURRENT_DATE=$(Get-Date -Format "yyyy-MM-dd")" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8
 
     - name: Cache cargo registry
       uses: actions/cache@v2


### PR DESCRIPTION
# Description of change

The `set-env` command is now deprecated (see [GitHub blog](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/))﻿

## Type of change

- [x] Bug fix (a non-breaking change which fixes an issue)


## How the change has been tested

Ran workflow

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code