### PR TITLE
fix(covector): cargo.toml styles

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -12,8 +12,6 @@ homepage = "https://iota.org"
 repository = "https://github.com/iotaledger/stronghold.rs"
 
 [dependencies]
-stronghold-engine = {path = "../engine"}
-
 bincode = "1.3"
 serde = {version = "1.0", features = ["derive"]}
 zeroize = "1.1"
@@ -21,10 +19,13 @@ zeroize_derive = "1.0"
 anyhow = "1.0"
 thiserror = "1.0"
 futures = "0.3"
-
 riker = "0.4"
 
-stronghold-runtime = {path = "../runtime"}
+[dependencies.stronghold-engine]
+path = "../engine"
+
+[dependencies.stronghold-runtime]
+path = "../runtime"
 
 [dependencies.iota-crypto]
 git = "https://github.com/iotaledger/crypto.rs"
@@ -33,10 +34,8 @@ features = [ "random", "ed25519", "sha", "hmac", "bip39-en" ]
 
 [dev-dependencies]
 hex = "0.4.2"
-
 criterion = "0.3.3"
 
 [[bench]]
 name = "benchmark"
 harness = false
-

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -14,9 +14,17 @@ repository = "https://github.com/iotaledger/stronghold.rs"
 [lib]
 name = "engine"
 
-[dependencies]
-crypto = { path = "crypto" }
-vault = { path = "vault" }
-primitives = { path = "primitives" }
-random = { path = "random" }
-snapshot = { path = "snapshot" }
+[dependencies.crypto]
+path = "crypto"
+
+[dependencies.vault]
+path = "vault"
+
+[dependencies.primitives]
+path = "primitives"
+
+[dependencies.random]
+path = "random"
+
+[dependencies.snapshot]
+path = "snapshot"

--- a/engine/crypto/Cargo.toml
+++ b/engine/crypto/Cargo.toml
@@ -3,14 +3,16 @@ name = "crypto"
 version = "0.1.0"
 authors = ["tensor-programming <tensordeveloper@gmail.com>"]
 edition = "2018"
+license = "Apache-2.0"
 readme = "README.md"
 
 [dependencies]
-primitives = {path = "../primitives"}
 thiserror = "1.0"
 anyhow = "1.0"
+
+[dependencies.primitives]
+path = "../primitives"
 
 [dev-dependencies]
 json = "0.12"
 hex = "0.4"
-

--- a/engine/primitives/Cargo.toml
+++ b/engine/primitives/Cargo.toml
@@ -3,6 +3,7 @@ name = "primitives"
 version = "0.1.0"
 authors = ["tensor-programming <tensordeveloper@gmail.com>"]
 edition = "2018"
+license = "Apache-2.0"
 readme = "README.md"
 
 [dependencies]

--- a/engine/random/Cargo.toml
+++ b/engine/random/Cargo.toml
@@ -3,10 +3,13 @@ name = "random"
 version = "0.1.0"
 authors = ["tensor-programming <tensordeveloper@gmail.com>"]
 edition = "2018"
+license = "Apache-2.0"
 readme = "README.md"
 
 [dependencies]
-primitives = {path = "../primitives"}
+
+[dependencies.primitives]
+path = "../primitives"
 
 [build-dependencies]
 cc = "1.0"

--- a/engine/vault/Cargo.toml
+++ b/engine/vault/Cargo.toml
@@ -14,5 +14,9 @@ serde = {version = "1.0", features = ["derive"]}
 [dev-dependencies]
 json = "0.12"
 rand = "0.7.3"
-crypto = {path = "../crypto", version = "0.1"}
-random = {path = "../random", version = "0.1"}
+
+[dev-dependencies.random]
+path = "../random"
+
+[dev-dependencies.crypto]
+path = "../crypto"

--- a/products/commandline/Cargo.toml
+++ b/products/commandline/Cargo.toml
@@ -3,17 +3,18 @@ name = "commandline"
 version = "0.1.0"
 authors = ["tensor-programming <tensordeveloper@gmail.com>"]
 edition = "2018"
+license = "Apache-2.0"
+readme = "README.md"
 
 [dependencies]
 clap = { version = "3.0.0-beta.1", features = ["yaml"] }
-
-iota-stronghold = {path = "../../client/"}
-
 futures = "0.3"
 riker = "0.4"
-
 bincode = "1.3.1"
 serde = {version = "1.0.114", features = ["derive"]}
+
+[dependencies.iota-stronghold]
+path = "../../client/"
 
 [[bin]]
 name = "stronghold"


### PR DESCRIPTION
the bug was because how covector expects us to have versions for crates that depend on each other. we left that out....

This was failing.
```
[dependencies]
stronghold-engine = {path = "../engine"}
```

This seems to be working, but it has to do with an issue in covector:
```
[dependencies.stronghold-engine]
path = "../engine"
```
