### PR TITLE
fix(ci): Exit coverage script early on error

### DIFF
--- a/.github/workflows/scripts/coverage.sh
+++ b/.github/workflows/scripts/coverage.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
+set -e
 
 # Remove stale coverage report
-rm -r coverage
+rm -rf coverage
 mkdir coverage
 
 # Run tests with profiling instrumentation


### PR DESCRIPTION
# Description of change

Adds `set -e` so the coverage script will exit early if an error occurs

## Links to any relevant issues

N/A

## Type of change

- [x] Bug fix (a non-breaking change which fixes an issue)


## How the change has been tested

N/A

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
