### PR TITLE
fix(stronghold/account): Pass BIP32Path instead of str

### DIFF
--- a/stronghold/src/account/mod.rs
+++ b/stronghold/src/account/mod.rs
@@ -14,7 +14,10 @@ use sha2::{Digest, Sha256};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 mod dummybip39;
-use bee_signing_ext::{binary::ed25519, binary::BIP32Path, Signer};
+use bee_signing_ext::{
+    binary::{ed25519, BIP32Path},
+    Signer,
+};
 use dummybip39::{dummy_derive_into_address, dummy_mnemonic_to_ed25_seed};
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -37,7 +40,8 @@ pub(in crate) fn generate_id(bip39_mnemonic: &str, bip39_passphrase: &Option<Str
         seed = dummy_mnemonic_to_ed25_seed(bip39_mnemonic, "");
     }
     let privkey =
-        ed25519::Ed25519PrivateKey::generate_from_seed(&seed, &BIP32Path::from_str("m/44H/4218H/0H/0H").unwrap()).expect("Error deriving seed");
+        ed25519::Ed25519PrivateKey::generate_from_seed(&seed, &BIP32Path::from_str("m/44H/4218H/0H/0H").unwrap())
+            .expect("Error deriving seed");
     let address = dummy_derive_into_address(privkey);
 
     // Account ID generation: 2/2 : Hash generated address in order to get ID
@@ -108,7 +112,8 @@ impl Account {
 
     fn get_privkey(&self, derivation_path: String) -> ed25519::Ed25519PrivateKey {
         let seed = self.get_seed();
-        ed25519::Ed25519PrivateKey::generate_from_seed(&seed, &BIP32Path::from_str(&derivation_path).unwrap()).expect("Error deriving seed")
+        ed25519::Ed25519PrivateKey::generate_from_seed(&seed, &BIP32Path::from_str(&derivation_path).unwrap())
+            .expect("Error deriving seed")
     }
 
     pub fn get_address(&self, derivation_path: String) -> String {

--- a/stronghold/src/account/mod.rs
+++ b/stronghold/src/account/mod.rs
@@ -14,7 +14,7 @@ use sha2::{Digest, Sha256};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 mod dummybip39;
-use bee_signing_ext::{binary::ed25519, Signer};
+use bee_signing_ext::{binary::ed25519, binary::BIP32Path, Signer};
 use dummybip39::{dummy_derive_into_address, dummy_mnemonic_to_ed25_seed};
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -37,7 +37,7 @@ pub(in crate) fn generate_id(bip39_mnemonic: &str, bip39_passphrase: &Option<Str
         seed = dummy_mnemonic_to_ed25_seed(bip39_mnemonic, "");
     }
     let privkey =
-        ed25519::Ed25519PrivateKey::generate_from_seed(&seed, "m/44H/4218H/0H/0H").expect("Error deriving seed");
+        ed25519::Ed25519PrivateKey::generate_from_seed(&seed, &BIP32Path::from_str("m/44H/4218H/0H/0H").unwrap()).expect("Error deriving seed");
     let address = dummy_derive_into_address(privkey);
 
     // Account ID generation: 2/2 : Hash generated address in order to get ID
@@ -108,7 +108,7 @@ impl Account {
 
     fn get_privkey(&self, derivation_path: String) -> ed25519::Ed25519PrivateKey {
         let seed = self.get_seed();
-        ed25519::Ed25519PrivateKey::generate_from_seed(&seed, &derivation_path).expect("Error deriving seed")
+        ed25519::Ed25519PrivateKey::generate_from_seed(&seed, &BIP32Path::from_str(&derivation_path).unwrap()).expect("Error deriving seed")
     }
 
     pub fn get_address(&self, derivation_path: String) -> String {


### PR DESCRIPTION
# Description of change

Passes `BIP32Path` instead of `str` as a parameter to `generate_from_seed`. Reflects upstream changes in `bee-signing-ext`.

## Links to any relevant issues

N/A

## Type of change

- [x] Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Build no longer fails, unit tests pass

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
