### PR TITLE
patch(comms): libp2p v0.36

### DIFF
--- a/.changes/libp2p-patch.md
+++ b/.changes/libp2p-patch.md
@@ -1,0 +1,7 @@
+---
+"stronghold-communication": patch
+"communication-macros": patch
+---
+
+Patch libp2p v0.35 -> v0.36, handle Mdns and dns transport changes, and make P2PNetworkBehaviour init_swarm method async.
+Move communication macro test to stronghold-communication.

--- a/communication/Cargo.toml
+++ b/communication/Cargo.toml
@@ -16,8 +16,8 @@ async-std = "1.6"
 async-trait = "0.1"
 futures = "0.3"
 clap = { version = "3.0.0-beta.1", features = [ "yaml" ] }
-libp2p = { version = "0.35", default-features = false, features = [
-  "dns",
+libp2p = { version = "0.36", default-features = false, features = [
+  "dns-async-std",
   "identify",
   "mdns",
   "noise",

--- a/communication/communication-macros/Cargo.toml
+++ b/communication/communication-macros/Cargo.toml
@@ -15,7 +15,3 @@ proc-macro = true
 syn = { version ="1.0", features = ["parsing", "full", "extra-traits", "proc-macro"] }
 quote = "1.0"
 proc-macro2 = "1.0"
-
-
-[dev-dependencies]
-stronghold-communication = {path = "..", version = "0.3.0"}

--- a/communication/examples/mailbox.rs
+++ b/communication/examples/mailbox.rs
@@ -150,191 +150,183 @@ fn eval_arg_matches(matches: &ArgMatches) -> Option<Matches> {
     None
 }
 
-// Start a mailbox that publishes record for other peers
-fn run_mailbox(matches: &ArgMatches) {
-    if matches.subcommand_matches("start-mailbox").is_some() {
-        let local_keys = Keypair::generate_ed25519();
-        let config = BehaviourConfig::default();
+// Create swarm for communication
+async fn create_swarm() -> Swarm<P2PNetworkBehaviour<Request, Response>> {
+    let local_keys = Keypair::generate_ed25519();
+    let config = BehaviourConfig::default();
+    // Create swarm for communication
+    P2PNetworkBehaviour::<Request, Response>::init_swarm(local_keys, config)
+        .await
+        .expect("Could not create swarm.")
+}
 
-        // Create swarm for communication
-        let mut swarm =
-            P2PNetworkBehaviour::<Request, Response>::init_swarm(local_keys, config).expect("Could not create swarm.");
-        Swarm::listen_on(
-            &mut swarm,
-            "/ip4/0.0.0.0/tcp/16384".parse().expect("Invalid Multiaddress."),
-        )
-        .expect("Listening error.");
-        println!("Local PeerId: {:?}", Swarm::local_peer_id(&swarm));
-        // temporary key-value store
-        let mut local_records = HashMap::new();
-        // Poll for events from the swarm
-        task::block_on(async {
-            loop {
-                match swarm.next_event().await {
-                    SwarmEvent::NewListenAddr(addr) => {
-                        println!("Listening on {:?}", addr);
-                    }
-                    SwarmEvent::ListenerError { error } => {
-                        println!("Listener error: {:?}", error);
-                        return;
-                    }
-                    SwarmEvent::Behaviour(P2PEvent::RequestResponse(event)) => {
-                        // Handle messages from remote peers
-                        if let P2PReqResEvent::Req {
-                            peer_id: _,
-                            request_id,
-                            request,
-                        } = event.deref().clone()
-                        {
-                            match request {
-                                // Store the record as a key-value pair in the local binary
-                                // tree
-                                Request::PutRecord(record) => {
-                                    local_records.insert(record.key(), record.value());
-                                    let _ = swarm.send_response(request_id, Response::Outcome(RequestOutcome::Success));
-                                }
-                                // Send the record for that key to the remote peer
-                                Request::GetRecord(key) => {
-                                    if let Some((key, value)) = local_records.get_key_value(&key) {
-                                        let record = MailboxRecord::new(key.clone(), value.clone());
-                                        let _ = swarm.send_response(request_id, Response::Record(record));
-                                    } else {
-                                        let _ =
-                                            swarm.send_response(request_id, Response::Outcome(RequestOutcome::Error));
-                                    }
-                                }
-                            };
+// Start a mailbox that publishes record for other peers
+async fn run_mailbox() {
+    let mut swarm = create_swarm().await;
+    Swarm::listen_on(
+        &mut swarm,
+        "/ip4/0.0.0.0/tcp/16384".parse().expect("Invalid Multiaddress."),
+    )
+    .expect("Listening error.");
+    println!("Local PeerId: {:?}", Swarm::local_peer_id(&swarm));
+    // temporary key-value store
+    let mut local_records = HashMap::new();
+    // Poll for events from the swarm
+    loop {
+        match swarm.next_event().await {
+            SwarmEvent::NewListenAddr(addr) => {
+                println!("Listening on {:?}", addr);
+            }
+            SwarmEvent::ListenerError { error } => {
+                println!("Listener error: {:?}", error);
+                return;
+            }
+            SwarmEvent::Behaviour(P2PEvent::RequestResponse(event)) => {
+                // Handle messages from remote peers
+                if let P2PReqResEvent::Req {
+                    peer_id: _,
+                    request_id,
+                    request,
+                } = event.deref().clone()
+                {
+                    match request {
+                        // Store the record as a key-value pair in the local binary
+                        // tree
+                        Request::PutRecord(record) => {
+                            local_records.insert(record.key(), record.value());
+                            let _ = swarm.send_response(request_id, Response::Outcome(RequestOutcome::Success));
                         }
-                    }
-                    _ => {}
+                        // Send the record for that key to the remote peer
+                        Request::GetRecord(key) => {
+                            if let Some((key, value)) = local_records.get_key_value(&key) {
+                                let record = MailboxRecord::new(key.clone(), value.clone());
+                                let _ = swarm.send_response(request_id, Response::Record(record));
+                            } else {
+                                let _ = swarm.send_response(request_id, Response::Outcome(RequestOutcome::Error));
+                            }
+                        }
+                    };
                 }
             }
-        });
+            _ => {}
+        }
     }
 }
 
 // Deposit a record in the mailbox
-fn put_record(matches: &ArgMatches) {
-    if let Some(matches) = matches.subcommand_matches("put-mailbox") {
-        if let Some(Matches {
-            mail_addr,
-            key,
-            value: Some(value),
-        }) = eval_arg_matches(matches)
-        {
-            let local_keys = Keypair::generate_ed25519();
-            let config = BehaviourConfig::default();
-            // Create swarm for communication
-            let mut swarm = P2PNetworkBehaviour::<Request, Response>::init_swarm(local_keys, config)
-                .expect("Could not create swarm.");
+async fn put_record(matches: &ArgMatches) {
+    if let Some(Matches {
+        mail_addr,
+        key,
+        value: Some(value),
+    }) = eval_arg_matches(matches)
+    {
+        let mut swarm = create_swarm().await;
 
-            if let Err(err) = Swarm::dial_addr(&mut swarm, mail_addr.clone()) {
-                println!("Error dialing address{:?}, {:?}", mail_addr, err);
-                return;
-            }
-            // Connect to a remote mailbox on the server and then send the request.
-            loop {
-                match task::block_on(swarm.next_event()) {
-                    SwarmEvent::Behaviour(P2PEvent::RequestResponse(boxed_event)) => {
-                        let event = boxed_event.deref().clone();
-                        if let P2PReqResEvent::Res {
-                            peer_id: _,
-                            request_id: _,
-                            response,
-                        } = event
-                        {
-                            println!("{:?}", response);
-                        } else {
-                            println!("{:?}", event);
-                        }
+        if let Err(err) = Swarm::dial_addr(&mut swarm, mail_addr.clone()) {
+            println!("Error dialing address{:?}, {:?}", mail_addr, err);
+            return;
+        }
+        // Connect to a remote mailbox on the server and then send the request.
+        loop {
+            match swarm.next_event().await {
+                SwarmEvent::Behaviour(P2PEvent::RequestResponse(boxed_event)) => {
+                    let event = boxed_event.deref().clone();
+                    if let P2PReqResEvent::Res {
+                        peer_id: _,
+                        request_id: _,
+                        response,
+                    } = event
+                    {
+                        println!("{:?}", response);
+                    } else {
+                        println!("{:?}", event);
+                    }
+                    return;
+                }
+                // Send the request once a conncection was successful
+                SwarmEvent::ConnectionEstablished {
+                    peer_id,
+                    endpoint: ConnectedPoint::Dialer { address },
+                    num_established: _,
+                } => {
+                    if address == mail_addr {
+                        let record = MailboxRecord::new(key.clone(), value.clone());
+                        swarm.send_request(&peer_id, Request::PutRecord(record));
+                    }
+                }
+                SwarmEvent::UnknownPeerUnreachableAddr { address, error: _ } => {
+                    if address == mail_addr {
+                        println!("Could not dial address {:?}", address);
                         return;
                     }
-                    // Send the request once a conncection was successful
-                    SwarmEvent::ConnectionEstablished {
-                        peer_id,
-                        endpoint: ConnectedPoint::Dialer { address },
-                        num_established: _,
-                    } => {
-                        if address == mail_addr {
-                            let record = MailboxRecord::new(key.clone(), value.clone());
-                            swarm.send_request(&peer_id, Request::PutRecord(record));
-                        }
-                    }
-                    SwarmEvent::UnknownPeerUnreachableAddr { address, error: _ } => {
-                        if address == mail_addr {
-                            println!("Could not dial address {:?}", address);
-                            return;
-                        }
-                    }
-                    _ => {}
                 }
+                _ => {}
             }
-        } else {
-            eprintln!("Invalid or missing arguments");
         }
+    } else {
+        eprintln!("Invalid or missing arguments");
     }
 }
 
 // Get a record from the mailbox
-fn get_record(matches: &ArgMatches) {
-    if let Some(matches) = matches.subcommand_matches("get-record") {
-        if let Some(Matches { mail_addr, key, .. }) = eval_arg_matches(matches) {
-            let local_keys = Keypair::generate_ed25519();
-            let config = BehaviourConfig::default();
-
-            // Create swarm for communication
-            let mut swarm = P2PNetworkBehaviour::<Request, Response>::init_swarm(local_keys, config)
-                .expect("Could not create swarm.");
-
-            if let Err(err) = Swarm::dial_addr(&mut swarm, mail_addr.clone()) {
-                println!("Error dialing address{:?}, {:?}", mail_addr, err);
-                return;
-            }
-            // Connect to a remote mailbox on the server and then send the request.
-            loop {
-                match task::block_on(swarm.next_event()) {
-                    SwarmEvent::Behaviour(P2PEvent::RequestResponse(boxed_event)) => {
-                        if let P2PReqResEvent::Res {
-                            peer_id: _,
-                            request_id: _,
-                            response: Response::Record(record),
-                        } = boxed_event.deref().clone()
-                        {
-                            println!("{:?}:\n{:?}", record.key(), record.value());
-                        } else {
-                            println!("{:?}", boxed_event.deref().clone());
-                        }
+async fn get_record(matches: &ArgMatches) {
+    if let Some(Matches { mail_addr, key, .. }) = eval_arg_matches(matches) {
+        let mut swarm = create_swarm().await;
+        if let Err(err) = Swarm::dial_addr(&mut swarm, mail_addr.clone()) {
+            println!("Error dialing address{:?}, {:?}", mail_addr, err);
+            return;
+        }
+        // Connect to a remote mailbox on the server and then send the request.
+        loop {
+            match swarm.next_event().await {
+                SwarmEvent::Behaviour(P2PEvent::RequestResponse(boxed_event)) => {
+                    if let P2PReqResEvent::Res {
+                        peer_id: _,
+                        request_id: _,
+                        response: Response::Record(record),
+                    } = boxed_event.deref().clone()
+                    {
+                        println!("{:?}:\n{:?}", record.key(), record.value());
+                    } else {
+                        println!("{:?}", boxed_event.deref().clone());
+                    }
+                    return;
+                }
+                // Send the request once a connection was successful
+                SwarmEvent::ConnectionEstablished {
+                    peer_id,
+                    endpoint: ConnectedPoint::Dialer { address },
+                    num_established: _,
+                } => {
+                    if address == mail_addr {
+                        swarm.send_request(&peer_id, Request::GetRecord(key.clone()));
+                    }
+                }
+                SwarmEvent::UnknownPeerUnreachableAddr { address, error } => {
+                    if address == mail_addr {
+                        println!("Could not dial address {:?}: {:?}", address, error);
                         return;
                     }
-                    // Send the request once a conncection was successful
-                    SwarmEvent::ConnectionEstablished {
-                        peer_id,
-                        endpoint: ConnectedPoint::Dialer { address },
-                        num_established: _,
-                    } => {
-                        if address == mail_addr {
-                            swarm.send_request(&peer_id, Request::GetRecord(key.clone()));
-                        }
-                    }
-                    SwarmEvent::UnknownPeerUnreachableAddr { address, error } => {
-                        if address == mail_addr {
-                            println!("Could not dial address {:?}: {:?}", address, error);
-                            return;
-                        }
-                    }
-                    _ => {}
                 }
+                _ => {}
             }
-        } else {
-            eprintln!("Invalid or missing arguments");
         }
+    } else {
+        eprintln!("Invalid or missing arguments");
     }
 }
 
 fn main() {
     let yaml = load_yaml!("cli_mailbox.yml");
     let matches = App::from(yaml).get_matches();
-    run_mailbox(&matches);
-    put_record(&matches);
-    get_record(&matches);
+    if matches.subcommand_matches("start-mailbox").is_some() {
+        task::block_on(run_mailbox())
+    }
+    if let Some(matches) = matches.subcommand_matches("put-mailbox") {
+        task::block_on(put_record(&matches));
+    }
+    if let Some(matches) = matches.subcommand_matches("get-record") {
+        task::block_on(get_record(&matches));
+    }
 }

--- a/communication/examples/relay.rs
+++ b/communication/examples/relay.rs
@@ -20,100 +20,144 @@ use std::{collections::HashMap, time::Instant};
 struct Ack;
 
 // Starts a relay that forwards RequestEnvelopes from source to target peer.
-fn run_relay(matches: &ArgMatches) {
-    if matches.subcommand_matches("start-relay").is_some() {
-        let local_keys = Keypair::generate_ed25519();
-        let config = BehaviourConfig::new(Some(Duration::from_secs(5)), Some(Duration::from_secs(60)));
-        // Create swarm for communication
-        let mut swarm = P2PNetworkBehaviour::<RequestEnvelope<String>, Ack>::init_swarm(local_keys, config)
-            .expect("Could not create swarm.");
-        Swarm::listen_on(
-            &mut swarm,
-            "/ip4/0.0.0.0/tcp/16384".parse().expect("Invalid Multiaddress."),
-        )
-        .expect("Listening error.");
-        println!("\nLocal PeerId: {:?}", Swarm::local_peer_id(&swarm));
+async fn run_relay() {
+    let local_keys = Keypair::generate_ed25519();
+    let config = BehaviourConfig::new(Some(Duration::from_secs(5)), Some(Duration::from_secs(60)), None, None);
+    // Create swarm for communication
+    let mut swarm = P2PNetworkBehaviour::<RequestEnvelope<String>, Ack>::init_swarm(local_keys, config)
+        .await
+        .expect("Could not create swarm.");
+    Swarm::listen_on(
+        &mut swarm,
+        "/ip4/0.0.0.0/tcp/16384".parse().expect("Invalid Multiaddress."),
+    )
+    .expect("Listening error.");
+    println!("\nLocal PeerId: {:?}", Swarm::local_peer_id(&swarm));
 
-        // map request from original peer to the request send to target
-        let mut requests = HashMap::new();
+    // map request from original peer to the request send to target
+    let mut requests = HashMap::new();
 
-        // Poll for events from the swarm
-        task::block_on(async {
-            loop {
-                match swarm.next_event().await {
-                    SwarmEvent::NewListenAddr(addr) => {
-                        println!("Listening on {:?}", addr);
+    // Poll for events from the swarm
+    loop {
+        match swarm.next_event().await {
+            SwarmEvent::NewListenAddr(addr) => {
+                println!("Listening on {:?}", addr);
+            }
+            SwarmEvent::ListenerError { error } => {
+                println!("Listener error: {:?}", error);
+                return;
+            }
+            SwarmEvent::Behaviour(P2PEvent::RequestResponse(event)) => {
+                match event.deref().clone() {
+                    // forward incoming request to the targeted peer
+                    P2PReqResEvent::Req {
+                        peer_id,
+                        request_id,
+                        request,
+                    } => {
+                        // verify that the claimed source is the actual peer that send the request
+                        if peer_id.to_string() != request.source {
+                            continue;
+                        }
+
+                        // forward request to the target
+                        if let Ok(target) = PeerId::from_str(&request.target) {
+                            let forward_request = swarm.send_request(&target, request);
+                            requests.insert(forward_request, request_id);
+                        }
                     }
-                    SwarmEvent::ListenerError { error } => {
-                        println!("Listener error: {:?}", error);
-                        return;
-                    }
-                    SwarmEvent::Behaviour(P2PEvent::RequestResponse(event)) => {
-                        match event.deref().clone() {
-                            // forward incoming request to the targeted peer
-                            P2PReqResEvent::Req {
-                                peer_id,
-                                request_id,
-                                request,
-                            } => {
-                                // verify that the claimed source is the actual peer that send the request
-                                if peer_id.to_string() != request.source {
-                                    continue;
-                                }
-
-                                // forward request to the target
-                                if let Ok(target) = PeerId::from_str(&request.target) {
-                                    let forward_request = swarm.send_request(&target, request);
-                                    requests.insert(forward_request, request_id);
-                                }
-                            }
-                            P2PReqResEvent::Res {
-                                peer_id: _,
-                                request_id,
-                                response,
-                            } => {
-                                if let Some(original_request) = requests.remove(&request_id) {
-                                    let _ = swarm.send_response(original_request, response);
-                                }
-                            }
-                            _ => {}
+                    P2PReqResEvent::Res {
+                        peer_id: _,
+                        request_id,
+                        response,
+                    } => {
+                        if let Some(original_request) = requests.remove(&request_id) {
+                            let _ = swarm.send_response(original_request, response);
                         }
                     }
                     _ => {}
                 }
             }
-        });
+            _ => {}
+        }
     }
 }
 
-fn start_peer(matches: &ArgMatches) {
-    if let Some(matches) = matches.subcommand_matches("connect") {
-        let relay_addr = matches
-            .value_of("relay_addr")
-            .and_then(|addr_arg| Multiaddr::from_str(addr_arg).ok())
-            .expect("Missing or invalid relay address");
-        let local_keys = Keypair::generate_ed25519();
+async fn start_peer(matches: &ArgMatches) {
+    let relay_addr = matches
+        .value_of("relay_addr")
+        .and_then(|addr_arg| Multiaddr::from_str(addr_arg).ok())
+        .expect("Missing or invalid relay address");
+    let local_keys = Keypair::generate_ed25519();
 
-        // Create swarm for communication
-        let config = BehaviourConfig::new(Some(Duration::from_secs(10)), Some(Duration::from_secs(60)));
-        let mut swarm = P2PNetworkBehaviour::<RequestEnvelope<String>, Ack>::init_swarm(local_keys, config)
-            .expect("Could not create swarm.");
-        println!("\nLocal Peer Id {:?}", Swarm::local_peer_id(&swarm));
+    // Create swarm for communication
+    let config = BehaviourConfig::new(Some(Duration::from_secs(10)), Some(Duration::from_secs(60)), None, None);
+    let mut swarm = P2PNetworkBehaviour::<RequestEnvelope<String>, Ack>::init_swarm(local_keys, config)
+        .await
+        .expect("Could not create swarm.");
+    println!("\nLocal Peer Id {:?}", Swarm::local_peer_id(&swarm));
 
-        Swarm::dial_addr(&mut swarm, relay_addr.clone()).expect("Could not dial address.");
+    Swarm::dial_addr(&mut swarm, relay_addr.clone()).expect("Could not dial address.");
 
-        let start = Instant::now();
-        let relay_peer = task::block_on(async {
-            loop {
-                let event = swarm.next_event().await;
+    let start = Instant::now();
+    let relay_peer = loop {
+        let event = swarm.next_event().await;
+        match event {
+            SwarmEvent::ConnectionEstablished {
+                peer_id,
+                endpoint: ConnectedPoint::Dialer { address },
+                num_established: _,
+            } => {
+                if address == relay_addr {
+                    break Some(peer_id);
+                }
+            }
+            SwarmEvent::UnreachableAddr {
+                peer_id: _,
+                address,
+                error,
+                attempts_remaining: 0,
+            }
+            | SwarmEvent::UnknownPeerUnreachableAddr { address, error } => {
+                println!("Could not connect address {:?}: {:?}", address, error);
+                break None;
+            }
+            _ => {}
+        }
+        if start.elapsed() > Duration::new(3, 0) {
+            break None;
+        }
+    }
+    .expect("Could not connect relay");
+
+    println!("\n'SET \"<targe-peer-id>\"' to set the target for your messages.");
+
+    let mut stdin = BufReader::new(stdin()).lines();
+    // Start polling for user input and events in the network
+    let mut peer_target: Option<PeerId> = None;
+    loop {
+        select! {
+            // User input from stdin
+            stdin_input = stdin.next().fuse()=> {
+                if let Some(Ok(command)) = stdin_input {
+                    handle_input_line(&mut swarm, &command, relay_peer, &mut peer_target);
+                } else {
+                    // stdin closed
+                    break;
+                }
+            },
+            // Events from the swarm
+            event = swarm.next_event().fuse() => {
                 match event {
-                    SwarmEvent::ConnectionEstablished {
-                        peer_id,
-                        endpoint: ConnectedPoint::Dialer { address },
-                        num_established: _,
-                    } => {
-                        if address == relay_addr {
-                            return Some(peer_id);
+                    SwarmEvent::Behaviour(P2PEvent::RequestResponse(boxed_event)) => {
+                        handle_event(&mut swarm, boxed_event.deref().clone(), relay_peer, &mut peer_target)
+                    }
+                    SwarmEvent::ConnectionClosed{peer_id, endpoint: _, num_established: 0, cause: _} => {
+                        if peer_id == relay_peer {
+                            if let Err(err) =  Swarm::dial_addr(&mut swarm, relay_addr.clone()){
+                                println!("Error reconnection relay: {:?}", err);
+                                return;
+                            }
                         }
                     }
                     SwarmEvent::UnreachableAddr {
@@ -121,66 +165,14 @@ fn start_peer(matches: &ArgMatches) {
                         address,
                         error,
                         attempts_remaining: 0,
-                    }
-                    | SwarmEvent::UnknownPeerUnreachableAddr { address, error } => {
-                        println!("Could not connect address {:?}: {:?}", address, error);
-                        return None;
-                    }
+                    } | SwarmEvent::UnknownPeerUnreachableAddr {
+                        address,
+                        error,
+                    } => panic!(format!("Unreachable addr: {:?}\n{:?}", address, error)),
                     _ => {}
                 }
-                if start.elapsed() > Duration::new(3, 0) {
-                    return None;
-                }
             }
-        })
-        .expect("Could not connect relay");
-
-        println!("\n'SET \"<targe-peer-id>\"' to set the target for your messages.");
-
-        let mut stdin = BufReader::new(stdin()).lines();
-        // Start polling for user input and events in the network
-        task::block_on(async {
-            let mut peer_target: Option<PeerId> = None;
-            loop {
-                select! {
-                    // User input from stdin
-                    stdin_input = stdin.next().fuse()=> {
-                        if let Some(Ok(command)) = stdin_input {
-                            handle_input_line(&mut swarm, &command, relay_peer, &mut peer_target);
-                        } else {
-                            // stdin closed
-                            break;
-                        }
-                    },
-                    // Events from the swarm
-                    event = swarm.next_event().fuse() => {
-                        match event {
-                            SwarmEvent::Behaviour(P2PEvent::RequestResponse(boxed_event)) => {
-                                handle_event(&mut swarm, boxed_event.deref().clone(), relay_peer, &mut peer_target)
-                            }
-                            SwarmEvent::ConnectionClosed{peer_id, endpoint: _, num_established: 0, cause: _} => {
-                                if peer_id == relay_peer {
-                                    if let Err(err) =  Swarm::dial_addr(&mut swarm, relay_addr.clone()){
-                                        println!("Error reconnection relay: {:?}", err);
-                                        return;
-                                    }
-                                }
-                            }
-                            SwarmEvent::UnreachableAddr {
-                                peer_id: _,
-                                address,
-                                error,
-                                attempts_remaining: 0,
-                            } | SwarmEvent::UnknownPeerUnreachableAddr {
-                                address,
-                                error,
-                            } => panic!(format!("Unreachable addr: {:?}\n{:?}", address, error)),
-                            _ => {}
-                        }
-                    }
-                };
-            }
-        });
+        };
     }
 }
 
@@ -267,6 +259,10 @@ fn handle_input_line(
 fn main() {
     let yaml = load_yaml!("cli_relay.yml");
     let matches = App::from(yaml).get_matches();
-    run_relay(&matches);
-    start_peer(&matches);
+    if matches.subcommand_matches("start-relay").is_some() {
+        task::block_on(run_relay())
+    }
+    if let Some(matches) = matches.subcommand_matches("connect") {
+        task::block_on(start_peer(&matches));
+    }
 }

--- a/communication/src/actor.rs
+++ b/communication/src/actor.rs
@@ -174,8 +174,13 @@ where
             self.swarm_tx = Some(swarm_tx);
 
             let actor_system = ctx.system.clone();
-            let swarm_task =
-                SwarmTask::<_, Res, _, _>::new(actor_system, swarm_rx, actor_config, keypair, behaviour_config);
+            let swarm_task = task::block_on(SwarmTask::<_, Res, _, _>::new(
+                actor_system,
+                swarm_rx,
+                actor_config,
+                keypair,
+                behaviour_config,
+            ));
             if let Ok(swarm_task) = swarm_task {
                 // Kick off the swarm communication.
                 self.poll_swarm_handle = ctx.run(swarm_task.poll_swarm()).ok();

--- a/communication/src/actor/types.rs
+++ b/communication/src/actor/types.rs
@@ -193,6 +193,8 @@ pub enum ConnectPeerError {
     Handler,
     /// Timout on connection attempt
     Timeout,
+    /// The address given for dialing is invalid.
+    InvalidAddress(Multiaddr),
 }
 
 impl<TTransErr> From<PendingConnectionError<TTransErr>> for ConnectPeerError {
@@ -212,6 +214,7 @@ impl From<DialError> for ConnectPeerError {
             DialError::Banned => ConnectPeerError::Banned,
             DialError::ConnectionLimit(limit) => ConnectPeerError::ConnectionLimit(limit),
             DialError::NoAddresses => ConnectPeerError::NoAddresses,
+            DialError::InvalidAddress(addr) => ConnectPeerError::InvalidAddress(addr),
         }
     }
 }

--- a/communication/src/lib.rs
+++ b/communication/src/lib.rs
@@ -30,6 +30,7 @@
 //!
 //! ### Example
 //! ```no_run
+//! use async_std::task;
 //! use communication::behaviour::{BehaviourConfig, P2PNetworkBehaviour};
 //! use libp2p::identity::Keypair;
 //! use serde::{Deserialize, Serialize};
@@ -46,8 +47,8 @@
 //!
 //! let local_keys = Keypair::generate_ed25519();
 //! let config = BehaviourConfig::default();
-//! let mut swarm =
-//!     P2PNetworkBehaviour::<Request, Response>::init_swarm(local_keys, config).expect("Init swarm failed.");
+//! let mut swarm = task::block_on(P2PNetworkBehaviour::<Request, Response>::init_swarm(local_keys, config))
+//!     .expect("Init swarm failed.");
 //! ```
 //!
 //! ## CommunicationActor

--- a/communication/tests/test_macro.rs
+++ b/communication/tests/test_macro.rs
@@ -1,8 +1,9 @@
 // Copyright 2020-2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use communication::actor::{FirewallPermission, PermissionValue, ToPermissionVariants, VariantPermission};
-use communication_macros::RequestPermissions;
+use communication::actor::{
+    FirewallPermission, PermissionValue, RequestPermissions, ToPermissionVariants, VariantPermission,
+};
 
 #[derive(RequestPermissions)]
 enum TestEnum {


### PR DESCRIPTION
# Description of change

Patch libp2p version to 0.36: handle changes in mdns and the dns transport, make P2PNetworkBehaviour init_swarm method async.
Move the communication macro tests to stronghold-communication.

Solves #168.

## Type of change

- [x] Bug fix (a non-breaking change which fixes an issue)
- [x] Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Adjusted existing tests to the changes.

