### PR TITLE
chore: adjust github workflows for publishing

### DIFF
--- a/.changes/config.json
+++ b/.changes/config.json
@@ -80,7 +80,7 @@
       "manager": "rust"
     },
     "stronghold-utils": {
-      "path": "./utils/utils/",
+      "path": "./utils/",
       "manager": "rust",
       "dependencies": [
         "stronghold-derive"

--- a/.github/workflows/covector-status.yml
+++ b/.github/workflows/covector-status.yml
@@ -1,12 +1,10 @@
+# This will only run on the Pull Request and let's you know the status of covector.
+# It will also fail if there is an issue with configuration or a change file that is submitted.
 
 name: status
-on:
-  push:
-    branches:
-      - dev
+on: [pull_request]
 
 jobs:
-
   update-changelog:
     runs-on: ubuntu-latest
     timeout-minutes: 65
@@ -18,32 +16,8 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v1
-        with:
-          node-version: 14
-          registry-url: 'https://registry.npmjs.org'
-
-      - name: git config
-        run: |
-          git config --global user.name "${{ github.event.pusher.name }}"
-          git config --global user.email "${{ github.event.pusher.email }}"
-      - name: covector version or publish (publish when no change files present)
+      - name: covector status
         uses: jbolda/covector/packages/action@covector-v0
         id: covector
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          CARGO_AUDIT_OPTIONS: ${{ secrets.CARGO_AUDIT_OPTIONS }}
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          command: 'version-or-publish'
-
-      - name: Create Pull Request With Versions Bumped
-        if: steps.covector.outputs.commandRan == 'version'
-        uses: iotaledger/create-pull-request@v3.4.1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          branch: release/version-updates
-          title: Apply Version Updates From Current Changes
-          commit-message: "apply version updates"
-          labels: "version updates"
-          body: ${{ steps.covector.outputs.change }}
+          command: "status"

--- a/.github/workflows/covector-status.yml
+++ b/.github/workflows/covector-status.yml
@@ -5,7 +5,7 @@ name: status
 on: [pull_request]
 
 jobs:
-  update-changelog:
+  status:
     runs-on: ubuntu-latest
     timeout-minutes: 65
     outputs:

--- a/.github/workflows/covector-version-or-publish.yml
+++ b/.github/workflows/covector-version-or-publish.yml
@@ -1,8 +1,15 @@
+# This runs every time a commit is pushed to the `dev` branch.
+# It will dynamically choose to run `covector version` or `covector publish`.
+# If there are change files present it will run `version`, otherwise it will run `publish`.
+# When it runs `publish`, it will use the `./.changes/config.json` packages configuration,
+#  and run the `getPublishedVersion`. If that returns a value that matches the current version number,
+#  then it will skip the attempting to publish.
+
 name: publish
 on:
   push:
     branches:
-      - main
+      - dev
 
 jobs:
   version-or-publish:
@@ -17,10 +24,6 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v1
-        with:
-          node-version: 14
-          registry-url: 'https://registry.npmjs.org'
       - name: cargo login
         run: cargo login ${{ secrets.CRATES_IO_TOKEN }}
       - name: git config
@@ -31,11 +34,10 @@ jobs:
         uses: jbolda/covector/packages/action@covector-v0
         id: covector
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           CARGO_AUDIT_OPTIONS: ${{ secrets.CARGO_AUDIT_OPTIONS }}
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          command: 'version-or-publish'
+          command: "version-or-publish"
           createRelease: true
       - name: Create Pull Request With Versions Bumped
         if: steps.covector.outputs.commandRan == 'version'
@@ -44,7 +46,6 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: release/version-updates
           title: Apply Version Updates From Current Changes
-          commit-message: 'apply version updates'
-          labels: 'version updates'
+          commit-message: "apply version updates"
+          labels: "version updates"
           body: ${{ steps.covector.outputs.change }}
-


### PR DESCRIPTION
# Description of change

The status and publish sequences in the Github workflows were targeting the wrong branch and had extraneous steps. Removed and adjusted these.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
