### PR TITLE
Patch libp2p dependency to v0.40.0-rc.2

### DIFF
--- a/.changes/patch-libp2pv0.40.0-rc2.md
+++ b/.changes/patch-libp2pv0.40.0-rc2.md
@@ -1,0 +1,6 @@
+---
+"stronghold-p2p": patch
+---
+
+[[PR 271](https://github.com/iotaledger/stronghold.rs/pull/271)]
+Patch libp2p version from v0.39 to v0.40.0-rc.2.

--- a/client/examples/cli/arguments.rs
+++ b/client/examples/cli/arguments.rs
@@ -1,9 +1,9 @@
 // Copyright 2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use clap::{Clap, Subcommand};
+use clap::Parser;
 
-#[derive(Clap, Debug)]
+#[derive(Parser, Debug)]
 #[clap(
     name = "Stronghold Example CLI",
     about = "Encrypts data into the Engine Vault.  Creates snapshots and can load from snapshots."
@@ -16,7 +16,7 @@ pub struct ExampleApp {
     pub actor_path: String,
 }
 
-#[derive(Debug, Subcommand)]
+#[derive(Debug, Parser)]
 pub enum Commands {
     #[clap(about = "Write data to the unencrypted cache store")]
     Write {

--- a/client/examples/cli/main.rs
+++ b/client/examples/cli/main.rs
@@ -4,7 +4,7 @@
 mod arguments;
 
 use arguments::*;
-use clap::Clap;
+use clap::Parser;
 use iota_stronghold::{home_dir, naive_kdf, Location, RecordHint, StatusMessage, Stronghold};
 use std::{
     error::Error,

--- a/client/examples/p2p/arguments.rs
+++ b/client/examples/p2p/arguments.rs
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /// CLI arguments module
-use clap::{Clap, Subcommand};
+use clap::Parser;
 
-#[derive(Clap, Debug)]
+#[derive(Parser, Debug)]
 #[clap(
     name = "Stronghold Example P2p-Network",
     about = "Example to show stronghold's p2p-network capabilities"
@@ -17,7 +17,7 @@ pub struct ExampleApp {
     pub actor_path: String,
 }
 
-#[derive(Debug, Subcommand)]
+#[derive(Debug, Parser)]
 pub enum Commands {
     #[cfg(feature = "p2p")]
     #[clap(alias = "peers", about = "Lists all peers.")]

--- a/client/examples/p2p/main.rs
+++ b/client/examples/p2p/main.rs
@@ -27,7 +27,7 @@
 mod arguments;
 use arguments::*;
 
-pub use clap::Clap;
+pub use clap::Parser;
 use iota_stronghold::p2p::{Multiaddr, NetworkConfig, SwarmInfo};
 pub use iota_stronghold::{ResultMessage, Stronghold};
 use p2p::firewall::Rule;

--- a/client/src/actors/p2p.rs
+++ b/client/src/actors/p2p.rs
@@ -468,7 +468,7 @@ pub mod messages {
     pub struct Shutdown;
 
     // Wrapper for Requests to a remote Secure Client
-    #[derive(Clone, Serialize, Deserialize)]
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub enum ShRequest {
         CheckVault(CheckVault),
         CheckRecord(CheckRecord),
@@ -499,7 +499,7 @@ pub mod messages {
     sh_request_from!(ClearCache);
     sh_request_from!(CallProcedure);
 
-    #[derive(Clone, Serialize, Deserialize)]
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub enum ShResult {
         Empty(()),
         Bool(bool),

--- a/engine/src/snapshot/compression/decoder.rs
+++ b/engine/src/snapshot/compression/decoder.rs
@@ -64,12 +64,14 @@ impl<'a> Lz4Decoder<'a> {
     fn read_int(&mut self) -> crate::Result<usize> {
         let mut size = 0;
 
-        while {
+        loop {
             let extra = self.take(1)?[0];
             size += extra as usize;
 
-            extra == 0xFF
-        } {}
+            if extra != 0xFF {
+                break;
+            }
+        }
 
         Ok(size)
     }

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -16,7 +16,7 @@ name = "p2p"
 
 [dependencies]
 futures = "0.3"
-libp2p = { version = "0.39", default-features = false, features = ["noise", "yamux"] }
+libp2p = { version = "0.40.0-rc.2", default-features = false, features = ["noise", "yamux"] }
 serde = { version = "1.0", default-features = false, features = [ "alloc", "derive" ] }
 serde_json = { version = "1.0", default-features = false, features = [ "alloc" ] }
 smallvec = "1.6.1"
@@ -33,4 +33,4 @@ tcp-transport = ["libp2p/tcp-tokio", "libp2p/dns-tokio", "libp2p/websocket"]
 [dev-dependencies]
 stronghold-utils = { path = "../utils", version = "0.3" }
 tokio = {version = "1.10", features = ["time", "macros"]}
-libp2p = { version = "0.39", default-features = false, features = ["tcp-tokio"] }
+libp2p = { version = "0.40.0-rc.2", default-features = false, features = ["tcp-tokio"] }

--- a/p2p/src/behaviour.rs
+++ b/p2p/src/behaviour.rs
@@ -357,7 +357,7 @@ where
         }
     }
 
-    fn new_self_handler(&mut self, peer: Option<PeerId>) -> ConnectionHandler<Rq, Rs> {
+    fn new_request_response_handler(&mut self, peer: Option<PeerId>) -> ConnectionHandler<Rq, Rs> {
         let protocol_support = match peer {
             Some(peer) => ProtocolSupport::from_rules(&self.firewall.get_effective_rules(&peer)),
             None => ProtocolSupport::Full,
@@ -374,7 +374,7 @@ where
     }
 
     fn new_handler_for_peer(&mut self, peer: Option<PeerId>) -> <Self as NetworkBehaviour>::ProtocolsHandler {
-        let handler = self.new_self_handler(peer);
+        let handler = self.new_request_response_handler(peer);
         let protocols_handler;
         #[cfg(all(feature = "mdns", feature = "relay"))]
         {
@@ -761,7 +761,7 @@ where
                 } => {
                     #[cfg(feature = "mdns")]
                     let handler = IntoProtocolsHandler::select(self.mdns.new_handler(), handler);
-                    let first = self.new_self_handler(Some(peer_id));
+                    let first = self.new_request_response_handler(Some(peer_id));
                     let handler = IntoProtocolsHandler::select(first, handler);
                     return Poll::Ready(NetworkBehaviourAction::DialPeer {
                         peer_id,

--- a/p2p/src/interface.rs
+++ b/p2p/src/interface.rs
@@ -455,7 +455,7 @@ where
         let (keypair, id) = match keys {
             InitKeypair::IdKeys(keypair) => {
                 let noise_keypair = NoiseKeypair::<X25519Spec>::new().into_authentic(&keypair).unwrap();
-                let id = keypair.public().into_peer_id();
+                let id = keypair.public().to_peer_id();
                 (noise_keypair, id)
             }
             InitKeypair::Authenticated { peer_id, noise_keypair } => (noise_keypair, peer_id),
@@ -533,8 +533,9 @@ where
         // Use the configured keypair or create a new one.
         let (noise_keypair, peer_id) = self.ident.unwrap_or_else(|| {
             let keypair = Keypair::generate_ed25519();
+            // Can never fail for `identity::Keypair::Ed25519` and `X25519Spec` protocol.
             let noise_keypair = NoiseKeypair::<X25519Spec>::new().into_authentic(&keypair).unwrap();
-            let peer_id = keypair.public().into_peer_id();
+            let peer_id = keypair.public().to_peer_id();
             (noise_keypair, peer_id)
         });
         #[cfg(feature = "relay")]

--- a/p2p/src/interface/types.rs
+++ b/p2p/src/interface/types.rs
@@ -25,8 +25,8 @@ use smallvec::SmallVec;
 use std::{convert::TryFrom, fmt, io, num::NonZeroU32};
 
 /// Trait for the generic request and response messages.
-pub trait RqRsMessage: Serialize + DeserializeOwned + Send + Sync + 'static {}
-impl<TRq: Serialize + DeserializeOwned + Send + Sync + 'static> RqRsMessage for TRq {}
+pub trait RqRsMessage: Serialize + DeserializeOwned + Send + Sync + fmt::Debug + 'static {}
+impl<TRq: Serialize + DeserializeOwned + Send + Sync + fmt::Debug + 'static> RqRsMessage for TRq {}
 
 /// Unique Id for each request.
 /// **Note**: This ID is only local and does not match the request's ID at the remote peer.
@@ -176,6 +176,7 @@ impl<Rq: RqRsMessage, Rs: RqRsMessage, THandleErr> TryFrom<SwarmEv<Rq, Rs, THand
                 peer_id,
                 endpoint,
                 num_established,
+                concurrent_dial_errors: _,
             } => Ok(NetworkEvent::ConnectionEstablished {
                 peer: peer_id,
                 num_established,

--- a/products/commandline/src/main.rs
+++ b/products/commandline/src/main.rs
@@ -128,7 +128,6 @@ fn snapshot_command(matches: &ArgMatches, stronghold: &mut iota_stronghold::Stro
 
                     if let StatusMessage::Error(error) = status {
                         println!("{:?}", error);
-                        return;
                     } else {
                         block_on(stronghold.write_all_to_snapshot(
                             &key.to_vec(),
@@ -176,8 +175,6 @@ fn list_command(matches: &ArgMatches, stronghold: &mut iota_stronghold::Strongho
                     println!("{:?}", list);
                 } else {
                     println!("Could not find a snapshot at the home path.  Try writing first. ");
-
-                    return;
                 }
             }
         }
@@ -213,8 +210,6 @@ fn read_from_store_command(matches: &ArgMatches, stronghold: &mut iota_stronghol
                     println!("Data: {:?}", std::str::from_utf8(&data).unwrap());
                 } else {
                     println!("Could not find a snapshot at the home path.  Try writing first. ");
-
-                    return;
                 }
             }
         }
@@ -252,8 +247,6 @@ fn revoke_command(matches: &ArgMatches, stronghold: &mut iota_stronghold::Strong
                     block_on(stronghold.write_all_to_snapshot(&key.to_vec(), Some("commandline".to_string()), None));
                 } else {
                     println!("Could not find a snapshot at the home path.  Try writing first. ");
-
-                    return;
                 }
             }
         }
@@ -298,8 +291,6 @@ fn garbage_collect_vault_command(
                     block_on(stronghold.write_all_to_snapshot(&key.to_vec(), Some("commandline".to_string()), None));
                 } else {
                     println!("Could not find a snapshot at the home path.  Try writing first. ");
-
-                    return;
                 }
             }
         }
@@ -337,8 +328,6 @@ fn purge_command(matches: &ArgMatches, stronghold: &mut iota_stronghold::Strongh
                     block_on(stronghold.write_all_to_snapshot(&key.to_vec(), Some("commandline".to_string()), None));
                 } else {
                     println!("Could not find a snapshot at the home path.  Try writing first. ");
-
-                    return;
                 }
             }
         }


### PR DESCRIPTION
# Description of change

Update to the newest version of libp2p [v40.0-rc2](https://github.com/libp2p/rust-libp2p/pull/2290).

**Note:** This PR additionally cherry-picks https://github.com/iotaledger/stronghold.rs/commit/b2233b8676ef9990eacef2bca60126f4469e2c95 and https://github.com/iotaledger/stronghold.rs/commit/b2bcb6f9223ded29c5d322f7c36e7ee0d02dab66 from PR #269, to allow the Github actions to pass. 
