### PR TITLE
Fix(client): Avoid Key cloning, remove redundant code

### DIFF
--- a/.changes/key-cloning.md
+++ b/.changes/key-cloning.md
@@ -3,5 +3,5 @@
 ---
 
 [[PR 254](https://github.com/iotaledger/stronghold.rs/pull/254)]  
-Change key handling in the `SecureClient` to avoid unnecessary cloning of `Key`s.
+Change key handling in the `SecureClient` to avoid unnecessary cloning of keys.
 Remove obsolete VaultId-HashSet from the `SecureClient`.

--- a/.changes/key-cloning.md
+++ b/.changes/key-cloning.md
@@ -1,0 +1,7 @@
+---
+"iota-stronghold": patch
+---
+
+[[PR 254](https://github.com/iotaledger/stronghold.rs/pull/254)]  
+Change key handling in the `SecureClient` to avoid unnecessary cloning of `Key`s.
+Remove obsolete VaultId-HashSet from the `SecureClient`.

--- a/client/src/actors.rs
+++ b/client/src/actors.rs
@@ -17,7 +17,7 @@ pub use self::{
     secure::{
         messages as secure_messages, procedures as secure_procedures,
         procedures::{ProcResult, SLIP10DeriveInput},
-        SecureClient,
+        SecureClient, VaultError,
     },
     snapshot::{messages as snapshot_messages, returntypes as snapshot_returntypes},
 };

--- a/client/src/actors/secure.rs
+++ b/client/src/actors/secure.rs
@@ -53,10 +53,10 @@ pub enum VaultError {
     NotExisting,
 
     #[error("Failed to revoke record, vault does not exist")]
-    RevokationError,
+    RevocationError,
 
     #[error("Failed to collect gargabe, vault does not exist")]
-    GargabeCollectError,
+    GarbageCollectError,
 
     #[error("Failed to get list, vault does not exist")]
     ListError,
@@ -517,23 +517,23 @@ pub mod testing {
     impl_handler!(ReadFromVault, Result<Vec<u8>, anyhow::Error>, (self, msg, _ctx), {
         let (vid, rid) = self.resolve_location(msg.location);
 
-        if let Some(key) = self.keystore.get_key(vid) {
-            let mut data = Vec::new();
+        let key = self
+            .keystore
+            .take_key(vid)
+            .ok_or(anyhow::anyhow!(VaultError::NotExisting))?;
 
-            self.db
-                .get_guard(&key, vid, rid, |guarded_data| {
-                    let guarded_data = guarded_data.borrow();
-                    data.extend_from_slice(&*guarded_data);
+        let mut data = Vec::new();
+        let res = self.db.get_guard(&key, vid, rid, |guarded_data| {
+            let guarded_data = guarded_data.borrow();
+            data.extend_from_slice(&*guarded_data);
+            Ok(())
+        });
+        self.keystore.insert_key(vid, key);
 
-                    Ok(())
-                })
-                .map_err(|e| anyhow::anyhow!(e))?;
-            self.keystore.insert_key(vid, key);
-
-            return Ok(data);
+        match res {
+            Ok(_) => Ok(data),
+            Err(e) => Err(anyhow::anyhow!(e)),
         }
-
-        Err(anyhow::anyhow!(VaultError::AccessError))
     });
 }
 
@@ -557,16 +557,17 @@ impl_handler!(messages::CreateVault, (), (self, msg, _ctx), {
     let (vault_id, _) = self.resolve_location(msg.location);
 
     let key = self.keystore.create_key(vault_id);
-    self.db.init_vault(&key, vault_id).unwrap(); // potentially produces an error
+    self.db.init_vault(key, vault_id).unwrap(); // potentially produces an error
 });
 
 impl_handler!(messages::CheckRecord, bool, (self, msg, _ctx), {
     let (vault_id, record_id) = self.resolve_location(msg.location);
 
-    return match self.keystore.get_key(vault_id) {
+    return match self.keystore.take_key(vault_id) {
         Some(key) => {
-            self.keystore.insert_key(vault_id, key.clone());
-            self.db.contains_record(&key, vault_id, record_id)
+            let res = self.db.contains_record(&key, vault_id, record_id);
+            self.keystore.insert_key(vault_id, key);
+            res
         }
         None => false,
     };
@@ -575,43 +576,40 @@ impl_handler!(messages::CheckRecord, bool, (self, msg, _ctx), {
 impl_handler!(messages::WriteToVault, Result<(), anyhow::Error>, (self, msg, _ctx), {
     let (vault_id, record_id) = self.resolve_location(msg.location);
 
-    return match self.keystore.get_key(vault_id) {
-        Some(key) => {
-            self.keystore.insert_key(vault_id, key.clone());
-            self.db.write(&key, vault_id, record_id, &msg.payload, msg.hint).map_err(|e| anyhow::anyhow!(e))
-        }
-        None => {
-            Err(anyhow::anyhow!(VaultError::NotExisting))
-        }
-    }
+    let key = self
+        .keystore
+        .take_key(vault_id)
+        .ok_or(anyhow::anyhow!(VaultError::NotExisting))?;
+
+    let res = self.db.write(&key, vault_id, record_id, &msg.payload, msg.hint);
+    self.keystore.insert_key(vault_id, key);
+    res.map_err(|e| anyhow::anyhow!(e))
 });
 
 impl_handler!(messages::RevokeData, Result<(), anyhow::Error>, (self, msg, _ctx), {
     let (vault_id, record_id) = self.resolve_location(msg.location);
 
-    return match self.keystore.get_key(vault_id) {
-        Some(key) => {
-            self.keystore.insert_key(vault_id, key.clone());
-            self.db.revoke_record(&key, vault_id, record_id).map_err(|e| anyhow::anyhow!(e))
-        }
-        None => {
-            Err(anyhow::anyhow!(VaultError::RevokationError))
-        }
-    }
+    let key = self
+        .keystore
+        .take_key(vault_id)
+        .ok_or(anyhow::anyhow!(VaultError::NotExisting))?;
+
+    let res = self.db.revoke_record(&key, vault_id, record_id);
+    self.keystore.insert_key(vault_id, key);
+    res.map_err(|_| anyhow::anyhow!(VaultError::RevocationError))
 });
 
 impl_handler!(messages::GarbageCollect, Result<(), anyhow::Error>, (self, msg, _ctx), {
     let (vault_id, _) = self.resolve_location(msg.location);
 
-    return match self.keystore.get_key(vault_id) {
-        Some(key) => {
-            self.keystore.insert_key(vault_id, key.clone());
-            self.db.garbage_collect_vault(&key, vault_id).map_err(|e| anyhow::anyhow!(e))
-        }
-        None => {
-            Err(anyhow::anyhow!(VaultError::GargabeCollectError))
-        }
-    }
+    let key = self
+        .keystore
+        .take_key(vault_id)
+        .ok_or(anyhow::anyhow!(VaultError::NotExisting))?;
+
+    let res = self.db.garbage_collect_vault(&key, vault_id);
+    self.keystore.insert_key(vault_id, key);
+    res.map_err(|_| anyhow::anyhow!(VaultError::GarbageCollectError))
 });
 
 impl_handler!(
@@ -620,14 +618,14 @@ impl_handler!(
     (self, msg, _ctx),
     {
         let vault_id = self.derive_vault_id(msg.vault_path);
+        let key = self
+            .keystore
+            .take_key(vault_id)
+            .ok_or(anyhow::anyhow!(VaultError::NotExisting))?;
 
-        match self.keystore.get_key(vault_id) {
-            Some(key) => {
-                self.keystore.insert_key(vault_id, key.clone());
-                Ok(self.db.list_hints_and_ids(&key, vault_id))
-            }
-            None => Err(anyhow::anyhow!(VaultError::ListError)),
-        }
+        let list = self.db.list_hints_and_ids(&key, vault_id);
+        self.keystore.insert_key(vault_id, key);
+        Ok(list)
     }
 );
 
@@ -666,10 +664,10 @@ impl_handler!(
 );
 
 impl_handler!( messages::DeleteFromStore, Result <(), anyhow::Error>, (self, msg, _ctx), {
-        let (vault_id, _) = self.resolve_location(msg.location);
-        self.store_delete_item(vault_id.into());
+    let (vault_id, _) = self.resolve_location(msg.location);
+    self.store_delete_item(vault_id.into());
 
-        Ok(())
+    Ok(())
 });
 
 impl_handler!(
@@ -842,277 +840,242 @@ impl Handler<CallProcedure> for SecureClient {
     }
 }
 
-impl_handler!(
-procedures::SLIP10Generate, Result<crate::ProcResult, anyhow::Error>, (self, msg, _ctx), {
-
-    let key = if !self.keystore.vault_exists(msg.vault_id) {
+impl_handler!(procedures::SLIP10Generate, Result<crate::ProcResult, anyhow::Error>, (self, msg, _ctx), {
+    if !self.keystore.vault_exists(msg.vault_id) {
         let key = self.keystore.create_key(msg.vault_id);
-        self.db.init_vault(&key, msg.vault_id)?;
-        key
-    } else {
-        self.keystore.get_key(msg.vault_id).unwrap()
-    };
-
-    self.keystore.insert_key(msg.vault_id, key.clone());
+        self.db.init_vault(key, msg.vault_id)?;
+    }
+    let key = self.keystore.take_key(msg.vault_id).unwrap();
 
     let mut seed = vec![0u8; msg.size_bytes];
     fill(&mut seed).map_err(|e| anyhow::anyhow!(e))?;
 
-    match self.db.write(&key, msg.vault_id, msg.record_id,&seed, msg.hint).map_err(|e| anyhow::anyhow!(e)) {
-        Ok(_) => {
-            Ok(crate::ProcResult::SLIP10Generate(StatusMessage::OK))
-        },
-        Err(e) => Err(anyhow::anyhow!(e))
+    let res = self.db.write(&key, msg.vault_id, msg.record_id, &seed, msg.hint);
+
+    self.keystore.insert_key(msg.vault_id, key);
+
+    match res {
+        Ok(_) => Ok(ProcResult::SLIP10Generate(StatusMessage::OK)),
+        Err(e) => Err(anyhow::anyhow!(e)),
     }
 });
 
 impl_handler!(procedures::SLIP10DeriveFromSeed, Result<crate::ProcResult, anyhow::Error>, (self, msg, _ctx), {
-    match self.keystore.get_key(msg.seed_vault_id) {
-        Some(seed_key) => {
-            self.keystore.insert_key(msg.seed_vault_id, seed_key.clone());
-            let dk_key = if !self.keystore.vault_exists(msg.key_vault_id) {
-                let key = self.keystore.create_key(msg.key_vault_id);
-                self.db.init_vault(&key, msg.key_vault_id).map_err(|e| anyhow::anyhow!(e))?;
-                key
+    let seed_key = self
+        .keystore
+        .take_key(msg.seed_vault_id)
+        .ok_or(anyhow::anyhow!(VaultError::NotExisting))?;
 
-            } else {
-                self.keystore.get_key(msg.key_vault_id).ok_or_else(||
-                    Err::<crate::ProcResult, anyhow::Error>(anyhow::anyhow!(crate::Error::KeyStoreError("".into())))
-                ).unwrap()
-            };
+    if !self.keystore.vault_exists(msg.key_vault_id) {
+        let key = self.keystore.create_key(msg.key_vault_id);
+        self.db.init_vault(key, msg.key_vault_id)?;
+    }
+    let dk_key = self.keystore.take_key(msg.key_vault_id).unwrap();
 
-            self.keystore.insert_key(msg.key_vault_id, dk_key.clone());
+    // FIXME if you see this fix here, that a single-threaded mutable reference
+    // is being passed into the closure to obtain the result of the pro-
+    // cedure calculation, you should consider rethinking this approach.
 
-            // FIXME if you see this fix here, that a single-threaded mutable reference
-            // is being passed into the closure to obtain the result of the pro-
-            // cedure calculation, you should consider rethinking this approach.
+    let result = Rc::new(Cell::default());
 
-            let result = Rc::new(Cell::default());
+    let res = self.db.exec_proc(
+        &seed_key,
+        msg.seed_vault_id,
+        msg.seed_record_id,
+        &dk_key,
+        msg.key_vault_id,
+        msg.key_record_id,
+        msg.hint,
+        |gdata| {
+            let dk = Seed::from_bytes(&gdata.borrow())
+                .derive(Curve::Ed25519, &msg.chain)
+                .map_err(|e| anyhow::anyhow!(e))
+                .unwrap();
+            let data: Vec<u8> = dk.into();
 
-            match self.db.exec_proc(&seed_key, msg.seed_vault_id, msg.seed_record_id, &dk_key, msg.key_vault_id, msg.key_record_id, msg.hint, |gdata| {
-                let dk = Seed::from_bytes(&gdata.borrow())
-                    .derive(Curve::Ed25519, &msg.chain).map_err(|e| anyhow::anyhow!(e)).unwrap();
-                let data : Vec<u8> = dk.into();
+            result.set(dk.chain_code());
 
-                // was formerly sent to the client
-                result.set(dk.chain_code());
+            Ok(data)
+        },
+    );
 
-                Ok(data)
-            }) {
-                Ok(_) => {
-                    let result = result.get();
-                    Ok(ProcResult::SLIP10Derive(ResultMessage::Ok(result)))
-                }
-                Err(e) => {
-                    Err(anyhow::anyhow!(e))
-                }
-            }
-        }
+    self.keystore.insert_key(msg.seed_vault_id, seed_key);
+    self.keystore.insert_key(msg.key_vault_id, dk_key);
 
-        None => {
-            Err(anyhow::anyhow!(VaultError::NotExisting))
-        }
+    match res {
+        Ok(_) => Ok(ProcResult::SLIP10Derive(ResultMessage::Ok(result.get()))),
+        Err(e) => Err(anyhow::anyhow!(e)),
     }
 });
 
 impl_handler!( procedures::SLIP10DeriveFromKey,Result<crate::ProcResult, anyhow::Error>, (self, msg, _ctx),{
-    use std::{rc::Rc, cell::Cell};
+    let parent_key = self
+        .keystore
+        .take_key(msg.parent_vault_id)
+        .ok_or(anyhow::anyhow!(VaultError::NotExisting))?;
 
-    match self.keystore.get_key(msg.parent_vault_id) {
-        Some(parent_key) => {
-            self.keystore.insert_key(msg.parent_vault_id, parent_key.clone());
-            let child_key = if !self.keystore.vault_exists(msg.child_vault_id) {
-                let key = self.keystore.create_key(msg.child_vault_id);
-                self.db.init_vault(&key, msg.child_vault_id).unwrap();
-
-                key
-            } else {
-                self.keystore.get_key(msg.child_vault_id).unwrap()
-            };
-
-            self.keystore.insert_key(msg.child_vault_id, child_key.clone());
-
-            let result = Rc::new(Cell::default());
-
-            match self.db.exec_proc(&parent_key, msg.parent_vault_id, msg.parent_record_id, &child_key, msg.child_vault_id, msg.child_record_id, msg.hint, |parent | {
-                        let parent = slip10::Key::try_from(&*parent.borrow()).unwrap();
-                        let dk = parent.derive(&msg.chain).unwrap();
-
-                        let data: Vec<u8> = dk.into();
-
-                        result.set(dk.chain_code());
-
-                    Ok(data)
-            }) {
-                Ok(_) => {
-                    let result = result.get();
-                    Ok(ProcResult::SLIP10Derive(ResultMessage::Ok(result)))
-                },
-                Err(e) => {
-                    Err(anyhow::anyhow!(e))
-                }
-            }
-        }
-        None => {
-            Err(anyhow::anyhow!(VaultError::AccessError))
-        }
+    if !self.keystore.vault_exists(msg.child_vault_id) {
+        let key = self.keystore.create_key(msg.child_vault_id);
+        self.db.init_vault(key, msg.child_vault_id)?;
     }
+    let child_key = self.keystore.take_key(msg.child_vault_id).unwrap();
 
+    let result = Rc::new(Cell::default());
+
+    let res = self.db.exec_proc(
+        &parent_key,
+        msg.parent_vault_id,
+        msg.parent_record_id,
+        &child_key,
+        msg.child_vault_id,
+        msg.child_record_id,
+        msg.hint,
+        |parent| {
+            let parent = slip10::Key::try_from(&*parent.borrow()).unwrap();
+            let dk = parent.derive(&msg.chain).unwrap();
+
+            let data: Vec<u8> = dk.into();
+
+            result.set(dk.chain_code());
+
+            Ok(data)
+        },
+    );
+
+    self.keystore.insert_key(msg.parent_vault_id, parent_key);
+    self.keystore.insert_key(msg.child_vault_id, child_key);
+
+    match res {
+        Ok(_) => Ok(ProcResult::SLIP10Derive(ResultMessage::Ok(result.get()))),
+        Err(e) => Err(anyhow::anyhow!(e)),
+    }
 });
 
 impl_handler!(procedures::BIP39Generate, Result<crate::ProcResult, anyhow::Error>, (self, msg, _ctx), {
-            let mut entropy = [0u8; 32];
-            if let Err(e) =  fill(&mut entropy) {
-                return Err(anyhow::anyhow!(e))
-            }
+    let mut entropy = [0u8; 32];
+    fill(&mut entropy).map_err(|e| anyhow::anyhow!(e))?;
+    let mnemonic = bip39::wordlist::encode(
+        &entropy,
+        &bip39::wordlist::ENGLISH, // TODO: make this user configurable
+    ).map_err(|e| anyhow::anyhow!(format!("{:?}", e)))?;
 
-            let mnemonic = match bip39::wordlist::encode(
-                &entropy,
-                &bip39::wordlist::ENGLISH, // TODO: make this user configurable
-            ) {
-                Ok(encoded) => encoded,
-                Err(e) => { return Err(anyhow::anyhow!(format!("{:?}", e))); }
-            };
+    let mut seed = [0u8; 64];
+    bip39::mnemonic_to_seed(&mnemonic, &msg.passphrase, &mut seed);
 
-            let mut seed = [0u8; 64];
-            bip39::mnemonic_to_seed(&mnemonic, &msg.passphrase, &mut seed);
+    if !self.keystore.vault_exists(msg.vault_id) {
+        let key = self.keystore.create_key(msg.vault_id);
+        self.db.init_vault(key, msg.vault_id)?;
+    }
+    let key = self.keystore.take_key(msg.vault_id).unwrap();
 
-            let key = if !self.keystore.vault_exists(msg.vault_id) {
-                let k = self.keystore.create_key(msg.vault_id);
+    let res = self.db.write(&key, msg.vault_id, msg.record_id, &seed, msg.hint);
 
-                if let Err(e) = self.db.init_vault(&k, msg.vault_id) {
-                    return Err(anyhow::anyhow!(e))
-                };
+    self.keystore.insert_key(msg.vault_id, key);
 
-                k
-            } else {
-
-                match self.keystore.get_key(msg.vault_id) {
-                    Some(k) => k,
-                    None => { return Err(anyhow::anyhow!(VaultError::NotExisting)); }
-                }
-            };
-
-            self.keystore.insert_key(msg.vault_id, key.clone());
-
-            // TODO: also store the mnemonic to be able to export it in the
-            // BIP39MnemonicSentence message
-            match self.db.write(&key, msg.vault_id, msg.record_id, &seed, msg.hint) {
-                    Ok(_) => Ok(ProcResult::BIP39Generate(ResultMessage::OK)),
-                    Err(e) => Err(anyhow::anyhow!(e))
-            }
-
-
+    // TODO: also store the mnemonic to be able to export it in the
+    // BIP39MnemonicSentence message
+    match res {
+        Ok(_) => Ok(ProcResult::BIP39Generate(ResultMessage::OK)),
+        Err(e) => Err(anyhow::anyhow!(e)),
+    }
 });
 
 impl_handler!(procedures::BIP39Recover, Result<crate::ProcResult, anyhow::Error>, (self, msg, _ctx), {
+    if !self.keystore.vault_exists(msg.vault_id) {
+        let key = self.keystore.create_key(msg.vault_id);
+        self.db.init_vault(key, msg.vault_id)?;
+    }
+    let key = self.keystore.take_key(msg.vault_id).unwrap();
 
-        let key = if !self.keystore.vault_exists(msg.vault_id) {
-            let k = self.keystore.create_key(msg.vault_id);
-            if let Err(e) = self.db.init_vault(&k, msg.vault_id) {
-               return Err(anyhow::anyhow!(e))
-            };
+    let mut seed = [0u8; 64];
+    bip39::mnemonic_to_seed(&msg.mnemonic, &msg.passphrase, &mut seed);
 
-            k
-        } else {
-            match self.keystore.get_key(msg.vault_id) {
-                Some(key) => key,
-                None => { return Err(anyhow::anyhow!(VaultError::NotExisting)); }
-            }
-        };
-            self.keystore.insert_key(msg.vault_id, key.clone());
+    let res = self.db.write(&key, msg.vault_id, msg.record_id, &seed, msg.hint);
+    self.keystore.insert_key(msg.vault_id, key);
 
-            let mut seed = [0u8; 64];
-            bip39::mnemonic_to_seed(&msg.mnemonic, &msg.passphrase, &mut seed);
-
-            // TODO: also store the mnemonic to be able to export it in the
-            // BIP39MnemonicSentence message
-            if let Err(e) = self.db.write(&key, msg.vault_id, msg.record_id, &seed, msg.hint) {
-                return Err(anyhow::anyhow!(e))
-            };
-
-
-    Ok(ProcResult::BIP39Recover(ResultMessage::OK))
+    // TODO: also store the mnemonic to be able to export it in the
+    // BIP39MnemonicSentence message
+    match res {
+        Ok(_) => Ok(ProcResult::BIP39Recover(ResultMessage::OK)),
+        Err(e) => Err(anyhow::anyhow!(e)),
+    }
 });
 
 impl_handler!(procedures::Ed25519PublicKey, Result<crate::ProcResult, anyhow::Error>, (self, msg, _ctx), {
-    use std::{rc::Rc, cell::Cell};
-    if let Some(key) = self.keystore.get_key(msg.vault_id) {
-        self.keystore.insert_key(msg.vault_id, key.clone());
-        let result = Rc::new(Cell::default());
+    let key = self
+        .keystore
+        .take_key(msg.vault_id)
+        .ok_or(anyhow::anyhow!(VaultError::NotExisting))?;
 
-        match self.db
-            .get_guard(&key, msg.vault_id, msg.record_id, |data| {
-                let raw = data.borrow();
-                let mut raw = (*raw).to_vec();
+    let result = Rc::new(Cell::default());
 
-                if raw.len() < 32 {
+    let res = self.db.get_guard(&key, msg.vault_id, msg.record_id, |data| {
+        let raw = data.borrow();
+        let mut raw = (*raw).to_vec();
 
-                    return Err(engine::Error::CryptoError(
-                        crypto::error::Error::BufferSize{has : raw.len(), needs : 32, name: "data buffer" }));
+        if raw.len() < 32 {
+            return Err(engine::Error::CryptoError(crypto::error::Error::BufferSize {
+                has: raw.len(),
+                needs: 32,
+                name: "data buffer",
+            }));
+        }
+        raw.truncate(32);
+        let mut bs = [0; 32];
+        bs.copy_from_slice(&raw);
 
-                }
-                raw.truncate(32);
-                let mut bs = [0; 32];
-                bs.copy_from_slice(&raw);
+        let sk = ed25519::SecretKey::from_bytes(bs);
+        let pk = sk.public_key();
 
-                let sk = ed25519::SecretKey::from_bytes(bs);
-                let pk = sk.public_key();
+        // send to client this result
+        result.set(pk.to_bytes());
 
-                // send to client this result
-                result.set(pk.to_bytes());
+        Ok(())
+    });
+    self.keystore.insert_key(msg.vault_id, key);
 
-                Ok(())
-            }) {
-                Ok(_) => {},
-                Err(e) => {return Err(anyhow::anyhow!(e));}
-            }
-
-            let result = result.get();
-
-            Ok(ProcResult::Ed25519PublicKey(ResultMessage::Ok(result)))
-
-    } else {
-        Err(anyhow::anyhow!(VaultError::AccessError))
+    match res {
+        Ok(_) => Ok(ProcResult::Ed25519PublicKey(ResultMessage::Ok(result.get()))),
+        Err(e) => Err(anyhow::anyhow!(e)),
     }
-
 });
 
 impl_handler!(procedures::Ed25519Sign, Result <crate::ProcResult, anyhow::Error>, (self, msg, _ctx), {
-    if let Some(pkey) = self.keystore.get_key(msg.vault_id) {
-            self.keystore.insert_key(msg.vault_id, pkey.clone());
+    let pkey = self
+        .keystore
+        .take_key(msg.vault_id)
+        .ok_or(anyhow::anyhow!(VaultError::NotExisting))?;
 
-            let result = Rc::new(Cell::new([0u8; 64]));
+    let result = Rc::new(Cell::new([0u8; 64]));
 
-            match self.db
-                .get_guard(&pkey, msg.vault_id, msg.record_id, |data| {
-                    let raw = data.borrow();
-                    let mut raw = (*raw).to_vec();
+    let res = self.db.get_guard(&pkey, msg.vault_id, msg.record_id, |data| {
+        let raw = data.borrow();
+        let mut raw = (*raw).to_vec();
 
-                    if raw.len() < 32 {
-
-                        return Err(engine::Error::CryptoError(
-                            crypto::Error::BufferSize {has : raw.len(),needs : 32, name: "data buffer" }));
-                    }
-                    raw.truncate(32);
-                    let mut bs = [0; 32];
-                    bs.copy_from_slice(&raw);
-
-                    let sk =  ed25519::SecretKey::from_bytes(bs);
-
-                    let sig = sk.sign(&msg.msg);
-                    result.set(sig.to_bytes());
-
-                    Ok(())
-                }) {
-                    Ok(_) => {},
-                    Err(e) => {return Err(anyhow::anyhow!(e))}
-                };
-
-                let result = result.get();
-                Ok(ProcResult::Ed25519Sign(ResultMessage::Ok(result)))
-        } else {
-            Err(anyhow::anyhow!(VaultError::AccessError))
+        if raw.len() < 32 {
+            return Err(engine::Error::CryptoError(crypto::Error::BufferSize {
+                has: raw.len(),
+                needs: 32,
+                name: "data buffer",
+            }));
         }
+        raw.truncate(32);
+        let mut bs = [0; 32];
+        bs.copy_from_slice(&raw);
+
+        let sk = ed25519::SecretKey::from_bytes(bs);
+
+        let sig = sk.sign(&msg.msg);
+        result.set(sig.to_bytes());
+
+        Ok(())
+    });
+
+    self.keystore.insert_key(msg.vault_id, pkey);
+
+    match res {
+        Ok(_) => Ok(ProcResult::Ed25519Sign(ResultMessage::Ok(result.get()))),
+        Err(e) => Err(anyhow::anyhow!(e)),
+    }
 
 });

--- a/client/src/interface.rs
+++ b/client/src/interface.rs
@@ -153,58 +153,55 @@ impl Stronghold {
         let vault_path = &location.vault_path();
         let vault_path = vault_path.to_vec();
 
-        if let Ok(result) = self.target.send(CheckVault { vault_path }).await {
-            match result {
-                Ok(_) => {
-                    // exists
-                    return match self
-                        .target
-                        .send(WriteToVault {
-                            location,
-                            payload,
-                            hint,
-                        })
-                        .await
-                    {
-                        Ok(result) => match result {
-                            Ok(_) => StatusMessage::OK,
-                            Err(e) => StatusMessage::Error(e.to_string()),
-                        },
+        if let Ok(vault_exists) = self.target.send(CheckVault { vault_path }).await {
+            if vault_exists {
+                // exists
+                return match self
+                    .target
+                    .send(WriteToVault {
+                        location,
+                        payload,
+                        hint,
+                    })
+                    .await
+                {
+                    Ok(result) => match result {
+                        Ok(_) => StatusMessage::OK,
                         Err(e) => StatusMessage::Error(e.to_string()),
-                    };
-                }
-                Err(_) => {
-                    // does not exist
-                    match self
-                        .target
-                        .send(CreateVault {
-                            location: location.clone(),
-                        })
-                        .await
-                    {
-                        Ok(_) => {
-                            // write to vault
-                            if let Ok(result) = self
-                                .target
-                                .send(WriteToVault {
-                                    location,
-                                    payload,
-                                    hint,
-                                })
-                                .await
-                            {
-                                if result.is_ok() {
-                                    return StatusMessage::OK;
-                                } else {
-                                    return StatusMessage::Error(result.err().unwrap().to_string());
-                                }
+                    },
+                    Err(e) => StatusMessage::Error(e.to_string()),
+                };
+            } else {
+                // does not exist
+                match self
+                    .target
+                    .send(CreateVault {
+                        location: location.clone(),
+                    })
+                    .await
+                {
+                    Ok(_) => {
+                        // write to vault
+                        if let Ok(result) = self
+                            .target
+                            .send(WriteToVault {
+                                location,
+                                payload,
+                                hint,
+                            })
+                            .await
+                        {
+                            if result.is_ok() {
+                                return StatusMessage::OK;
                             } else {
-                                return StatusMessage::Error("Error Writing data".into());
+                                return StatusMessage::Error(result.err().unwrap().to_string());
                             }
+                        } else {
+                            return StatusMessage::Error("Error Writing data".into());
                         }
-                        Err(_e) => {
-                            return StatusMessage::Error("Cannot create new vault".into());
-                        }
+                    }
+                    Err(_e) => {
+                        return StatusMessage::Error("Cannot create new vault".into());
                     }
                 }
             }
@@ -358,13 +355,7 @@ impl Stronghold {
         let vault_path = &location.vault_path();
         let vault_path = vault_path.to_vec();
 
-        match self.target.send(CheckVault { vault_path }).await {
-            Ok(success) => match success {
-                Ok(_) => true,
-                Err(_e) => false,
-            },
-            Err(_e) => false,
-        }
+        self.target.send(CheckVault { vault_path }).await.unwrap_or(false)
     }
 
     /// Reads data from a given snapshot file.  Can only read the data for a single `client_path` at a time. If the new
@@ -746,7 +737,7 @@ impl Stronghold {
         let vault_exists = unwrap_result_msg!(actor.send(send_request).await);
 
         // no vault so create new one before writing.
-        if vault_exists.is_err() {
+        if !vault_exists {
             let send_request = network_msg::SendRequest {
                 peer,
                 request: CreateVault {

--- a/client/src/interface.rs
+++ b/client/src/interface.rs
@@ -20,7 +20,7 @@ use crate::{
         snapshot_messages::{FillSnapshot, ReadFromSnapshot, WriteSnapshot},
         GetAllClients, GetClient, GetSnapshot, InsertClient, Registry, RemoveClient, SecureClient,
     },
-    line_error, unwrap_or_err, unwrap_result_msg,
+    line_error,
     utils::{LoadFromPath, StatusMessage, StrongholdFlags, VaultFlags},
     Location,
 };
@@ -33,7 +33,7 @@ use crate::{
         messages::{ShRequest, SwarmInfo},
         NetworkActor, NetworkConfig,
     },
-    ResultMessage,
+    unwrap_or_err, unwrap_result_msg, ResultMessage,
 };
 #[cfg(feature = "p2p")]
 use p2p::{

--- a/client/src/state/key_store.rs
+++ b/client/src/state/key_store.rs
@@ -1,24 +1,24 @@
 // Copyright 2020-2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use engine::vault::{BoxProvider, Key, VaultId};
+use engine::vault::{Key, VaultId};
 
 use std::collections::HashMap;
 
-use crate::line_error;
+use crate::{line_error, Provider};
 
-pub struct KeyStore<P: BoxProvider + Clone + Send + Sync + 'static> {
-    store: HashMap<VaultId, Key<P>>,
+pub struct KeyStore {
+    store: HashMap<VaultId, Key<Provider>>,
 }
 
-impl<P: BoxProvider + Clone + Send + Sync + 'static> KeyStore<P> {
+impl KeyStore {
     /// Creates a new [`KeyStore`].
     pub fn new() -> Self {
         Self { store: HashMap::new() }
     }
 
-    /// Gets the key from the [`KeyStore`] and removes it.  Returns an [`Option<Key<P>>`]
-    pub fn get_key(&mut self, id: VaultId) -> Option<Key<P>> {
+    /// Gets the key from the [`KeyStore`] and removes it.  Returns an [`Option<Key<Provider>>`]
+    pub fn take_key(&mut self, id: VaultId) -> Option<Key<Provider>> {
         self.store.remove(&id)
     }
 
@@ -28,30 +28,28 @@ impl<P: BoxProvider + Clone + Send + Sync + 'static> KeyStore<P> {
     }
 
     /// Returns an existing key for the `id` or creates one.
-    pub fn create_key(&mut self, id: VaultId) -> Key<P> {
-        let key = self
-            .store
+    pub fn create_key(&mut self, id: VaultId) -> &Key<Provider> {
+        self.store
             .entry(id)
-            .or_insert_with(|| Key::<P>::random().expect(line_error!()));
-
-        key.clone()
+            .or_insert_with(|| Key::random().expect(line_error!()))
     }
 
     /// Inserts a key into the [`KeyStore`] by [`VaultId`].  If the [`VaultId`] already exists, it just returns the
-    /// existing [`&Key<P>`]
-    pub fn insert_key(&mut self, id: VaultId, key: Key<P>) -> &Key<P> {
+    /// existing [`&Key<Provider>`]
+    pub fn insert_key(&mut self, id: VaultId, key: Key<Provider>) -> &Key<Provider> {
         self.store.entry(id).or_insert(key)
     }
 
-    /// Rebuilds the [`KeyStore`] while throwing out any existing [`VaultId`], [`Key<P>`] pairs.  Accepts a
-    /// [`Vec<Key<P>>`] and returns then a [`Vec<VaultId>`]; primarily used to repopulate the state from a snapshot.
-    pub fn rebuild_keystore(&mut self, keys: HashMap<VaultId, Key<P>>) {
+    /// Rebuilds the [`KeyStore`] while throwing out any existing [`VaultId`], [`Key<Provider>`] pairs.  Accepts a
+    /// [`Vec<Key<Provider>>`] and returns then a [`Vec<VaultId>`]; primarily used to repopulate the state from a
+    /// snapshot.
+    pub fn rebuild_keystore(&mut self, keys: HashMap<VaultId, Key<Provider>>) {
         self.store = keys;
     }
 
     /// Gets the state data in a hashmap format for the snapshot.
-    pub fn get_data(&mut self) -> HashMap<VaultId, Key<P>> {
-        let mut key_store: HashMap<VaultId, Key<P>> = HashMap::new();
+    pub fn get_data(&mut self) -> HashMap<VaultId, Key<Provider>> {
+        let mut key_store: HashMap<VaultId, Key<Provider>> = HashMap::new();
 
         self.store.iter().for_each(|(v, k)| {
             key_store.insert(*v, k.clone());

--- a/client/src/state/key_store.rs
+++ b/client/src/state/key_store.rs
@@ -5,7 +5,7 @@ use engine::vault::{Key, VaultId};
 
 use std::collections::HashMap;
 
-use crate::{line_error, Provider};
+use crate::{actors::VaultError, line_error, Provider};
 
 pub struct KeyStore {
     store: HashMap<VaultId, Key<Provider>>,
@@ -18,8 +18,11 @@ impl KeyStore {
     }
 
     /// Gets the key from the [`KeyStore`] and removes it.  Returns an [`Option<Key<Provider>>`]
-    pub fn take_key(&mut self, id: VaultId) -> Option<Key<Provider>> {
-        self.store.remove(&id)
+    pub fn take_key(&mut self, id: VaultId) -> Result<Key<Provider>, anyhow::Error> {
+        match self.store.remove(&id) {
+            Some(key) => Ok(key),
+            None => Err(anyhow::anyhow!(VaultError::NotExisting)),
+        }
     }
 
     /// Checks to see if the vault exists.

--- a/client/src/state/secure.rs
+++ b/client/src/state/secure.rs
@@ -18,7 +18,7 @@ pub type Store = Cache<Vec<u8>, Vec<u8>>;
 
 pub struct SecureClient {
     // A keystore
-    pub(crate) keystore: KeyStore<internals::Provider>,
+    pub(crate) keystore: KeyStore,
     // A view on the vault entries
     pub(crate) db: DbView<internals::Provider>,
     // The id of this client

--- a/client/src/state/secure.rs
+++ b/client/src/state/secure.rs
@@ -11,7 +11,7 @@ use engine::{
     store::Cache,
     vault::{ClientId, DbView, RecordId, VaultId},
 };
-use std::{collections::HashSet, time::Duration};
+use std::time::Duration;
 
 /// Cache type definition
 pub type Store = Cache<Vec<u8>, Vec<u8>>;
@@ -23,8 +23,6 @@ pub struct SecureClient {
     pub(crate) db: DbView<internals::Provider>,
     // The id of this client
     pub client_id: ClientId,
-    // Contains the vault ids and the record ids with their associated indexes.
-    pub vaults: HashSet<VaultId>,
     // Contains the Record Ids for the most recent Record in each vault.
     pub store: Store,
 }
@@ -32,13 +30,10 @@ pub struct SecureClient {
 impl SecureClient {
     /// Creates a new Client given a `ClientID` and `ChannelRef<SHResults>`
     pub fn new(client_id: ClientId) -> Self {
-        let vaults = HashSet::new();
-
         let store = Cache::new();
 
         Self {
             client_id,
-            vaults,
             store,
             keystore: KeyStore::new(),
             db: DbView::new(),
@@ -72,22 +67,9 @@ impl SecureClient {
         self.client_id = client_id
     }
 
-    /// Adds a new vault to the client.  If the [`VaultId`] already exists, will just use that existing Vault.
-    pub fn add_new_vault(&mut self, vid: VaultId) {
-        self.vaults.insert(vid);
-    }
-
-    /// Empty the Client Cache.
-    pub fn clear_cache(&mut self) -> Option<()> {
-        self.vaults = HashSet::default();
-
-        Some(())
-    }
-
     /// Rebuilds the cache using the parameters.
-    pub fn rebuild_cache(&mut self, id: ClientId, vaults: HashSet<VaultId>, store: Store) {
+    pub fn rebuild_cache(&mut self, id: ClientId, store: Store) {
         self.client_id = id;
-        self.vaults = vaults;
         self.store = store;
     }
 
@@ -134,11 +116,6 @@ impl SecureClient {
         self.client_id.into()
     }
 
-    /// Checks to see if the vault exists in the client.
-    pub fn vault_exist(&self, vid: VaultId) -> Option<&VaultId> {
-        self.vaults.get(&vid)
-    }
-
     /// Gets the current index of a record if its a counter.
     pub fn get_index_from_record_id<P: AsRef<Vec<u8>>>(&self, vault_path: P, record_id: RecordId) -> usize {
         let mut ctr = 0;
@@ -163,34 +140,17 @@ mod tests {
     use crate::Provider;
 
     #[test]
-    fn test_add() {
-        let vid = VaultId::random::<Provider>().expect(line_error!());
-
-        let mut cache: SecureClient = SecureClient::new(ClientId::random::<Provider>().expect(line_error!()));
-
-        cache.add_new_vault(vid);
-
-        assert_eq!(cache.vaults.get(&vid), Some(&vid));
-    }
-
-    #[test]
     fn test_rid_internals() {
         let clientid = ClientId::random::<Provider>().expect(line_error!());
 
-        let vid = VaultId::random::<Provider>().expect(line_error!());
-        let vid2 = VaultId::random::<Provider>().expect(line_error!());
         let vault_path = b"some_vault".to_vec();
 
-        let mut client: SecureClient = SecureClient::new(clientid);
+        let client: SecureClient = SecureClient::new(clientid);
         let mut ctr = 0;
         let mut ctr2 = 0;
 
         let _rid = client.derive_record_id(vault_path.clone(), ctr);
         let _rid2 = client.derive_record_id(vault_path.clone(), ctr2);
-
-        client.add_new_vault(vid);
-
-        client.add_new_vault(vid2);
 
         ctr += 1;
         ctr2 += 1;
@@ -216,13 +176,10 @@ mod tests {
         let vidlochead = Location::counter::<_, usize>("some_vault", 0);
         let vidlochead2 = Location::counter::<_, usize>("some_vault 2", 0);
 
-        let mut client: SecureClient = SecureClient::new(clientid);
+        let client: SecureClient = SecureClient::new(clientid);
 
-        let (vid, rid) = client.resolve_location(vidlochead.clone());
-        let (vid2, rid2) = client.resolve_location(vidlochead2.clone());
-
-        client.add_new_vault(vid);
-        client.add_new_vault(vid2);
+        let (_, rid) = client.resolve_location(vidlochead.clone());
+        let (_, rid2) = client.resolve_location(vidlochead2.clone());
 
         let (_, rid_head) = client.resolve_location(vidlochead);
         let (_, rid_head_2) = client.resolve_location(vidlochead2);


### PR DESCRIPTION
# Description of change

Adjust the handling of `Key`s in the `SecureClient` and remove obsolete code.

https://github.com/iotaledger/stronghold.rs/commit/da621b74944aedfa652194d4b51a8ea757a68d98:
- Avoid cloning of `Key`s by changing the key-handling in the `SecureClient` to follow the flow:
  _Take key from keystore -> Use key -> Insert key back into keystore_
- Rename `get_key` to `take_key`
- directly use concrete type `internals::Provider` in the `KeyStore` 


https://github.com/iotaledger/stronghold.rs/commit/e2e2fb93f126096ab2b38f7ce8176a64a87e6744:

- Remove `vaults: HashSet<VaultId>` property from the `SecureClient`. 
Before #248, this property was necessary in the `Client` because it did no have access to the `KeyStore`. Since the Keystore is now part of the `SecureClient`, the info about existing vaults can be gathered from the keystore, which makes the VaultId-Hashset obsolete.
- `CheckVault` is now checking `Keystore::vault_exists` and returns a `bool` instead of a `Result`.

## Type of change

- [X] Bug fix (a non-breaking change which fixes an issue)
- [X] Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Tested via existing tests.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
