### PR TITLE
fix(ci): Ensure tests for engine crates are run

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,7 +70,16 @@ jobs:
           ${{ matrix.project }}-${{ matrix.os }}-${{ matrix.rust }}-cargo-build-target-${{ hashFiles('**/Cargo.toml') }}
 
     - name: Run tests for ${{ matrix.project }}
+      if: matrix.project != 'engine'
       uses: actions-rs/cargo@v1
       with:
         command: test
         args: --manifest-path=${{ matrix.project }}/Cargo.toml --release
+
+    - name: Run tests for engine
+      # Because of the way engine is structured, we need to specify each package to be tested
+      if: matrix.project == 'engine'
+      uses: actions-rs/cargo@v1
+      with:
+        command: test
+        args: --manifest-path=engine/Cargo.toml --release -p crypto -p primitives -p random -p snapshot -p store -p vault


### PR DESCRIPTION
# Description of change

For some reason, the tests for the `engine` crates are not run on CI. Specifying the packages in the `cargo test` command seems to resolve the issue.

## Links to any relevant issues

N/A

## Type of change

- [x] Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Workflow runs and tests pass

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
