### PR TITLE
chore: adjust covector package search

### DIFF
--- a/.changes/config.json
+++ b/.changes/config.json
@@ -4,7 +4,7 @@
   "pkgManagers": {
     "rust": {
       "version": true,
-      "getPublishedVersion": "cargo search ${ pkg.pkg } --limit 1 | sed -nE 's/^[^\"]*\"//; s/\".*//1p' -",
+      "getPublishedVersion": "cargo search ${ pkgFile.pkg.package.name } --limit 1 | sed -nE \"s/^[^\\\"]*\\\"//; s/\\\".*//1p\"",
       "prepublish": [
         "cargo install cargo-audit --features=fix",
         {
@@ -67,72 +67,6 @@
           "path": "${ pkg.path }/${ pkg.pkg }-${ pkgFile.version }.crate",
           "name": "${ pkg.pkg }-${ pkgFile.version }.crate"
         }
-      ]
-    },
-    "javascript": {
-      "version": true,
-      "getPublishedVersion": "npm view ${ pkgFile.pkg.name } version",
-      "prepublish": [
-        {
-          "command": "yarn",
-          "dryRunCommand": true
-        },
-        {
-          "command": "echo \"# Yarn Audit\n\"",
-          "dryRunCommand": true,
-          "pipe": true
-        },
-        {
-          "command": "echo \"<details>\n<summary>click to view</summary>\n\n\\`\\`\\`\"",
-          "dryRunCommand": true,
-          "pipe": true
-        },
-        {
-          "command": "yarn audit",
-          "dryRunCommand": true,
-          "runFromRoot": true,
-          "pipe": true
-        },
-        {
-          "command": "echo \"\\`\\`\\`\n\n</details>\n\"",
-          "dryRunCommand": true,
-          "pipe": true
-        },
-        {
-          "command": "neon build --release",
-          "dryRunCommand": true
-        },
-        {
-          "command": "npm pack",
-          "dryRunCommand": true
-        }
-      ],
-      "publish": [
-        {
-          "command": "echo \"# Yarn Package Publish\"",
-          "dryRunCommand": true,
-          "pipe": true
-        },
-        {
-          "command": "echo \"\\`\\`\\`\"",
-          "dryRunCommand": true,
-          "pipe": true
-        },
-        {
-          "command": "yarn publish --access public --loglevel silly",
-          "dryRunCommand": "npm publish --dry-run --access public",
-          "pipe": true
-        },
-        {
-          "command": "echo \"\\`\\`\\`\"",
-          "dryRunCommand": true,
-          "pipe": true
-        }
-      ],
-      "postpublish": [
-        "git tag ${ pkg.pkg }-v${ pkgFile.versionMajor } -f",
-        "git tag ${ pkg.pkg }-v${ pkgFile.versionMajor }.${ pkgFile.versionMinor } -f",
-        "git push --tags -f"
       ]
     }
   },


### PR DESCRIPTION
# Description of change

Adjusting the `getPublishedVersion` in the covector config. The previous check would use the nickname defined in the `packages` object further below in the config. Instead, we want to be searching for the crate name as listed in the Cargo.toml. While this won't break anything, and may not matter for a first publish, subsequent publishes will be affected.

This check determines if the package already exists, and if it does, will skip publishing. If it always "fails" and "doesn't exist", then it will try to publish and fail as it _does_ exist. This failure may prevent further packages in the config to never be able to publish.

Also, this project does not contain any javascript so removing that config. 

## Links to any relevant issues

N/A

## Type of change

Choose a type of change, and delete any options that are not relevant.

- [x] Bug fix (a non-breaking change which fixes an issue)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested

Locally via `npx covector version --dry-run`.

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
