### PR TITLE
fix(covector): wrong version bump type

### DIFF
--- a/.changes/atomic_ed25519_procedures.md
+++ b/.changes/atomic_ed25519_procedures.md
@@ -1,5 +1,5 @@
 ---
-"iota-stronghold": client
+"iota-stronghold": patch
 ---
 
 Rename the previously incorrectly named combined SLIP10+Ed25519 procedures (now


### PR DESCRIPTION
Fix erroneous changelog version bump type. @rootmos - please be more careful in the future. I filed an issue at covector though, we shouldn't be able to commit this kind of change request:

https://github.com/jbolda/covector/issues/132

```
---
"iota-stronghold": client
---
```

should have been:

```
---
"iota-stronghold": patch
---
```