### PR TITLE
Address new clippy warnings (needless_lifetimes, unnecessary_cast)

### DIFF
--- a/.changes/new_clippy_warnings_needless_lifetimes_and_unnecessary_cast.md
+++ b/.changes/new_clippy_warnings_needless_lifetimes_and_unnecessary_cast.md
@@ -1,0 +1,8 @@
+---
+"stronghold-runtime": patch
+"vault": patch
+---
+
+Address two new clippy warnings: `needless_lifetimes` (addressed in the vault)
+and `unnecessary_cast` (ignored in the runtime since they are necessary for
+portability: `0 as libc::c_char` is not necessarily the same as `0_u8`).

--- a/engine/vault/src/vault.rs
+++ b/engine/vault/src/vault.rs
@@ -127,7 +127,7 @@ impl<P: BoxProvider> DBView<P> {
     }
 
     /// Creates an iterator over all valid record identifiers and their corresponding record hints
-    pub fn records<'a>(&'a self) -> impl Iterator<Item = (RecordId, RecordHint)> + 'a {
+    pub fn records(&self) -> impl Iterator<Item = (RecordId, RecordHint)> + '_ {
         self.chains.values().filter_map(move |r| {
             r.data()
                 .as_ref()
@@ -138,7 +138,7 @@ impl<P: BoxProvider> DBView<P> {
     }
 
     /// Creates an iterator over all valid records ids.
-    pub fn all<'a>(&'a self) -> impl ExactSizeIterator<Item = RecordId> + 'a {
+    pub fn all(&self) -> impl ExactSizeIterator<Item = RecordId> + '_ {
         self.chains.keys().map(|k| RecordId(*k))
     }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -75,6 +75,7 @@ impl From<zone::Error> for Error {
 
 #[cfg(unix)]
 fn strerror(errno: libc::c_int) -> &'static str {
+    #[allow(clippy::unnecessary_cast)]
     static mut BUF: [libc::c_char; 1024] = [0 as libc::c_char; 1024];
     unsafe {
         let res = libc::strerror_r(errno, BUF.as_mut_ptr(), BUF.len());

--- a/runtime/src/zone_posix.rs
+++ b/runtime/src/zone_posix.rs
@@ -8,6 +8,7 @@ where
     F: FnOnce() -> T,
 {
     unsafe {
+        #[allow(clippy::unnecessary_cast)]
         let mut fds: [libc::c_int; 2] = [-1 as libc::c_int; 2];
         let r = libc::pipe(fds.as_mut_ptr());
         if r != 0 {


### PR DESCRIPTION
New warning observed in: `clippy 0.0.212 (e1884a8 2020-12-29)`
