### PR TITLE
Use the guarded memory allocator in the zone

### DIFF
--- a/.changes/guarded_allocator_in_zone.md
+++ b/.changes/guarded_allocator_in_zone.md
@@ -1,0 +1,8 @@
+---
+"stronghold-runtime": minor
+---
+
+Add functionality to enable the guarded memory allocator in the zone when
+running on POSIX (Linux, MacOS targets). The major contribution is a toggleable
+memory allocator that can be used to work around rust's enforcement of only
+one `#[global_allocator]`.

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -14,6 +14,10 @@ repository = "https://github.com/iotaledger/stronghold.rs"
 [lib]
 name = "runtime"
 
+[features]
+default = []
+stdalloc = []
+
 [dependencies]
 memoffset = "0.6.1"
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -14,6 +14,10 @@ extern crate memoffset;
 #[cfg(unix)]
 extern crate lazy_static;
 
+#[macro_use]
+#[cfg(feature = "stdalloc")]
+extern crate std;
+
 #[cfg(unix)]
 pub mod mem;
 

--- a/runtime/src/mem.rs
+++ b/runtime/src/mem.rs
@@ -199,7 +199,7 @@ unsafe impl GlobalAlloc for GuardedAllocator {
 }
 
 #[cfg(feature = "stdalloc")]
-mod stdalloc {
+pub mod stdalloc {
     use super::*;
     use core::cell::Cell;
 

--- a/runtime/src/seccomp.rs
+++ b/runtime/src/seccomp.rs
@@ -76,7 +76,7 @@ impl Program {
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct Spec {
     pub write_stdout: bool,
     pub write_stderr: bool,
@@ -87,7 +87,25 @@ pub struct Spec {
     pub getrandom: bool,
 }
 
+impl AsRef<Spec> for Spec {
+    fn as_ref(&self) -> &Self {
+        &self
+    }
+}
+
 impl Spec {
+    pub fn join<O: AsRef<Self>>(&self, other: O) -> Self {
+        Self {
+            write_stdout: self.write_stdout || other.as_ref().write_stdout,
+            write_stderr: self.write_stderr || other.as_ref().write_stderr,
+            anonymous_mmap: self.anonymous_mmap || other.as_ref().anonymous_mmap,
+            munmap: self.munmap || other.as_ref().munmap,
+            mprotect: self.mprotect || other.as_ref().mprotect,
+            mlock: self.mlock || other.as_ref().mlock,
+            getrandom: self.getrandom || other.as_ref().getrandom,
+        }
+    }
+
     pub fn strict() -> Self {
         Self {
             write_stdout: true,

--- a/runtime/src/zone.rs
+++ b/runtime/src/zone.rs
@@ -31,4 +31,19 @@ mod common_tests {
         assert_eq!(ZoneSpec::default().run(|| bs)?, bs);
         Ok(())
     }
+
+    #[test]
+    fn heap() -> crate::Result<()> {
+        assert_eq!(
+            ZoneSpec::default().secure_memory().run(|| {
+                extern crate alloc;
+                use alloc::boxed::Box;
+
+                let b = Box::new(7);
+                *b
+            })?,
+            7
+        );
+        Ok(())
+    }
 }

--- a/runtime/src/zone_posix.rs
+++ b/runtime/src/zone_posix.rs
@@ -163,3 +163,16 @@ mod fork_tests {
         Ok(())
     }
 }
+
+#[cfg(not(feature = "stdalloc"))]
+fn with_guarded_allocator<A, F: FnOnce() -> A>(f: F) -> A {
+    f()
+}
+
+#[cfg(feature = "stdalloc")]
+fn with_guarded_allocator<A, F: FnOnce() -> A>(f: F) -> A {
+    unsafe { crate::mem::stdalloc::guarded() };
+    let a = f();
+    unsafe { crate::mem::stdalloc::std() };
+    a
+}

--- a/runtime/src/zone_windows.rs
+++ b/runtime/src/zone_windows.rs
@@ -4,11 +4,18 @@
 #[derive(PartialEq, Debug)]
 pub enum Error {}
 
+#[derive(Clone)]
 struct ZoneSpec {}
 
 impl Default for ZoneSpec {
     fn default() -> Self {
         Self {}
+    }
+}
+
+impl ZoneSpec {
+    pub fn secure_memory(&self) -> Self {
+        self.clone()
     }
 }
 


### PR DESCRIPTION
Sat on top of: https://github.com/iotaledger/stronghold.rs/pull/115 (now merged).

Main contribution here is the "togglable allocator" (in mem.rs): which is necessary for the whole program to be built with only one `#[global_allocator]` but makes it possible to "switch on" the guarded allocator when desired (i.e. in `ZoneSpec::run`).