### PR TITLE
feat(target): arm-unknown-linux-gnueabihf target for usbarmory

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,3 @@
+[target.arm-unknown-linux-gnueabihf]
+linker = "arm-linux-gnueabihf-gcc"
+

--- a/.changes/2020-12-20-runtime-arm.md
+++ b/.changes/2020-12-20-runtime-arm.md
@@ -1,0 +1,5 @@
+---
+"stronghold-runtime": patch
+---
+
+Add `arm` architecture mmap and linker for USB Armory.

--- a/runtime/src/seccomp.rs
+++ b/runtime/src/seccomp.rs
@@ -104,11 +104,19 @@ impl Spec {
         );
 
         if self.anonymous_mmap {
+            #[cfg(not(target_arch = "arm"))]
             p.jmp(
                 bindings::BPF_JEQ | bindings::BPF_K,
                 0,
                 6,
                 libc::SYS_mmap as bindings::__u32,
+            );
+            #[cfg(target_arch = "arm")]
+            p.jmp(
+                bindings::BPF_JEQ | bindings::BPF_K,
+                0,
+                6,
+                libc::SYS_mmap2 as bindings::__u32,
             );
 
             p.op(


### PR DESCRIPTION
# Description of change

Add config to support compilation for the USB Armory MK II

## Links to any relevant issues

#55 

## Type of change

Choose a type of change, and delete any options that are not relevant.

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested

Compilation of stronghold with `target=arm-unknown-linux-gnueabihf` was tested on Ubuntu 20.04 with the additional environment variables `TARGET_CC=arm-linux-gnueabihf-gcc` and `C_INCLUDE_PATH=/usr/arm-linux-gnueabihf/include`.
