### PR TITLE
fix(products/commandline): Fix build and copy changes from refactor

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        project: [engine, client, runtime]
+        project: [engine, client, runtime, products/commandline]
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        project: [engine, client, runtime]
+        project: [engine, client, runtime, products/commandline]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        project: [engine, client, runtime]
+        project: [engine, client, runtime, products/commandline]
 
     steps:
     - uses: actions/checkout@v2

--- a/products/commandline/src/client.rs
+++ b/products/commandline/src/client.rs
@@ -1,7 +1,7 @@
 // Copyright 2020 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use engine::vault::{BoxProvider, DBView, RecordId, Key, RecordHint, PreparedRead, Kind};
+use engine::vault::{BoxProvider, DBView, Key, Kind, PreparedRead, RecordHint, RecordId};
 
 use crate::{
     connection::{send_until_success, CRequest, CResult},
@@ -60,13 +60,15 @@ impl<P: BoxProvider + Send + Sync + 'static> Client<P> {
             let mut reqs = vec![];
             let mut w = db.writer(id);
 
-            if ! db.reader().exists(id) {
+            if !db.reader().exists(id) {
                 reqs.push(w.truncate().expect(line_error!()));
             }
 
-            reqs.append(&mut w
-                .write(&payload, RecordHint::new(b"").expect(line_error!()))
-                .expect(line_error!()));
+            reqs.append(
+                &mut w
+                    .write(&payload, RecordHint::new(b"").expect(line_error!()))
+                    .expect(line_error!()),
+            );
 
             reqs.into_iter().for_each(|req| {
                 send_until_success(CRequest::Write(req));
@@ -77,7 +79,8 @@ impl<P: BoxProvider + Send + Sync + 'static> Client<P> {
     // list the ids and hints of all of valid records in the Vault.
     pub fn list_ids(&self) {
         self.db.take(|db| {
-            db.records().for_each(|(id, hint)| println!("Id: {}, Hint: {:?}", id, hint));
+            db.records()
+                .for_each(|(id, hint)| println!("Id: {}, Hint: {:?}", id, hint));
         });
     }
 

--- a/products/commandline/src/client.rs
+++ b/products/commandline/src/client.rs
@@ -1,7 +1,7 @@
 // Copyright 2020 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use engine::vault::{BoxProvider, DBView, DBWriter, Id, Key, ListResult, RecordHint};
+use engine::vault::{BoxProvider, DBView, RecordId, Key, RecordHint, PreparedRead, Kind};
 
 use crate::{
     connection::{send_until_success, CRequest, CResult},
@@ -13,138 +13,17 @@ use std::{cell::RefCell, collections::HashMap};
 
 use serde::{Deserialize, Serialize};
 
-// structure of the client
-#[derive(Serialize, Deserialize)]
-pub struct Client<P: BoxProvider> {
-    pub id: Id,
-    pub db: Vault<P>,
-}
-
 // structure for the vault.
-#[derive(Serialize, Deserialize)]
 pub struct Vault<P: BoxProvider> {
     pub key: Key<P>,
     db: RefCell<Option<DBView<P>>>,
 }
 
-// structure for the snapshot
-#[derive(Serialize, Deserialize)]
-pub struct Snapshot<P: BoxProvider> {
-    pub id: Id,
-    pub key: Key<P>,
-    state: HashMap<Vec<u8>, Vec<u8>>,
-}
-
-impl<P: BoxProvider + Send + Sync + 'static> Client<P> {
-    // create a new client
-    pub fn new(key: Key<P>, id: Id) -> Self {
-        Self {
-            id,
-            db: Vault::<P>::new(key),
-        }
-    }
-
-    // create a chain for the user
-    pub fn create_chain(key: Key<P>, id: Id) -> Client<P> {
-        let req = DBWriter::<P>::create_chain(&key, id);
-        // send to the connection interface.
-        send_until_success(CRequest::Write(req));
-
-        Self {
-            id,
-            db: Vault::<P>::new(key),
-        }
-    }
-
-    // create a record in the vault.
-    pub fn create_record(&self, payload: Vec<u8>) -> Id {
-        self.db.take(|db| {
-            let (id, req) = db
-                .writer(self.id)
-                .write(&payload, RecordHint::new(b"").expect(line_error!()))
-                .expect(line_error!());
-
-            req.into_iter().for_each(|req| {
-                send_until_success(CRequest::Write(req));
-            });
-
-            id
-        })
-    }
-
-    // list the ids and hints of all of valid records in the Vault.
-    pub fn list_ids(&self) {
-        self.db.take(|db| {
-            db.records()
-                .for_each(|(id, hint)| println!("Id: {:?}, Hint: {:?}", id, hint));
-        });
-    }
-
-    // list the ids of all of the records in the Vault.
-    pub fn list_all_ids(&self) {
-        self.db.take(|db| {
-            db.all().for_each(|id| println!("Id: {:?}", id));
-        });
-    }
-
-    // read a record by its ID into plaintext.
-    pub fn read_record_by_id(&self, id: Id) {
-        self.db.take(|db| {
-            let read = db.reader().prepare_read(id).expect("unable to read id");
-
-            if let CResult::Read(read) = send_until_success(CRequest::Read(read)) {
-                let record = db.reader().read(read).expect(line_error!());
-
-                println!("Plain: {:?}", String::from_utf8(record).unwrap());
-            }
-        });
-    }
-
-    // Garbage collect the chain and build a new one.
-    pub fn perform_gc(&self) {
-        self.db.take(|db| {
-            let (to_write, to_delete) = db.writer(self.id).gc().expect(line_error!());
-            to_write.into_iter().for_each(|req| {
-                send_until_success(CRequest::Write(req));
-            });
-            to_delete.into_iter().for_each(|req| {
-                send_until_success(CRequest::Delete(req));
-            });
-        });
-    }
-
-    // Take ownership of an existing chain.  Requires that the new owner knows the old key to unlock the data.
-    pub fn take_ownership(&self, old: Id) {
-        // load all of the data from the storage vault.
-        let ids = send_until_success(CRequest::List).list();
-        // use the key to unlock the data.
-        let db = DBView::load(self.db.key.clone(), ListResult::new(ids.into())).expect(line_error!());
-
-        let (to_write, to_delete) = db.writer(self.id).take_ownership(&old).expect(line_error!());
-        to_write.into_iter().for_each(|req| {
-            send_until_success(CRequest::Write(req));
-        });
-        to_delete.into_iter().for_each(|req| {
-            send_until_success(CRequest::Delete(req));
-        });
-    }
-
-    // create a revoke transaction in the chain.
-    pub fn revoke_record_by_id(&self, id: Id) {
-        self.db.take(|db| {
-            let (to_write, to_delete) = db.writer(self.id).revoke(id).expect(line_error!());
-
-            send_until_success(CRequest::Write(to_write));
-            send_until_success(CRequest::Delete(to_delete));
-        });
-    }
-}
-
 impl<P: BoxProvider> Vault<P> {
     // create a new vault for the key.
     pub fn new(key: Key<P>) -> Self {
-        let req = send_until_success(CRequest::List).list();
-        let db = engine::vault::DBView::load(key.clone(), req).expect(line_error!());
+        let reads = send_until_success(CRequest::List).list();
+        let db = engine::vault::DBView::load(key.clone(), reads.iter()).expect(line_error!());
         Self {
             key,
             db: RefCell::new(Some(db)),
@@ -157,24 +36,113 @@ impl<P: BoxProvider> Vault<P> {
         let db = _db.take().expect(line_error!());
         let retval = f(db);
 
-        let req = send_until_success(CRequest::List).list();
-        *_db = Some(DBView::load(self.key.clone(), req).expect(line_error!()));
+        let reads = send_until_success(CRequest::List).list();
+        *_db = Some(DBView::load(self.key.clone(), reads.iter()).expect(line_error!()));
         retval
     }
 }
 
+// structure of the client
+pub struct Client<P: BoxProvider> {
+    pub db: Vault<P>,
+}
+
+impl<P: BoxProvider + Send + Sync + 'static> Client<P> {
+    // create a new client
+    pub fn new(key: Key<P>) -> Self {
+        Self {
+            db: Vault::<P>::new(key),
+        }
+    }
+
+    pub fn write(&self, id: RecordId, payload: Vec<u8>) {
+        self.db.take(|db| {
+            let mut reqs = vec![];
+            let mut w = db.writer(id);
+
+            if ! db.reader().exists(id) {
+                reqs.push(w.truncate().expect(line_error!()));
+            }
+
+            reqs.append(&mut w
+                .write(&payload, RecordHint::new(b"").expect(line_error!()))
+                .expect(line_error!()));
+
+            reqs.into_iter().for_each(|req| {
+                send_until_success(CRequest::Write(req));
+            });
+        })
+    }
+
+    // list the ids and hints of all of valid records in the Vault.
+    pub fn list_ids(&self) {
+        self.db.take(|db| {
+            db.records().for_each(|(id, hint)| println!("Id: {}, Hint: {:?}", id, hint));
+        });
+    }
+
+    // list the ids of all of the records in the Vault.
+    pub fn list_all_ids(&self) {
+        self.db.take(|db| {
+            db.all().for_each(|id| println!("Id: {}", id));
+        });
+    }
+
+    // read a record by its ID into plaintext.
+    pub fn read_record_by_id(&self, id: RecordId) {
+        self.db.take(|db| {
+            let plain = match db.reader().prepare_read(&id).expect("unable to read id") {
+                PreparedRead::CacheHit(bs) => bs,
+                PreparedRead::CacheMiss(req) => {
+                    if let CResult::Read(res) = send_until_success(CRequest::Read(req)) {
+                        db.reader().read(res).expect(line_error!())
+                    } else {
+                        panic!("unable to read")
+                    }
+                }
+                PreparedRead::NoSuchRecord => panic!("no such record"),
+                PreparedRead::RecordIsEmpty => vec![],
+            };
+
+            println!("Plain: {:?}", String::from_utf8(plain).unwrap());
+        });
+    }
+
+    // Garbage collect the chain and build a new one.
+    pub fn perform_gc(&self) {
+        self.db.take(|db| {
+            db.gc().into_iter().for_each(|req| {
+                send_until_success(CRequest::Delete(req));
+            });
+        });
+    }
+
+    // create a revoke transaction in the chain.
+    pub fn revoke_record(&self, id: RecordId) {
+        self.db.take(|db| {
+            let to_write = db.writer(id).revoke().expect(line_error!());
+            send_until_success(CRequest::Write(to_write));
+        });
+    }
+}
+
+// structure for the snapshot
+#[derive(Serialize, Deserialize)]
+pub struct Snapshot<P: BoxProvider> {
+    pub key: Key<P>,
+    state: HashMap<(Kind, Vec<u8>), Vec<u8>>,
+}
+
 impl<P: BoxProvider> Snapshot<P> {
     // create a new snapshot.
-    pub fn new(id: Id, key: Key<P>) -> Self {
+    pub fn new(key: Key<P>) -> Self {
         let map = State::offload_data();
-
-        Self { id, key, state: map }
+        Self { key, state: map }
     }
 
     // offload the snapshot data to the state map.
-    pub fn offload(self) -> (Id, Key<P>) {
+    pub fn offload(self) -> Key<P> {
         State::upload_data(self.state);
-
-        (self.id, self.key)
+        self.key
     }
 }

--- a/products/commandline/src/connection.rs
+++ b/products/commandline/src/connection.rs
@@ -1,7 +1,7 @@
 // Copyright 2020 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use engine::vault::{DeleteRequest, ReadRequest, ReadResult, WriteRequest, Kind};
+use engine::vault::{DeleteRequest, Kind, ReadRequest, ReadResult, WriteRequest};
 
 use std::{thread, time::Duration};
 
@@ -41,15 +41,16 @@ pub fn send(req: CRequest) -> Option<CResult> {
         // if the request is a list, get the keys from the map and put them into a ListResult.
         CRequest::List => {
             let entries = State::storage_map()
-                .read().expect(line_error!())
+                .read()
+                .expect(line_error!())
                 .iter()
-                .filter_map(|((k, id), bs)|
+                .filter_map(|((k, id), bs)| {
                     if *k == Kind::Transaction {
                         Some(ReadResult::new(*k, id, bs))
                     } else {
                         None
                     }
-                )
+                })
                 .collect();
             CResult::List(entries)
         }

--- a/products/commandline/src/main.rs
+++ b/products/commandline/src/main.rs
@@ -13,14 +13,11 @@ use crate::{
     snap::{deserialize_from_snapshot, get_snapshot_path, serialize_to_snapshot},
 };
 
-use engine::vault::{Base64Decodable, RecordId, Key};
+use engine::vault::{Base64Decodable, Key, RecordId};
 
 use clap::{load_yaml, App, ArgMatches};
 
-use std::{
-    path::Path,
-    convert::TryFrom,
-};
+use std::{convert::TryFrom, path::Path};
 
 // create a line error with the file and the line number
 #[macro_export]

--- a/products/commandline/src/main.rs
+++ b/products/commandline/src/main.rs
@@ -13,11 +13,14 @@ use crate::{
     snap::{deserialize_from_snapshot, get_snapshot_path, serialize_to_snapshot},
 };
 
-use engine::vault::{Base64Decodable, Id, Key};
+use engine::vault::{Base64Decodable, RecordId, Key};
 
 use clap::{load_yaml, App, ArgMatches};
 
-use std::path::Path;
+use std::{
+    path::Path,
+    convert::TryFrom,
+};
 
 // create a line error with the file and the line number
 #[macro_export]
@@ -37,16 +40,22 @@ fn encrypt_command(matches: &ArgMatches) {
     if let Some(matches) = matches.subcommand_matches("encrypt") {
         if let Some(ref pass) = matches.value_of("password") {
             if let Some(plain) = matches.value_of("plain") {
-                let client = if snapshot.exists() {
-                    deserialize_from_snapshot(&get_snapshot_path(), pass)
+                let client: Client<Provider> = if snapshot.exists() {
+                    let snapshot = get_snapshot_path();
+                    deserialize_from_snapshot(&snapshot, pass)
                 } else {
                     let key = Key::<Provider>::random().expect("Unable to generate a new key");
-                    let id = Id::random::<Provider>().expect("Unable to generate a new id");
-                    Client::create_chain(key, id)
+                    Client::new(key)
                 };
-                let id = client.create_record(plain.as_bytes().to_vec());
-                serialize_to_snapshot(&get_snapshot_path(), pass, client);
-                println!("{:?}", id);
+
+                // TODO: optionally get from argument
+                let id = RecordId::random::<Provider>().expect("Unable to generate a new id");
+
+                client.write(id, plain.as_bytes().to_vec());
+
+                let snapshot = get_snapshot_path();
+                serialize_to_snapshot(&snapshot, pass, client);
+                println!("{}", id);
             };
         };
     }
@@ -93,7 +102,7 @@ fn read_command(matches: &ArgMatches) {
                 let client: Client<Provider> = deserialize_from_snapshot(&snapshot, pass);
 
                 let id = Vec::from_base64(id.as_bytes()).expect("couldn't convert the id to from base64");
-                let id = Id::load(&id).expect("Couldn't build a new Id");
+                let id = RecordId::try_from(id).expect("Couldn't build a new Id");
 
                 client.read_record_by_id(id);
             }
@@ -110,9 +119,9 @@ fn revoke_command(matches: &ArgMatches) {
                 let client: Client<Provider> = deserialize_from_snapshot(&snapshot, pass);
 
                 let id = Vec::from_base64(id.as_bytes()).expect("couldn't convert the id to from base64");
-                let id = Id::load(&id).expect("Couldn't build a new Id");
+                let id = RecordId::try_from(id).expect("Couldn't build a new Id");
 
-                client.revoke_record_by_id(id);
+                client.revoke_record(id);
 
                 let snapshot = get_snapshot_path();
                 serialize_to_snapshot(&snapshot, pass, client);
@@ -137,26 +146,6 @@ fn garbage_collect_vault_command(matches: &ArgMatches) {
     }
 }
 
-// Take ownership of an existing chain. Requires that the new chain owner knows the old key to unlock the data.
-fn take_ownership_command(matches: &ArgMatches) {
-    if let Some(matches) = matches.subcommand_matches("take_ownership") {
-        if let Some(ref pass) = matches.value_of("password") {
-            let new_id = Id::random::<Provider>().expect("Unable to generate a new id");
-
-            let snapshot = get_snapshot_path();
-            let client: Client<Provider> = deserialize_from_snapshot(&snapshot, pass);
-            let new_client: Client<Provider> = Client::create_chain(client.db.key, new_id);
-
-            new_client.take_ownership(client.id);
-
-            println!("Old owner id: {:?}\nNew owner id: {:?}", client.id, new_client.id);
-
-            let snapshot = get_snapshot_path();
-            serialize_to_snapshot(&snapshot, pass, new_client);
-        }
-    }
-}
-
 // Purge a record from the chain: revoke and then garbage collect.
 fn purge_command(matches: &ArgMatches) {
     if let Some(matches) = matches.subcommand_matches("purge") {
@@ -166,15 +155,15 @@ fn purge_command(matches: &ArgMatches) {
                 let client: Client<Provider> = deserialize_from_snapshot(&snapshot, pass);
 
                 let id = Vec::from_base64(id.as_bytes()).expect("couldn't convert the id to from base64");
-                let id = Id::load(&id).expect("Couldn't build a new Id");
+                let id = RecordId::try_from(id).expect("Couldn't build a new Id");
 
-                client.revoke_record_by_id(id);
+                client.revoke_record(id);
+                serialize_to_snapshot(&get_snapshot_path(), pass, client);
+
+                let client = deserialize_from_snapshot(&snapshot, pass);
                 client.perform_gc();
-
                 assert!(client.db.take(|db| db.all().find(|i| i == &id).is_none()));
-
-                let snapshot = get_snapshot_path();
-                serialize_to_snapshot(&snapshot, pass, client);
+                serialize_to_snapshot(&get_snapshot_path(), pass, client);
             }
         }
     }
@@ -190,6 +179,5 @@ fn main() {
     list_command(&matches);
     revoke_command(&matches);
     garbage_collect_vault_command(&matches);
-    take_ownership_command(&matches);
     purge_command(&matches);
 }

--- a/products/commandline/src/provider.rs
+++ b/products/commandline/src/provider.rs
@@ -1,14 +1,16 @@
 // Copyright 2020 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use engine::crypto::XChaChaPoly;
-use engine::random::{
-    primitives::{cipher::AeadCipher, rng::SecureRng},
-    OsRng,
+use engine::{
+    crypto::XChaChaPoly,
+    random::{
+        primitives::{cipher::AeadCipher, rng::SecureRng},
+        OsRng,
+    },
 };
 
-use serde::{Deserialize, Serialize};
 use engine::vault::{BoxProvider, Key};
+use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize, Debug)]
 pub struct Provider;

--- a/products/commandline/src/snap.rs
+++ b/products/commandline/src/snap.rs
@@ -30,9 +30,8 @@ pub(in crate) fn deserialize_from_snapshot(snapshot: &PathBuf, pass: &str) -> Cl
 
     let snap: Snapshot<Provider> = bincode::deserialize(&buffer[..]).expect("Unable to deserialize data");
 
-    let (id, key) = snap.offload();
-
-    Client::<Provider>::new(key, id)
+    let key = snap.offload();
+    Client::<Provider>::new(key)
 }
 
 // serialize the snapshot data into the snapshot file.
@@ -46,7 +45,7 @@ pub(in crate) fn serialize_to_snapshot(snapshot: &PathBuf, pass: &str, client: C
     // clear contents of the file before writing.
     file.set_len(0).expect("unable to clear the contents of the file file");
 
-    let snap: Snapshot<Provider> = Snapshot::new(client.id, client.db.key);
+    let snap: Snapshot<Provider> = Snapshot::new(client.db.key);
 
     let data: Vec<u8> = bincode::serialize(&snap).expect("Couldn't serialize the client data");
     encrypt_snapshot(data, &mut file, pass.as_bytes()).expect("Couldn't write to the snapshot");

--- a/products/commandline/src/state.rs
+++ b/products/commandline/src/state.rs
@@ -1,9 +1,12 @@
 // Copyright 2020 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashMap;
+use std::{
+    collections::HashMap,
+    sync::{Arc, RwLock},
+};
 
-use std::sync::{Arc, RwLock};
+use engine::vault::Kind;
 
 use crate::line_error;
 
@@ -22,16 +25,16 @@ macro_rules! lazy_static {
 pub struct State;
 impl State {
     // lazy static global hashmap
-    pub fn storage_map() -> Arc<RwLock<HashMap<Vec<u8>, Vec<u8>>>> {
+    pub fn storage_map() -> Arc<RwLock<HashMap<(Kind, Vec<u8>), Vec<u8>>>> {
         lazy_static!(
-            Arc::new(RwLock::new(HashMap::new())) => Arc<RwLock<HashMap<Vec<u8>, Vec<u8>>>>
+            Arc::new(RwLock::new(HashMap::new())) => Arc<RwLock<HashMap<(Kind, Vec<u8>), Vec<u8>>>>
         )
         .clone()
     }
 
     // offload the hashmap data.
-    pub fn offload_data() -> HashMap<Vec<u8>, Vec<u8>> {
-        let mut map: HashMap<Vec<u8>, Vec<u8>> = HashMap::new();
+    pub fn offload_data() -> HashMap<(Kind, Vec<u8>), Vec<u8>> {
+        let mut map: HashMap<(Kind, Vec<u8>), Vec<u8>> = HashMap::new();
         State::storage_map()
             .write()
             .expect("failed to read map")
@@ -45,7 +48,7 @@ impl State {
     }
 
     // upload data to the hashmap.
-    pub fn upload_data(map: HashMap<Vec<u8>, Vec<u8>>) {
+    pub fn upload_data(map: HashMap<(Kind, Vec<u8>), Vec<u8>>) {
         map.into_iter().for_each(|(k, v)| {
             State::storage_map().write().expect("couldn't open map").insert(k, v);
         });

--- a/products/commandline/src/state.rs
+++ b/products/commandline/src/state.rs
@@ -10,6 +10,8 @@ use engine::vault::Kind;
 
 use crate::line_error;
 
+type StateHashMap = HashMap<(Kind, Vec<u8>), Vec<u8>>;
+
 // lazy static macro
 #[macro_export]
 macro_rules! lazy_static {
@@ -25,16 +27,16 @@ macro_rules! lazy_static {
 pub struct State;
 impl State {
     // lazy static global hashmap
-    pub fn storage_map() -> Arc<RwLock<HashMap<(Kind, Vec<u8>), Vec<u8>>>> {
+    pub fn storage_map() -> Arc<RwLock<StateHashMap>> {
         lazy_static!(
-            Arc::new(RwLock::new(HashMap::new())) => Arc<RwLock<HashMap<(Kind, Vec<u8>), Vec<u8>>>>
+            Arc::new(RwLock::new(HashMap::new())) => Arc<RwLock<StateHashMap>>
         )
         .clone()
     }
 
     // offload the hashmap data.
-    pub fn offload_data() -> HashMap<(Kind, Vec<u8>), Vec<u8>> {
-        let mut map: HashMap<(Kind, Vec<u8>), Vec<u8>> = HashMap::new();
+    pub fn offload_data() -> StateHashMap {
+        let mut map: StateHashMap = HashMap::new();
         State::storage_map()
             .write()
             .expect("failed to read map")
@@ -48,7 +50,7 @@ impl State {
     }
 
     // upload data to the hashmap.
-    pub fn upload_data(map: HashMap<(Kind, Vec<u8>), Vec<u8>>) {
+    pub fn upload_data(map: StateHashMap) {
         map.into_iter().for_each(|(k, v)| {
             State::storage_map().write().expect("couldn't open map").insert(k, v);
         });


### PR DESCRIPTION
# Description of change

Fixes CLI build by copying [changes](https://github.com/iotaledger/stronghold.rs/commit/3835d10328e649eaf6f8d01d8081daaf20b2ed54#diff-e04effe27677d5b66e5abb42d7441f440edd8f90f50cd534a01752887c38ca8e) made during refactoring. While the CLI was refactored to match the changes made in stronghold, it seems like they were only made in `engine/examples/commandline`, which was later deleted. Therefore, the changes did not get copied to the new location (`products/commandline`).

Also adds `products/commandline` to the matrix so it is built and tested on CI

## Links to any relevant issues

N/A

## Type of change

- [x] Bug fix (a non-breaking change which fixes an issue)
- [x] Chore

## How the change has been tested

Builds successfully

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
