### PR TITLE
Fix/wrong cf on write to vault

### DIFF
--- a/.changes/write_to_vault.md
+++ b/.changes/write_to_vault.md
@@ -1,0 +1,5 @@
+---
+"iota-stronghold": patch
+---
+
+- corrects wrong control flow. `write_to_vault` always returned an error even if the operation was successful. 

--- a/client/src/interface.rs
+++ b/client/src/interface.rs
@@ -157,7 +157,7 @@ impl Stronghold {
             match result {
                 Ok(_) => {
                     // exists
-                    match self
+                    return match self
                         .target
                         .send(WriteToVault {
                             location,
@@ -170,7 +170,7 @@ impl Stronghold {
                             Ok(_) => StatusMessage::OK,
                             Err(e) => StatusMessage::Error(e.to_string()),
                         },
-                        Err(e) => return StatusMessage::Error(e.to_string()),
+                        Err(e) => StatusMessage::Error(e.to_string()),
                     };
                 }
                 Err(_) => {

--- a/client/src/interface.rs
+++ b/client/src/interface.rs
@@ -166,13 +166,10 @@ impl Stronghold {
                         })
                         .await
                     {
-                        Ok(result) => {
-                            return if result.is_ok() {
-                                StatusMessage::OK
-                            } else {
-                                StatusMessage::Error(result.err().unwrap().to_string())
-                            }
-                        }
+                        Ok(result) => match result {
+                            Ok(_) => StatusMessage::OK,
+                            Err(e) => StatusMessage::Error(e.to_string()),
+                        },
                         Err(e) => return StatusMessage::Error(e.to_string()),
                     };
                 }

--- a/client/src/interface.rs
+++ b/client/src/interface.rs
@@ -157,14 +157,24 @@ impl Stronghold {
             match result {
                 Ok(_) => {
                     // exists
-                    let _result = self
+                    match self
                         .target
                         .send(WriteToVault {
                             location,
                             payload,
                             hint,
                         })
-                        .await;
+                        .await
+                    {
+                        Ok(result) => {
+                            return if result.is_ok() {
+                                StatusMessage::OK
+                            } else {
+                                StatusMessage::Error(result.err().unwrap().to_string())
+                            }
+                        }
+                        Err(e) => return StatusMessage::Error(e.to_string()),
+                    };
                 }
                 Err(_) => {
                     // does not exist
@@ -177,7 +187,7 @@ impl Stronghold {
                     {
                         Ok(_) => {
                             // write to vault
-                            if let Ok(_result) = self
+                            if let Ok(result) = self
                                 .target
                                 .send(WriteToVault {
                                     location,
@@ -186,6 +196,11 @@ impl Stronghold {
                                 })
                                 .await
                             {
+                                if result.is_ok() {
+                                    return StatusMessage::OK;
+                                } else {
+                                    return StatusMessage::Error(result.err().unwrap().to_string());
+                                }
                             } else {
                                 return StatusMessage::Error("Error Writing data".into());
                             }

--- a/client/src/tests/interface_tests.rs
+++ b/client/src/tests/interface_tests.rs
@@ -31,14 +31,15 @@ async fn test_stronghold() {
         .unwrap();
 
     // Write at the first record of the vault using Some(0).  Also creates the new vault.
-    stronghold
+    assert!(stronghold
         .write_to_vault(
             loc0.clone(),
             b"test".to_vec(),
             RecordHint::new(b"first hint").expect(line_error!()),
             vec![],
         )
-        .await;
+        .await
+        .is_ok());
 
     // read head.
     let (p, _) = stronghold.read_secret(client_path.clone(), loc0.clone()).await;
@@ -46,28 +47,30 @@ async fn test_stronghold() {
     assert_eq!(std::str::from_utf8(&p.unwrap()), Ok("test"));
 
     // Write on the next record of the vault using None.  This calls InitRecord and creates a new one at index 1.
-    stronghold
+    assert!(stronghold
         .write_to_vault(
             loc1.clone(),
             b"another test".to_vec(),
             RecordHint::new(b"another hint").expect(line_error!()),
             vec![],
         )
-        .await;
+        .await
+        .is_ok());
 
     // read head.
     let (p, _) = stronghold.read_secret(client_path.clone(), loc1.clone()).await;
 
     assert_eq!(std::str::from_utf8(&p.unwrap()), Ok("another test"));
 
-    stronghold
+    assert!(stronghold
         .write_to_vault(
             loc2.clone(),
             b"yet another test".to_vec(),
             RecordHint::new(b"yet another hint").expect(line_error!()),
             vec![],
         )
-        .await;
+        .await
+        .is_ok());
 
     // read head.
     let (p, _) = stronghold.read_secret(client_path.clone(), loc2.clone()).await;
@@ -174,14 +177,15 @@ async fn run_stronghold_multi_actors() {
 
     stronghold.switch_actor_target(client_path0.clone()).await;
 
-    stronghold
+    assert!(stronghold
         .write_to_vault(
             loc0.clone(),
             b"test".to_vec(),
             RecordHint::new(b"0").expect(line_error!()),
             vec![],
         )
-        .await;
+        .await
+        .is_ok());
 
     // read head.
     let (p, _) = stronghold.read_secret(client_path0.clone(), loc0.clone()).await;
@@ -191,14 +195,15 @@ async fn run_stronghold_multi_actors() {
     stronghold.switch_actor_target(client_path1.clone()).await;
 
     // Write on the next record of the vault using None.  This calls InitRecord and creates a new one at index 1.
-    stronghold
+    assert!(stronghold
         .write_to_vault(
             loc0.clone(),
             b"another test".to_vec(),
             RecordHint::new(b"1").expect(line_error!()),
             vec![],
         )
-        .await;
+        .await
+        .is_ok());
 
     // read head.
     let (p, _) = stronghold.read_secret(client_path1.clone(), loc0.clone()).await;
@@ -207,14 +212,15 @@ async fn run_stronghold_multi_actors() {
 
     stronghold.switch_actor_target(client_path0.clone()).await;
 
-    stronghold
+    assert!(stronghold
         .write_to_vault(
             loc0.clone(),
             b"yet another test".to_vec(),
             RecordHint::new(b"2").expect(line_error!()),
             vec![],
         )
-        .await;
+        .await
+        .is_ok());
 
     let (p, _) = stronghold.read_secret(client_path0.clone(), loc0.clone()).await;
 
@@ -249,27 +255,29 @@ async fn run_stronghold_multi_actors() {
 
     assert_eq!(std::str::from_utf8(&p.unwrap()), Ok("another test"));
 
-    stronghold
+    assert!(stronghold
         .write_to_vault(
             loc3.clone(),
             b"a new actor test".to_vec(),
             RecordHint::new(b"2").expect(line_error!()),
             vec![],
         )
-        .await;
+        .await
+        .is_ok());
 
     let (p, _) = stronghold.read_secret(client_path2.clone(), loc3).await;
 
     assert_eq!(std::str::from_utf8(&p.unwrap()), Ok("a new actor test"));
 
-    stronghold
+    assert!(stronghold
         .write_to_vault(
             loc4.clone(),
             b"a new actor test again".to_vec(),
             RecordHint::new(b"3").expect(line_error!()),
             vec![],
         )
-        .await;
+        .await
+        .is_ok());
 
     let (p, _) = stronghold.read_secret(client_path2, loc4.clone()).await;
 
@@ -329,14 +337,15 @@ async fn test_stronghold_generics() {
         .await
         .unwrap();
 
-    stronghold
+    assert!(stronghold
         .write_to_vault(
             slip10_seed.clone(),
             b"AAAAAA".to_vec(),
             RecordHint::new(b"first hint").expect(line_error!()),
             vec![],
         )
-        .await;
+        .await
+        .is_ok());
     let (p, _) = stronghold.read_secret(client_path, slip10_seed).await;
     assert_eq!(std::str::from_utf8(&p.unwrap()), Ok("AAAAAA"));
 


### PR DESCRIPTION
# Description of change

This PR corrects a wrong control flow in `client/src/write_to_vault`, that always returned an error even if the operation was successful. 

## Links to any relevant issues

none. 

## Type of change

Choose a type of change, and delete any options that are not relevant.

- [x] Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

`client/src/tests/interface_tests.rs` have been extended to detect this kind of behavior. 

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
