### PR TITLE
Use Registry for all actors

### DIFF
--- a/.changes/client-registry-usage.md
+++ b/.changes/client-registry-usage.md
@@ -1,0 +1,8 @@
+---
+"iota-stronghold": patch
+---
+
+[[PR 270](https://github.com/iotaledger/stronghold.rs/pull/270)]
+- Move management of network-Actor and client-target into Registry
+- Make client-target optional, in case that it is killed before switching to another target
+- Make registry a normal actor instead of a system-service

--- a/client/src/actors.rs
+++ b/client/src/actors.rs
@@ -13,7 +13,7 @@ pub use self::registry::messages::{GetNetwork, InsertNetwork, StopNetwork};
 pub use self::secure::testing as secure_testing;
 pub use self::{
     registry::{
-        messages::{GetAllClients, GetClient, GetSnapshot, HasClient, RemoveClient, SpawnClient, SwitchClient},
+        messages::{GetAllClients, GetClient, GetSnapshot, GetTarget, RemoveClient, SpawnClient, SwitchTarget},
         Registry, RegistryError,
     },
     secure::{

--- a/client/src/actors.rs
+++ b/client/src/actors.rs
@@ -8,7 +8,7 @@ mod secure;
 mod snapshot;
 
 #[cfg(feature = "p2p")]
-pub use self::registry::messages::{GetNetwork, InsertNetwork, StopNetwork};
+pub use self::registry::p2p_messages::{GetNetwork, InsertNetwork, StopNetwork};
 #[cfg(test)]
 pub use self::secure::testing as secure_testing;
 pub use self::{

--- a/client/src/actors.rs
+++ b/client/src/actors.rs
@@ -7,11 +7,13 @@ mod registry;
 mod secure;
 mod snapshot;
 
+#[cfg(feature = "p2p")]
+pub use self::registry::messages::{GetNetwork, InsertNetwork, StopNetwork};
 #[cfg(test)]
 pub use self::secure::testing as secure_testing;
 pub use self::{
     registry::{
-        messages::{GetAllClients, GetClient, GetSnapshot, HasClient, InsertClient, RemoveClient},
+        messages::{GetAllClients, GetClient, GetSnapshot, HasClient, RemoveClient, SpawnClient, SwitchClient},
         Registry, RegistryError,
     },
     secure::{

--- a/client/src/actors/p2p.rs
+++ b/client/src/actors/p2p.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::actors::SecureClient;
+use crate::actors::{GetClient, Registry};
 use actix::prelude::*;
 use futures::{channel::mpsc, FutureExt, TryFutureExt};
 pub use messages::SwarmInfo;
@@ -97,12 +97,12 @@ macro_rules! sh_result_mapping {
 pub struct NetworkActor {
     network: StrongholdP2p<ShRequest, ShResult>,
     inbound_request_rx: Option<mpsc::Receiver<ReceiveRequest<ShRequest, ShResult>>>,
-    client: Addr<SecureClient>,
+    registry: Addr<Registry>,
 }
 
 impl NetworkActor {
     pub async fn new(
-        client: Addr<SecureClient>,
+        registry: Addr<Registry>,
         firewall_rule: Rule<ShRequest>,
         network_config: NetworkConfig,
     ) -> Result<Self, io::Error> {
@@ -127,7 +127,7 @@ impl NetworkActor {
         let actor = Self {
             network,
             inbound_request_rx: Some(inbound_request_rx),
-            client,
+            registry,
         };
         Ok(actor)
     }
@@ -148,20 +148,14 @@ impl StreamHandler<ReceiveRequest<ShRequest, ShResult>> for NetworkActor {
             request, response_tx, ..
         } = item;
         sh_request_dispatch!(request => |inner| {
-            let fut = self.client
-                .send(inner)
+            let fut = self.registry
+                .send(GetClient)
+                .and_then(|client| client.send(inner))
                 .map_ok(|response| response_tx.send(response.into()))
                 .map(|_| ())
                 .into_actor(self);
             ctx.wait(fut);
         });
-    }
-}
-impl Handler<SwitchClient> for NetworkActor {
-    type Result = ();
-
-    fn handle(&mut self, msg: SwitchClient, _: &mut Self::Context) -> Self::Result {
-        self.client = msg.client;
     }
 }
 
@@ -331,12 +325,6 @@ pub mod messages {
         },
         secure_procedures::CallProcedure,
     };
-
-    #[derive(Message)]
-    #[rtype(result = "()")]
-    pub struct SwitchClient {
-        pub client: Addr<SecureClient>,
-    }
 
     #[derive(Message)]
     #[rtype(result = "Result<Rq::Result, OutboundFailure>")]

--- a/client/src/actors/registry.rs
+++ b/client/src/actors/registry.rs
@@ -14,7 +14,9 @@ use engine::vault::ClientId;
 use std::collections::HashMap;
 use thiserror::Error as ErrorType;
 
-use crate::{actors::SecureClient, state::snapshot::Snapshot};
+#[cfg(feature = "p2p")]
+use super::p2p::NetworkActor;
+use crate::{actors::SecureClient, internals, state::snapshot::Snapshot};
 
 #[derive(Debug, ErrorType)]
 pub enum RegistryError {
@@ -23,17 +25,27 @@ pub enum RegistryError {
 
     #[error("Client Already Present By Id ({0})")]
     ClientAlreadyPresentById(String),
+
+    #[error("Network actor was already spawned")]
+    NetworkAlreadySpawned,
 }
 
 pub mod messages {
-
     use super::*;
 
-    pub struct InsertClient {
+    pub struct SpawnClient {
         pub id: ClientId,
     }
 
-    impl Message for InsertClient {
+    impl Message for SpawnClient {
+        type Result = Result<Addr<SecureClient>, RegistryError>;
+    }
+
+    pub struct SwitchClient {
+        pub id: ClientId,
+    }
+
+    impl Message for SwitchClient {
         type Result = Result<Addr<SecureClient>, RegistryError>;
     }
 
@@ -45,12 +57,10 @@ pub mod messages {
         type Result = Result<(), RegistryError>;
     }
 
-    pub struct GetClient {
-        pub id: ClientId,
-    }
+    pub struct GetClient;
 
     impl Message for GetClient {
-        type Result = Option<Addr<SecureClient>>;
+        type Result = Addr<SecureClient>;
     }
 
     pub struct HasClient {
@@ -72,14 +82,54 @@ pub mod messages {
     impl Message for GetAllClients {
         type Result = Vec<(ClientId, Addr<SecureClient>)>;
     }
+
+    #[cfg(feature = "p2p")]
+    pub struct InsertNetwork {
+        pub addr: Addr<NetworkActor>,
+    }
+
+    #[cfg(feature = "p2p")]
+    impl Message for InsertNetwork {
+        type Result = ();
+    }
+
+    #[cfg(feature = "p2p")]
+    pub struct GetNetwork;
+
+    #[cfg(feature = "p2p")]
+    impl Message for GetNetwork {
+        type Result = Option<Addr<NetworkActor>>;
+    }
+
+    #[cfg(feature = "p2p")]
+    pub struct StopNetwork;
+
+    #[cfg(feature = "p2p")]
+    impl Message for StopNetwork {
+        type Result = bool;
+    }
 }
 
 /// Registry [`Actor`], that owns [`Client`] actors, and manages them. The registry
 /// can be modified
-#[derive(Default)]
 pub struct Registry {
     clients: HashMap<ClientId, Addr<SecureClient>>,
+    current_client: ClientId,
     snapshot: Option<Addr<Snapshot>>,
+    #[cfg(feature = "p2p")]
+    network: Option<Addr<NetworkActor>>,
+}
+
+impl Default for Registry {
+    fn default() -> Self {
+        Registry {
+            clients: HashMap::new(),
+            current_client: ClientId::random::<internals::Provider>().unwrap(),
+            snapshot: None,
+            #[cfg(feature = "p2p")]
+            network: None,
+        }
+    }
 }
 
 impl Supervised for Registry {}
@@ -100,28 +150,41 @@ impl Handler<messages::HasClient> for Registry {
     }
 }
 
-impl Handler<messages::InsertClient> for Registry {
+impl Handler<messages::SpawnClient> for Registry {
     type Result = Result<Addr<SecureClient>, RegistryError>;
 
-    fn handle(&mut self, msg: messages::InsertClient, _ctx: &mut Self::Context) -> Self::Result {
+    fn handle(&mut self, msg: messages::SpawnClient, ctx: &mut Self::Context) -> Self::Result {
         if let Some(_) = self.clients.get(&msg.id) {
             return Err(RegistryError::ClientAlreadyPresentById(msg.id.into()));
         }
-
         let addr = SecureClient::new(msg.id).start();
-        self.clients.insert(msg.id, addr.clone());
-        Ok(addr)
+        self.clients.insert(msg.id, addr);
+
+        <Self as Handler<messages::SwitchClient>>::handle(self, messages::SwitchClient { id: msg.id }, ctx)
     }
 }
 
 impl Handler<messages::GetClient> for Registry {
-    type Result = Option<Addr<SecureClient>>;
+    type Result = Addr<SecureClient>;
 
-    fn handle(&mut self, msg: messages::GetClient, _ctx: &mut Self::Context) -> Self::Result {
-        if let Some(client) = self.clients.get(&msg.id) {
-            return Some(client.clone());
-        }
-        None
+    fn handle(&mut self, _msg: messages::GetClient, _ctx: &mut Self::Context) -> Self::Result {
+        self.clients
+            .get(&self.current_client)
+            .expect("Current Client is always present")
+            .clone()
+    }
+}
+
+impl Handler<messages::SwitchClient> for Registry {
+    type Result = Result<Addr<SecureClient>, RegistryError>;
+
+    fn handle(&mut self, msg: messages::SwitchClient, _ctx: &mut Self::Context) -> Self::Result {
+        let addr = self
+            .clients
+            .get(&msg.id)
+            .ok_or_else(|| RegistryError::NoClientPresentById(msg.id.into()))?;
+        self.current_client = msg.id;
+        Ok(addr.clone())
     }
 }
 
@@ -154,5 +217,33 @@ impl Handler<messages::GetAllClients> for Registry {
             result.push((*id, addr.clone()));
         }
         result
+    }
+}
+
+#[cfg(feature = "p2p")]
+impl Handler<messages::InsertNetwork> for Registry {
+    type Result = ();
+    fn handle(&mut self, msg: messages::InsertNetwork, _ctx: &mut Self::Context) -> Self::Result {
+        self.network = Some(msg.addr);
+    }
+}
+
+#[cfg(feature = "p2p")]
+impl Handler<messages::GetNetwork> for Registry {
+    type Result = Option<Addr<NetworkActor>>;
+
+    fn handle(&mut self, _: messages::GetNetwork, _: &mut Self::Context) -> Self::Result {
+        self.network.clone()
+    }
+}
+
+#[cfg(feature = "p2p")]
+impl Handler<messages::StopNetwork> for Registry {
+    type Result = bool;
+
+    fn handle(&mut self, _: messages::StopNetwork, _: &mut Self::Context) -> Self::Result {
+        // Dropping the only address of the network actor will stop the actor.
+        // Upon stopping the actor, its `StrongholdP2p` instance will be dropped, which results in a graceful shutdown.
+        self.network.take().is_some()
     }
 }

--- a/client/src/actors/registry.rs
+++ b/client/src/actors/registry.rs
@@ -82,29 +82,29 @@ pub mod messages {
     impl Message for GetAllClients {
         type Result = Vec<(ClientId, Addr<SecureClient>)>;
     }
+}
 
-    #[cfg(feature = "p2p")]
+#[cfg(feature = "p2p")]
+pub mod p2p_messages {
+
+    use super::*;
+
     pub struct InsertNetwork {
         pub addr: Addr<NetworkActor>,
     }
 
-    #[cfg(feature = "p2p")]
     impl Message for InsertNetwork {
         type Result = ();
     }
 
-    #[cfg(feature = "p2p")]
     pub struct GetNetwork;
 
-    #[cfg(feature = "p2p")]
     impl Message for GetNetwork {
         type Result = Option<Addr<NetworkActor>>;
     }
 
-    #[cfg(feature = "p2p")]
     pub struct StopNetwork;
 
-    #[cfg(feature = "p2p")]
     impl Message for StopNetwork {
         type Result = bool;
     }
@@ -203,27 +203,27 @@ impl Handler<messages::GetAllClients> for Registry {
 }
 
 #[cfg(feature = "p2p")]
-impl Handler<messages::InsertNetwork> for Registry {
+impl Handler<p2p_messages::InsertNetwork> for Registry {
     type Result = ();
-    fn handle(&mut self, msg: messages::InsertNetwork, _ctx: &mut Self::Context) -> Self::Result {
+    fn handle(&mut self, msg: p2p_messages::InsertNetwork, _ctx: &mut Self::Context) -> Self::Result {
         self.network = Some(msg.addr);
     }
 }
 
 #[cfg(feature = "p2p")]
-impl Handler<messages::GetNetwork> for Registry {
+impl Handler<p2p_messages::GetNetwork> for Registry {
     type Result = Option<Addr<NetworkActor>>;
 
-    fn handle(&mut self, _: messages::GetNetwork, _: &mut Self::Context) -> Self::Result {
+    fn handle(&mut self, _: p2p_messages::GetNetwork, _: &mut Self::Context) -> Self::Result {
         self.network.clone()
     }
 }
 
 #[cfg(feature = "p2p")]
-impl Handler<messages::StopNetwork> for Registry {
+impl Handler<p2p_messages::StopNetwork> for Registry {
     type Result = bool;
 
-    fn handle(&mut self, _: messages::StopNetwork, _: &mut Self::Context) -> Self::Result {
+    fn handle(&mut self, _: p2p_messages::StopNetwork, _: &mut Self::Context) -> Self::Result {
         // Dropping the only address of the network actor will stop the actor.
         // Upon stopping the actor, its `StrongholdP2p` instance will be dropped, which results in a graceful shutdown.
         self.network.take().is_some()

--- a/client/src/actors/registry.rs
+++ b/client/src/actors/registry.rs
@@ -9,7 +9,7 @@
 //! The registry can also be queried for the snapshot actor.
 
 #![allow(clippy::redundant_pattern_matching)]
-use actix::{Actor, Addr, Context, Handler, Message, Supervised, SystemService};
+use actix::{Actor, Addr, Context, Handler, Message, Supervised};
 use engine::vault::ClientId;
 use std::collections::HashMap;
 use thiserror::Error as ErrorType;
@@ -137,10 +137,6 @@ impl Supervised for Registry {}
 impl Actor for Registry {
     type Context = Context<Self>;
 }
-
-/// For synchronized access across multiple clients, the [`Registry`]
-/// will run as a service.
-impl SystemService for Registry {}
 
 impl Handler<messages::HasClient> for Registry {
     type Result = bool;

--- a/client/src/interface.rs
+++ b/client/src/interface.rs
@@ -64,7 +64,7 @@ impl Stronghold {
             .unwrap_or_else(|_| panic!("{}", crate::Error::IDError));
 
         // the registry will be run as a system service
-        let registry = Registry::from_registry();
+        let registry = Registry::default().start();
 
         // we need to block for the target client actor
         match registry.send(SpawnClient { id: client_id }).await? {

--- a/client/src/interface.rs
+++ b/client/src/interface.rs
@@ -73,10 +73,7 @@ impl Stronghold {
             Err(e) => return Err(anyhow::anyhow!(e)),
         };
 
-        let mut sh = Self { registry };
-        sh.switch_client(client_id).await;
-
-        Ok(sh)
+        Ok(Self { registry })
     }
 
     /// Spawns a new set of actors for the Stronghold system. Accepts the client_path: [`Vec<u8>`] and the options:

--- a/client/src/interface.rs
+++ b/client/src/interface.rs
@@ -76,8 +76,8 @@ impl Stronghold {
         Ok(Self { registry })
     }
 
-    /// Spawns a new set of actors for the Stronghold system. Accepts the client_path: [`Vec<u8>`] and the options:
-    /// `StrongholdFlags`
+    /// Spawn a new client for the Stronghold system and switch the actor target to it.
+    /// Accepts the client_path: [`Vec<u8>`] and the options: `StrongholdFlags`
     pub async fn spawn_stronghold_actor(
         &mut self,
         client_path: Vec<u8>,

--- a/client/src/tests/actor_tests.rs
+++ b/client/src/tests/actor_tests.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::actors::{GetClient, InsertClient, Registry, RemoveClient};
+use crate::actors::{GetClient, Registry, RemoveClient, SpawnClient};
 use actix::Actor;
 use engine::vault::ClientId;
 
@@ -13,7 +13,7 @@ async fn test_insert_client() {
         let format_str = format!("{}", d).repeat(24);
         let id_str = format_str.as_str().as_bytes();
         let n = registry
-            .send(InsertClient {
+            .send(SpawnClient {
                 id: ClientId::load(id_str).unwrap(),
             })
             .await;
@@ -30,19 +30,14 @@ async fn test_get_client() {
         let format_str = format!("{}", d).repeat(24);
         let id_str = format_str.as_str().as_bytes();
         assert!(registry
-            .send(InsertClient {
+            .send(SpawnClient {
                 id: ClientId::load(id_str).unwrap(),
             })
             .await
             .is_ok());
     }
 
-    assert!(registry
-        .send(GetClient {
-            id: ClientId::load("b".repeat(24).as_bytes()).unwrap(),
-        })
-        .await
-        .is_ok());
+    assert!(registry.send(GetClient).await.is_ok());
 }
 
 #[actix::test]
@@ -53,7 +48,7 @@ async fn test_remove_client() {
         let format_str = format!("{}", d).repeat(24);
         let id_str = format_str.as_str().as_bytes();
         assert!(registry
-            .send(InsertClient {
+            .send(SpawnClient {
                 id: ClientId::load(id_str).unwrap(),
             })
             .await

--- a/client/src/tests/actor_tests.rs
+++ b/client/src/tests/actor_tests.rs
@@ -37,7 +37,12 @@ async fn test_get_client() {
             .is_ok());
     }
 
-    assert!(registry.send(GetClient).await.is_ok());
+    assert!(registry
+        .send(GetClient {
+            id: ClientId::load("b".repeat(24).as_bytes()).unwrap(),
+        })
+        .await
+        .is_ok());
 }
 
 #[actix::test]

--- a/client/src/tests/interface_tests.rs
+++ b/client/src/tests/interface_tests.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{line_error, Location, RecordHint, Stronghold};
+use crate::{line_error, Location, RecordHint, StatusMessage, Stronghold};
 
 #[cfg(feature = "p2p")]
 use p2p::firewall::Rule;
@@ -10,7 +10,7 @@ use p2p::firewall::Rule;
 use crate::{
     actors::p2p::{messages::SwarmInfo, NetworkConfig},
     tests::fresh,
-    ProcResult, Procedure, ResultMessage, SLIP10DeriveInput, StatusMessage,
+    ProcResult, Procedure, ResultMessage, SLIP10DeriveInput,
 };
 
 #[actix::test]
@@ -156,10 +156,12 @@ async fn test_stronghold() {
 
     assert_eq!(std::str::from_utf8(&data), Ok(""));
 
-    stronghold.kill_stronghold(client_path, true).await;
+    stronghold.kill_stronghold(client_path.clone(), true).await;
 
-    // actor tree?
-    // stronghold.system.print_tree();
+    assert!(matches!(
+        stronghold.switch_actor_target(client_path).await,
+        StatusMessage::Error(_)
+    ))
 }
 
 #[actix::test]


### PR DESCRIPTION
# Description of change

Also maintain network actor and current client target in the registry.
Make current client-target optional, in case that it is killed before switching to another target.
Make registry a normal actor instead of a system-service.

**Note:** Proper erorr handling will be included in #269.

## Type of change

- [X] Bug fix (a non-breaking change which fixes an issue)
- [X] Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Tested via existing tests

## Change checklist

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] New and existing unit tests pass locally with my changes
