### PR TITLE
fix(ci): Remove deprecated set-env commands

### DIFF
--- a/.github/workflows/covector-version-or-publish.yml
+++ b/.github/workflows/covector-version-or-publish.yml
@@ -67,8 +67,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - run: echo ::set-env name=PUBLISHED::$(jq '.${{ matrix.package.name }}.command' ${{ needs.version-or-publish.outputs.change }})
-      - run: echo ::set-env name=PACKAGE_VERSION::$(jq '.${{ matrix.package.name }}.pkg.pkgFile.version' ${{ needs.version-or-publish.outputs.change }})
+      - run: echo "PUBLISHED=$(jq '.${{ matrix.package.name }}.command' ${{ needs.version-or-publish.outputs.change }})" >> $GITHUB_ENV
+      - run: echo "PACKAGE_VERSION=$(jq '.${{ matrix.package.name }}.pkg.pkgFile.version' ${{ needs.version-or-publish.outputs.change }})" >> $GITHUB_ENV
       - name: Tangle Release
         if:  env.PUBLISHED != 'false' && startsWith(env.PUBLISHED, 'parse error') != true && startsWith(env.PACKAGE_VERSION, 'parse error') != true
         id: tangle_release


### PR DESCRIPTION
# Description of change

`set-env` was deprecated and removed (see https://github.com/actions/toolkit/security/advisories/GHSA-mfwh-5m23-j46w)

## Links to any relevant issues

N/A

## Type of change

- [x] Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

N/A

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code