### PR TITLE
Fix error being returned in `Ed25519Sign` when key size == 32

### DIFF
--- a/client/src/actors/internal.rs
+++ b/client/src/actors/internal.rs
@@ -679,7 +679,7 @@ impl Receive<InternalMsg> for InternalActor<Provider> {
                             let raw = data.borrow();
                             let mut raw = (*raw).to_vec();
 
-                            if raw.len() <= 32 {
+                            if raw.len() < 32 {
                                 client.try_tell(
                                     ClientMsg::InternalResults(InternalResults::ReturnControlRequest(
                                         ProcResult::Ed25519Sign(ResultMessage::Error(


### PR DESCRIPTION
# Description of change

Storing a key with exactly 32 bytes and using it in an `Ed25519Sign` procedure returns an `"incorrect number of key bytes"` error. The error is returned because of the `raw.len() <= 32` check. This PR changes that to use a `<` comparison instead.

## Links to any relevant issues

None

## Type of change

Choose a type of change, and delete any options that are not relevant.

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
