### PR TITLE
P2p/configure features

### DIFF
--- a/.changes/p2p-feature-config.md
+++ b/.changes/p2p-feature-config.md
@@ -1,7 +1,11 @@
 ---
 "stronghold-p2p": patch
+"iota-stronghold": patch
 ---
 
 [[PR 276](https://github.com/iotaledger/stronghold.rs/pull/276)]
-Remove `relay` and `mdns` features.
-Enable / disable mdns and relay functionality on init via config flags in the `StrongholdP2pBuilder`.
+- Remove `relay` and `mdns` features.
+- In the `StrongholdP2p` Interface enable / disable mdns and relay functionality on init via config flags in the `StrongholdP2pBuilder`.
+  Per default, both are enabled.
+- In the `Stronghold` client interface enable / disable mdns and relay in the `NetworkConfig` when spawning a new p2p-network actor.
+  Per default, both are disabled.

--- a/.changes/p2p-feature-config.md
+++ b/.changes/p2p-feature-config.md
@@ -1,0 +1,7 @@
+---
+"stronghold-p2p": patch
+---
+
+[[PR 276](https://github.com/iotaledger/stronghold.rs/pull/276)]
+Remove `relay` and `mdns` features.
+Enable / disable mdns and relay functionality on init via config flags in the `StrongholdP2pBuilder`.

--- a/client/src/actors/p2p.rs
+++ b/client/src/actors/p2p.rs
@@ -211,7 +211,7 @@ impl_handler!(StopListeningAddr => (), |network, msg| {
     network.stop_listening_addr(msg.address).await
 });
 
-impl_handler!(StopListeningRelay => (), |network, msg| {
+impl_handler!(StopListeningRelay => bool, |network, msg| {
     network.stop_listening_relay(msg.relay).await
 });
 
@@ -256,10 +256,10 @@ impl_handler!(RemovePeerAddr => (), |network, msg| {
 });
 
 impl_handler!(AddDialingRelay => Option<Multiaddr>, |network, msg| {
-    network.add_dialing_relay(msg.relay, None).await
+    network.add_dialing_relay(msg.relay, None).await.unwrap()
 });
 
-impl_handler!(RemoveDialingRelay => (), |network, msg| {
+impl_handler!(RemoveDialingRelay => bool, |network, msg| {
     network.remove_dialing_relay(msg.relay).await
 });
 
@@ -382,7 +382,7 @@ pub mod messages {
     }
 
     #[derive(Message)]
-    #[rtype(result = "()")]
+    #[rtype(result = "bool")]
     pub struct StopListeningRelay {
         pub relay: PeerId,
     }
@@ -458,7 +458,7 @@ pub mod messages {
     }
 
     #[derive(Message)]
-    #[rtype(result = "()")]
+    #[rtype(result = "bool")]
     pub struct RemoveDialingRelay {
         pub relay: PeerId,
     }

--- a/client/src/actors/p2p.rs
+++ b/client/src/actors/p2p.rs
@@ -189,7 +189,7 @@ where
 
 impl_handler!(GetSwarmInfo => SwarmInfo, |network, _msg| {
     let listeners = network.get_listeners().await;
-    let local_peer_id = network.get_peer_id();
+    let local_peer_id = network.peer_id();
     let connections = network.get_connections().await;
     SwarmInfo { local_peer_id, listeners, connections}
 });

--- a/client/src/actors/p2p.rs
+++ b/client/src/actors/p2p.rs
@@ -109,8 +109,10 @@ impl NetworkActor {
         let (firewall_tx, _) = mpsc::channel(0);
         let (inbound_request_tx, inbound_request_rx) = EventChannel::new(10, ChannelSinkConfig::BufferLatest);
         let firewall_config = FirewallConfiguration::new(Some(firewall_rule), Some(Rule::AllowAll));
-        let mut builder =
-            StrongholdP2pBuilder::new(firewall_tx, inbound_request_tx, None).with_firewall_config(firewall_config);
+        let mut builder = StrongholdP2pBuilder::new(firewall_tx, inbound_request_tx, None)
+            .with_firewall_config(firewall_config)
+            .with_mdns_support(network_config.enable_mdns)
+            .with_relay_support(network_config.enable_relay);
         if let Some(keypair) = network_config.keypair {
             builder = builder.with_keys(keypair)
         }
@@ -123,6 +125,7 @@ impl NetworkActor {
         if let Some(limit) = network_config.connections_limit {
             builder = builder.with_connections_limit(limit)
         }
+
         let network = builder.build().await?;
         let actor = Self {
             network,
@@ -268,11 +271,16 @@ impl_handler!(RemoveDialingRelay => bool, |network, msg| {
 /// - A new keypair is created and used, from which the [`PeerId`] of the local peer is derived.
 /// - No limit for simultaneous connections.
 /// - Request-timeout and Connection-timeout are 10s.
+/// - [`Mdns`][`libp2p::mdns`] protocol is disabled. **Note**: Enabling mdns will broadcast our own address and id to
+///   the local network.
+/// - [`Relay`][`libp2p::relay`] functionality is disabled.
 pub struct NetworkConfig {
     keypair: Option<InitKeypair>,
     request_timeout: Option<Duration>,
     connection_timeout: Option<Duration>,
     connections_limit: Option<ConnectionLimits>,
+    enable_mdns: bool,
+    enable_relay: bool,
 }
 
 impl NetworkConfig {
@@ -303,6 +311,20 @@ impl NetworkConfig {
         self.connection_timeout = Some(t);
         self
     }
+
+    /// Enable / Disable [`Mdns`][`libp2p::mdns`] protocol.
+    /// **Note**: Enabling mdns will broadcast our own address and id to the local network.
+    pub fn with_mdns_enabled(mut self, is_enabled: bool) -> Self {
+        self.enable_mdns = is_enabled;
+        self
+    }
+
+    /// Enable / Disable [`Relay`][`libp2p::relay`] functionality.
+    /// This also means that other peers can use us as relay/
+    pub fn with_relay_enabled(mut self, is_enabled: bool) -> Self {
+        self.enable_relay = is_enabled;
+        self
+    }
 }
 
 impl Default for NetworkConfig {
@@ -312,6 +334,8 @@ impl Default for NetworkConfig {
             request_timeout: None,
             connection_timeout: None,
             connections_limit: None,
+            enable_mdns: false,
+            enable_relay: false,
         }
     }
 }

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -17,7 +17,7 @@ name = "p2p"
 [dependencies]
 either = "1.6"
 futures = "0.3"
-libp2p = { version = "0.40.0-rc.2", default-features = false, features = ["noise", "yamux", "mdns", "relay"] }
+libp2p = { version = "0.40.0-rc.3", default-features = false, features = ["noise", "yamux", "mdns", "relay"] }
 serde = { version = "1.0", default-features = false, features = [ "alloc", "derive" ] }
 serde_json = { version = "1.0", default-features = false, features = [ "alloc" ] }
 smallvec = "1.6.1"
@@ -32,4 +32,4 @@ tcp-transport = ["libp2p/tcp-tokio", "libp2p/dns-tokio", "libp2p/websocket"]
 [dev-dependencies]
 stronghold-utils = { path = "../utils", version = "0.3" }
 tokio = {version = "1.10", features = ["time", "macros"]}
-libp2p = { version = "0.40.0-rc.2", default-features = false, features = ["tcp-tokio"] }
+libp2p = { version = "0.40.0-rc.3", default-features = false, features = ["tcp-tokio"] }

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -22,6 +22,7 @@ serde = { version = "1.0", default-features = false, features = [ "alloc", "deri
 serde_json = { version = "1.0", default-features = false, features = [ "alloc" ] }
 smallvec = "1.6.1"
 stronghold-derive = { path = "../derive", version = "0.2" }
+thiserror = "1.0.30"
 tokio = { version = "1.10", default-features = false, features = ["rt", "sync"] }
 wasm-timer = "0.2.5"
 

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -15,8 +15,9 @@ homepage = "https://stronghold.docs.iota.org"
 name = "p2p"
 
 [dependencies]
+either = "1.6"
 futures = "0.3"
-libp2p = { version = "0.40.0-rc.2", default-features = false, features = ["noise", "yamux"] }
+libp2p = { version = "0.40.0-rc.2", default-features = false, features = ["noise", "yamux", "mdns", "relay"] }
 serde = { version = "1.0", default-features = false, features = [ "alloc", "derive" ] }
 serde_json = { version = "1.0", default-features = false, features = [ "alloc" ] }
 smallvec = "1.6.1"
@@ -25,9 +26,7 @@ tokio = { version = "1.10", default-features = false, features = ["rt", "sync"] 
 wasm-timer = "0.2.5"
 
 [features]
-default = [ "mdns", "relay", "tcp-transport"]
-mdns = ["libp2p/mdns"]
-relay = ["libp2p/relay"]
+default = [ "tcp-transport"]
 tcp-transport = ["libp2p/tcp-tokio", "libp2p/dns-tokio", "libp2p/websocket"]
 
 [dev-dependencies]

--- a/p2p/src/behaviour.rs
+++ b/p2p/src/behaviour.rs
@@ -22,9 +22,9 @@ mod handler;
 mod request_manager;
 pub use self::request_manager::EstablishedConnections;
 use crate::{InboundFailure, OutboundFailure, RequestDirection, RequestId, RqRsMessage};
-#[cfg(feature = "relay")]
 pub use addresses::assemble_relayed_addr;
 use addresses::AddressInfo;
+use either::Either;
 use firewall::{FirewallConfiguration, FirewallRequest, FirewallRules, Rule, RuleDirection};
 use futures::{
     channel::{
@@ -38,20 +38,18 @@ use futures::{
 };
 pub use handler::MessageProtocol;
 use handler::{ConnectionHandler, HandlerInEvent, HandlerOutEvent, ProtocolSupport};
-#[cfg(feature = "mdns")]
-use libp2p::mdns::Mdns;
-#[cfg(feature = "relay")]
-use libp2p::relay::Relay;
-#[cfg(any(feature = "mdns", feature = "relay"))]
-use libp2p::{core::either::EitherOutput, swarm::IntoProtocolsHandlerSelect};
 use libp2p::{
     core::{
         connection::{ConnectionId, ListenerId},
+        either::EitherOutput,
         ConnectedPoint, Multiaddr, PeerId,
     },
+    mdns::Mdns,
+    relay::Relay,
     swarm::{
-        DialPeerCondition, IntoProtocolsHandler, NetworkBehaviour, NetworkBehaviourAction, NotifyHandler,
-        PollParameters, ProtocolsHandler,
+        protocols_handler::either::IntoEitherHandler, DialPeerCondition, IntoProtocolsHandler,
+        IntoProtocolsHandlerSelect, NetworkBehaviour, NetworkBehaviourAction, NotifyHandler, PollParameters,
+        ProtocolsHandler,
     },
 };
 use request_manager::{ApprovalStatus, BehaviourAction, RequestManager};
@@ -62,23 +60,22 @@ use std::{
     time::Duration,
 };
 
-#[cfg(all(feature = "mdns", feature = "relay"))]
-type ProtoHandler<Rq, Rs> = IntoProtocolsHandlerSelect<
-    ConnectionHandler<Rq, Rs>,
-    IntoProtocolsHandlerSelect<
-        <Mdns as NetworkBehaviour>::ProtocolsHandler,
-        <Relay as NetworkBehaviour>::ProtocolsHandler,
+type ProtoHandler<Rq, Rs> = IntoEitherHandler<
+    IntoEitherHandler<
+        ConnectionHandler<Rq, Rs>,
+        IntoProtocolsHandlerSelect<
+            ConnectionHandler<Rq, Rs>,
+            IntoProtocolsHandlerSelect<
+                <Mdns as NetworkBehaviour>::ProtocolsHandler,
+                <Relay as NetworkBehaviour>::ProtocolsHandler,
+            >,
+        >,
+    >,
+    IntoEitherHandler<
+        IntoProtocolsHandlerSelect<ConnectionHandler<Rq, Rs>, <Mdns as NetworkBehaviour>::ProtocolsHandler>,
+        IntoProtocolsHandlerSelect<ConnectionHandler<Rq, Rs>, <Relay as NetworkBehaviour>::ProtocolsHandler>,
     >,
 >;
-#[cfg(all(not(feature = "mdns"), feature = "relay"))]
-type ProtoHandler<Rq, Rs> =
-    IntoProtocolsHandlerSelect<ConnectionHandler<Rq, Rs>, <Relay as NetworkBehaviour>::ProtocolsHandler>;
-#[cfg(all(feature = "mdns", not(feature = "relay")))]
-type ProtoHandler<Rq, Rs> =
-    IntoProtocolsHandlerSelect<ConnectionHandler<Rq, Rs>, <Mdns as NetworkBehaviour>::ProtocolsHandler>;
-
-#[cfg(not(any(feature = "mdns", feature = "relay")))]
-type ProtoHandler<Rq, Rs> = ConnectionHandler<Rq, Rs>;
 
 // Future for a pending response to a sent [`FirewallRequest::PeerSpecificRule`].
 type PendingPeerRuleRequest<TRq> = BoxFuture<'static, (PeerId, Option<FirewallRules<TRq>>)>;
@@ -121,6 +118,10 @@ pub enum BehaviourEvent<Rq, Rs> {
     },
 }
 
+/// The Relay protocol is not supported.
+#[derive(Debug)]
+pub struct RelayNotSupported;
+
 /// Configuration of the [`NetBehaviour`].
 pub struct NetBehaviourConfig<TRq: Clone> {
     /// Supported versions of the `MessageProtocol`.
@@ -158,11 +159,10 @@ where
     TRq: Clone + Send + 'static,
 {
     // integrate Mdns protocol
-    #[cfg(feature = "mdns")]
-    mdns: Mdns,
+    mdns: Option<Mdns>,
+
     // integrate Relay protocol
-    #[cfg(feature = "relay")]
-    relay: Relay,
+    relay: Option<Relay>,
 
     // List of supported protocol versions.
     supported_protocols: SmallVec<[MessageProtocol; 2]>,
@@ -204,14 +204,12 @@ where
     /// Create a new instance of a NetBehaviour to customize the [`Swarm`][libp2p::Swarm].
     pub fn new(
         config: NetBehaviourConfig<TRq>,
-        #[cfg(feature = "mdns")] mdns: Mdns,
-        #[cfg(feature = "relay")] relay: Relay,
+        mdns: Option<Mdns>,
+        relay: Option<Relay>,
         permission_req_channel: mpsc::Sender<FirewallRequest<TRq>>,
     ) -> Self {
         NetBehaviour {
-            #[cfg(feature = "mdns")]
             mdns,
-            #[cfg(feature = "relay")]
             relay,
             supported_protocols: config.supported_protocols,
             request_timeout: config.request_timeout,
@@ -315,6 +313,51 @@ where
         self.request_manager.get_established_connections()
     }
 
+    /// Add a relay to the list of relays that may be tried to use if a remote peer can not be reached directly.
+    pub fn add_dialing_relay(
+        &mut self,
+        peer: PeerId,
+        address: Option<Multiaddr>,
+    ) -> Result<Option<Multiaddr>, RelayNotSupported> {
+        Ok(self.addresses.add_relay(peer, address))
+    }
+
+    /// Remove a relay from the list of dialing relays.
+    // Returns `false` if the peer was not among the known relays.
+    //
+    // **Note**: Known relayed addresses for remote peers using this relay will not be influenced by this.
+    pub fn remove_dialing_relay(&mut self, peer: &PeerId) -> bool {
+        self.addresses.remove_relay(peer)
+    }
+
+    /// Configure whether it should be attempted to reach the remote via known relays, if it can not be reached via
+    /// known addresses.
+    pub fn set_relay_fallback(&mut self, peer: PeerId, use_relay_fallback: bool) -> Result<(), RelayNotSupported> {
+        if self.relay.is_none() {
+            return Err(RelayNotSupported);
+        }
+        self.addresses.set_relay_fallback(peer, use_relay_fallback);
+        Ok(())
+    }
+
+    /// Dial the target via the specified relay.
+    /// The `is_exclusive` parameter specifies whether other known relays should be used if using the set relay is not
+    /// successful.
+    ///
+    /// Returns the relayed address of the local peer (`<relay-addr>/<relay-id>/p2p-circuit/<local-id>),
+    /// if an address for the relay is known.
+    pub fn use_specific_relay(
+        &mut self,
+        target: PeerId,
+        relay: PeerId,
+        is_exclusive: bool,
+    ) -> Result<Option<Multiaddr>, RelayNotSupported> {
+        if self.relay.is_none() {
+            return Err(RelayNotSupported);
+        }
+        Ok(self.addresses.use_relay(target, relay, is_exclusive))
+    }
+
     /// [`RequestId`] for the next outbound request.
     fn next_request_id(&mut self) -> RequestId {
         *self.next_request_id.inc()
@@ -375,30 +418,23 @@ where
 
     fn new_handler_for_peer(&mut self, peer: Option<PeerId>) -> <Self as NetworkBehaviour>::ProtocolsHandler {
         let handler = self.new_request_response_handler(peer);
-        let protocols_handler;
-        #[cfg(all(feature = "mdns", feature = "relay"))]
-        {
-            let mdns_handler = self.mdns.new_handler();
-            let relay_handler = self.relay.new_handler();
-            protocols_handler =
-                IntoProtocolsHandler::select(handler, IntoProtocolsHandler::select(mdns_handler, relay_handler))
+        let mdns_handler = self.mdns.as_mut().map(|mdns| mdns.new_handler());
+        let relay_handler = self.relay.as_mut().map(|relay| relay.new_handler());
+        match mdns_handler {
+            Some(mh) => match relay_handler {
+                Some(rh) => IntoEitherHandler::Left(IntoEitherHandler::Right(IntoProtocolsHandler::select(
+                    handler,
+                    IntoProtocolsHandler::select(mh, rh),
+                ))),
+                None => IntoEitherHandler::Right(IntoEitherHandler::Left(IntoProtocolsHandler::select(handler, mh))),
+            },
+            None => match relay_handler {
+                Some(rh) => {
+                    IntoEitherHandler::Right(IntoEitherHandler::Right(IntoProtocolsHandler::select(handler, rh)))
+                }
+                None => IntoEitherHandler::Left(IntoEitherHandler::Left(handler)),
+            },
         }
-        #[cfg(all(feature = "mdns", not(feature = "relay")))]
-        {
-            let mdns_handler = self.mdns.new_handler();
-            protocols_handler = IntoProtocolsHandler::select(handler, mdns_handler)
-        }
-        #[cfg(all(not(feature = "mdns"), feature = "relay"))]
-        {
-            let relay_handler = self.relay.new_handler();
-            protocols_handler = IntoProtocolsHandler::select(handler, relay_handler)
-        }
-        #[cfg(not(any(feature = "mdns", feature = "relay")))]
-        {
-            protocols_handler = handler;
-        }
-
-        protocols_handler
     }
 
     // Handle new [`HandlerOutEvent`] emitted by the [`ConnectionHandler`].
@@ -504,40 +540,6 @@ where
     }
 }
 
-#[cfg(feature = "relay")]
-impl<Rq, Rs, TRq> NetBehaviour<Rq, Rs, TRq>
-where
-    Rq: RqRsMessage + Borrow<TRq>,
-    Rs: RqRsMessage,
-    TRq: Clone + Send + 'static,
-{
-    /// Add a relay to the list of relays that may be tried to use if a remote peer can not be reached directly.
-    pub fn add_dialing_relay(&mut self, peer: PeerId, address: Option<Multiaddr>) -> Option<Multiaddr> {
-        self.addresses.add_relay(peer, address)
-    }
-
-    /// Remove a relay from the list of dialing relays.
-    pub fn remove_dialing_relay(&mut self, peer: &PeerId) {
-        self.addresses.remove_relay(peer);
-    }
-
-    /// Configure whether it should be attempted to reach the remote via known relays, if it can not be reached via
-    /// known addresses.
-    pub fn set_relay_fallback(&mut self, peer: PeerId, use_relay_fallback: bool) {
-        self.addresses.set_relay_fallback(peer, use_relay_fallback);
-    }
-
-    /// Dial the target via the specified relay.
-    /// The `is_exclusive` paramter specifies whether other known relays should be used if using the set relay is not
-    /// successful.
-    ///
-    /// Returns the relayed address of the local peer (`<relay-addr>/<relay-id>/p2p-circuit/<local-id>),
-    /// if an address for the relay is known.
-    pub fn use_specific_relay(&mut self, target: PeerId, relay: PeerId, is_exclusive: bool) -> Option<Multiaddr> {
-        self.addresses.use_relay(target, relay, is_exclusive)
-    }
-}
-
 impl<Rq, Rs, TRq> NetworkBehaviour for NetBehaviour<Rq, Rs, TRq>
 where
     Rq: RqRsMessage + Borrow<TRq>,
@@ -551,175 +553,28 @@ where
         self.new_handler_for_peer(None)
     }
 
-    fn addresses_of_peer(&mut self, peer: &PeerId) -> Vec<Multiaddr> {
-        #[allow(unused_mut)]
-        let mut addresses = self.addresses.get_addrs(peer);
-        #[cfg(feature = "relay")]
-        addresses.extend(self.relay.addresses_of_peer(peer));
-        #[cfg(feature = "mdns")]
-        addresses.extend(self.mdns.addresses_of_peer(peer));
-        addresses
-    }
-
-    fn inject_connected(&mut self, peer: &PeerId) {
-        #[cfg(feature = "relay")]
-        self.relay.inject_connected(peer);
-        #[cfg(feature = "mdns")]
-        self.mdns.inject_connected(peer);
-        self.request_manager.on_peer_connected(*peer);
-    }
-
-    fn inject_disconnected(&mut self, peer: &PeerId) {
-        #[cfg(feature = "relay")]
-        self.relay.inject_disconnected(peer);
-        #[cfg(feature = "mdns")]
-        self.mdns.inject_disconnected(peer);
-        self.request_manager.on_peer_disconnected(*peer);
-    }
-
-    fn inject_connection_established(
-        &mut self,
-        peer: &PeerId,
-        connection: &ConnectionId,
-        endpoint: &ConnectedPoint,
-        failed_addresses: Option<&Vec<Multiaddr>>,
-    ) {
-        // If the remote connected to us and there is no rule for inbound requests yet, query firewall.
-        if endpoint.is_listener() && self.firewall.get_effective_rules(peer).inbound.is_none() {
-            self.query_peer_rule(*peer);
-        }
-        // Set the protocol support for the remote peer.
-        let support = ProtocolSupport::from_rules(&self.firewall.get_effective_rules(peer));
-        self.request_manager
-            .set_protocol_support(*peer, Some(*connection), support);
-
-        if let Some(addrs) = failed_addresses {
-            for addr in addrs {
-                self.addresses.deprioritize_addr(*peer, addr.clone());
-            }
-        }
-
-        self.request_manager
-            .on_connection_established(*peer, *connection, endpoint.clone());
-        self.addresses
-            .prioritize_addr(*peer, endpoint.get_remote_address().clone());
-        #[cfg(feature = "relay")]
-        self.relay
-            .inject_connection_established(peer, connection, endpoint, failed_addresses);
-        #[cfg(feature = "mdns")]
-        self.mdns
-            .inject_connection_established(peer, connection, endpoint, failed_addresses);
-    }
-
-    fn inject_connection_closed(
-        &mut self,
-        peer: &PeerId,
-        connection: &ConnectionId,
-        _endpoint: &ConnectedPoint,
-        _handler: <Self::ProtocolsHandler as IntoProtocolsHandler>::Handler,
-    ) {
-        self.request_manager.on_connection_closed(*peer, connection);
-
-        #[cfg(all(feature = "relay", feature = "mdns"))]
-        {
-            let (_, select) = _handler.into_inner();
-            let (mdns_handler, relay_handler) = select.into_inner();
-            self.relay
-                .inject_connection_closed(peer, connection, _endpoint, relay_handler);
-            self.mdns
-                .inject_connection_closed(peer, connection, _endpoint, mdns_handler);
-        }
-
-        #[cfg(all(feature = "relay", not(feature = "mdns")))]
-        {
-            let (_, relay_handler) = _handler.into_inner();
-            self.relay
-                .inject_connection_closed(peer, connection, _endpoint, relay_handler);
-        }
-
-        #[cfg(all(feature = "mdns", not(feature = "relay")))]
-        {
-            let (_, mdns_handler) = _handler.into_inner();
-            self.mdns
-                .inject_connection_closed(peer, connection, _endpoint, mdns_handler);
-        }
-    }
-
-    fn inject_address_change(
-        &mut self,
-        _peer: &PeerId,
-        _connection: &ConnectionId,
-        _old: &ConnectedPoint,
-        _new: &ConnectedPoint,
-    ) {
-        #[cfg(feature = "relay")]
-        self.relay.inject_address_change(_peer, _connection, _old, _new);
-        #[cfg(feature = "mdns")]
-        self.mdns.inject_address_change(_peer, _connection, _old, _new);
-    }
-
     fn inject_event(
         &mut self,
         peer: PeerId,
         connection: ConnectionId,
         event: <<Self::ProtocolsHandler as IntoProtocolsHandler>::Handler as ProtocolsHandler>::OutEvent,
     ) {
-        #[cfg(all(feature = "mdns", feature = "relay"))]
         match event {
-            EitherOutput::First(ev) => self.handle_handler_event(peer, connection, ev),
-            EitherOutput::Second(EitherOutput::First(ev)) => self.mdns.inject_event(peer, connection, ev),
-            EitherOutput::Second(EitherOutput::Second(ev)) => self.relay.inject_event(peer, connection, ev),
+            Either::Left(Either::Left(ev))
+            | Either::Left(Either::Right(EitherOutput::First(ev)))
+            | Either::Right(Either::Left(EitherOutput::First(ev)))
+            | Either::Right(Either::Right(EitherOutput::First(ev))) => self.handle_handler_event(peer, connection, ev),
+            Either::Left(Either::Right(EitherOutput::Second(EitherOutput::First(ev))))
+            | Either::Right(Either::Left(EitherOutput::Second(ev))) => {
+                // Event can only occur if mdns is not `None`
+                self.mdns.as_mut().unwrap().inject_event(peer, connection, ev)
+            }
+            Either::Left(Either::Right(EitherOutput::Second(EitherOutput::Second(ev))))
+            | Either::Right(Either::Right(EitherOutput::Second(ev))) => {
+                // Event can only occur if relay is not `None`
+                self.relay.as_mut().unwrap().inject_event(peer, connection, ev)
+            }
         };
-        #[cfg(all(feature = "mdns", not(feature = "relay")))]
-        return match event {
-            EitherOutput::First(ev) => self.handle_handler_event(peer, connection, ev),
-            EitherOutput::Second(ev) => self.mdns.inject_event(peer, connection, ev),
-        };
-        #[cfg(all(not(feature = "mdns"), feature = "relay"))]
-        return match event {
-            EitherOutput::First(ev) => self.handle_handler_event(peer, connection, ev),
-            EitherOutput::Second(ev) => self.relay.inject_event(peer, connection, ev),
-        };
-        #[cfg(not(any(feature = "mdns", feature = "relay")))]
-        self.handle_handler_event(peer, connection, event)
-    }
-
-    fn inject_dial_failure(
-        &mut self,
-        peer_id: Option<PeerId>,
-        _handler: Self::ProtocolsHandler,
-        _error: &libp2p::swarm::DialError,
-    ) {
-        if let Some(peer) = peer_id {
-            self.request_manager.on_dial_failure(peer);
-        }
-
-        #[cfg(all(feature = "relay", feature = "mdns"))]
-        {
-            let (_, select) = _handler.into_inner();
-            let (mdns_handler, relay_handler) = select.into_inner();
-            self.relay.inject_dial_failure(peer_id, relay_handler, _error);
-            self.mdns.inject_dial_failure(peer_id, mdns_handler, _error);
-        }
-
-        #[cfg(all(feature = "relay", not(feature = "mdns")))]
-        {
-            let (_, relay_handler) = _handler.into_inner();
-            self.relay.inject_dial_failure(peer_id, relay_handler, _error);
-        }
-
-        #[cfg(all(feature = "mdns", not(feature = "relay")))]
-        {
-            let (_, mdns_handler) = _handler.into_inner();
-            self.mdns.inject_dial_failure(peer_id, mdns_handler, _error);
-        }
-    }
-
-    fn inject_new_listen_addr(&mut self, _id: ListenerId, _addr: &Multiaddr) {
-        #[cfg(feature = "mdns")]
-        self.mdns.inject_new_listen_addr(_id, _addr);
-        #[cfg(feature = "relay")]
-        self.relay.inject_new_listen_addr(_id, _addr);
     }
 
     fn poll(
@@ -728,8 +583,9 @@ where
         _params: &mut impl PollParameters,
     ) -> Poll<NetworkBehaviourAction<Self::OutEvent, Self::ProtocolsHandler>> {
         // Drive mdns.
-        #[cfg(feature = "mdns")]
-        let _ = self.mdns.poll(cx, _params);
+        if let Some(mdns) = self.mdns.as_mut() {
+            let _ = mdns.poll(cx, _params);
+        }
 
         // Update firewall rules if a peer specific rule was return after a [`FirewallRequest::PeerSpecificRule`] query.
         while let Poll::Ready(Some((peer, rules))) = self.pending_rule_rqs.poll_next_unpin(cx) {
@@ -751,43 +607,59 @@ where
         }
 
         // Handle events from the relay protocol.
-        #[cfg(feature = "relay")]
-        if let Poll::Ready(action) = self.relay.poll(cx, _params) {
-            match action {
-                NetworkBehaviourAction::DialPeer {
-                    peer_id,
-                    condition,
-                    handler,
-                } => {
-                    #[cfg(feature = "mdns")]
-                    let handler = IntoProtocolsHandler::select(self.mdns.new_handler(), handler);
-                    let first = self.new_request_response_handler(Some(peer_id));
-                    let handler = IntoProtocolsHandler::select(first, handler);
-                    return Poll::Ready(NetworkBehaviourAction::DialPeer {
+        if let Some(relay) = self.relay.as_mut() {
+            if let Poll::Ready(action) = relay.poll(cx, _params) {
+                match action {
+                    NetworkBehaviourAction::DialPeer {
                         peer_id,
                         condition,
                         handler,
-                    });
-                }
-                NetworkBehaviourAction::NotifyHandler {
-                    peer_id,
-                    handler,
-                    event,
-                } => {
-                    #[cfg(feature = "mdns")]
-                    let event = EitherOutput::Second(EitherOutput::Second(event));
-                    #[cfg(not(feature = "mdns"))]
-                    let event = EitherOutput::Second(event);
-                    return Poll::Ready(NetworkBehaviourAction::NotifyHandler {
+                    } => {
+                        let first = self.new_request_response_handler(Some(peer_id));
+                        let handler = match self.mdns.as_mut() {
+                            Some(mdns) => {
+                                let into_protocols = IntoProtocolsHandler::select(
+                                    first,
+                                    IntoProtocolsHandler::select(mdns.new_handler(), handler),
+                                );
+                                IntoEitherHandler::Left(IntoEitherHandler::Right(into_protocols))
+                            }
+                            None => {
+                                let into_protocols = IntoProtocolsHandler::select(first, handler);
+                                IntoEitherHandler::Right(IntoEitherHandler::Right(into_protocols))
+                            }
+                        };
+                        return Poll::Ready(NetworkBehaviourAction::DialPeer {
+                            peer_id,
+                            condition,
+                            handler,
+                        });
+                    }
+                    NetworkBehaviourAction::NotifyHandler {
                         peer_id,
                         handler,
                         event,
-                    });
+                    } => {
+                        let event = match self.mdns {
+                            Some(_) => {
+                                let event = EitherOutput::Second(EitherOutput::Second(event));
+                                Either::Left(Either::Right(event))
+                            }
+                            None => {
+                                let event = EitherOutput::Second(event);
+                                Either::Right(Either::Right(event))
+                            }
+                        };
+                        return Poll::Ready(NetworkBehaviourAction::NotifyHandler {
+                            peer_id,
+                            handler,
+                            event,
+                        });
+                    }
+                    _ => {}
                 }
-                _ => {}
             }
         }
-
         // Emit events for pending requests and required dial attempts.
         if let Some(event) = self.request_manager.take_next_action() {
             let action = match event {
@@ -818,8 +690,16 @@ where
                     connection,
                 } => {
                     let event = HandlerInEvent::SendRequest { request_id, request };
-                    #[cfg(any(feature = "mdns", feature = "relay"))]
-                    let event = EitherOutput::First(event);
+                    let event = match self.mdns {
+                        Some(_) => match self.relay {
+                            Some(_) => Either::Left(Either::Right(EitherOutput::First(event))),
+                            None => Either::Right(Either::Left(EitherOutput::First(event))),
+                        },
+                        None => match self.relay {
+                            Some(_) => Either::Right(Either::Right(EitherOutput::First(event))),
+                            None => Either::Left(Either::Left(event)),
+                        },
+                    };
                     NetworkBehaviourAction::NotifyHandler {
                         peer_id: peer,
                         handler: NotifyHandler::One(connection),
@@ -855,8 +735,16 @@ where
                     support,
                 } => {
                     let event = HandlerInEvent::SetProtocolSupport(support);
-                    #[cfg(any(feature = "mdns", feature = "relay"))]
-                    let event = EitherOutput::First(event);
+                    let event = match self.mdns {
+                        Some(_) => match self.relay {
+                            Some(_) => Either::Left(Either::Right(EitherOutput::First(event))),
+                            None => Either::Right(Either::Left(EitherOutput::First(event))),
+                        },
+                        None => match self.relay {
+                            Some(_) => Either::Right(Either::Right(EitherOutput::First(event))),
+                            None => Either::Left(Either::Left(event)),
+                        },
+                    };
                     NetworkBehaviourAction::NotifyHandler {
                         peer_id: peer,
                         handler: NotifyHandler::One(connection),
@@ -868,6 +756,267 @@ where
         }
         Poll::Pending
     }
+
+    fn addresses_of_peer(&mut self, peer: &PeerId) -> Vec<Multiaddr> {
+        #[allow(unused_mut)]
+        let mut addresses = self.addresses.get_addrs(peer);
+        if let Some(relay) = self.relay.as_mut() {
+            addresses.extend(relay.addresses_of_peer(peer));
+        }
+        if let Some(mdns) = self.mdns.as_mut() {
+            addresses.extend(mdns.addresses_of_peer(peer));
+        }
+        addresses
+    }
+
+    fn inject_connected(&mut self, peer: &PeerId) {
+        if let Some(relay) = self.relay.as_mut() {
+            relay.inject_connected(peer);
+        }
+        if let Some(mdns) = self.mdns.as_mut() {
+            mdns.inject_connected(peer);
+        }
+        self.request_manager.on_peer_connected(*peer);
+    }
+
+    fn inject_disconnected(&mut self, peer: &PeerId) {
+        if let Some(relay) = self.relay.as_mut() {
+            relay.inject_disconnected(peer);
+        }
+
+        if let Some(mdns) = self.mdns.as_mut() {
+            mdns.inject_disconnected(peer);
+        }
+        self.request_manager.on_peer_disconnected(*peer);
+    }
+
+    fn inject_connection_established(
+        &mut self,
+        peer: &PeerId,
+        connection: &ConnectionId,
+        endpoint: &ConnectedPoint,
+        failed_addresses: Option<&Vec<Multiaddr>>,
+    ) {
+        // If the remote connected to us and there is no rule for inbound requests yet, query firewall.
+        if endpoint.is_listener() && self.firewall.get_effective_rules(peer).inbound.is_none() {
+            self.query_peer_rule(*peer);
+        }
+        // Set the protocol support for the remote peer.
+        let support = ProtocolSupport::from_rules(&self.firewall.get_effective_rules(peer));
+        self.request_manager
+            .set_protocol_support(*peer, Some(*connection), support);
+
+        if let Some(addrs) = failed_addresses {
+            for addr in addrs {
+                self.addresses.deprioritize_addr(*peer, addr.clone());
+            }
+        }
+
+        self.request_manager
+            .on_connection_established(*peer, *connection, endpoint.clone());
+        self.addresses
+            .prioritize_addr(*peer, endpoint.get_remote_address().clone());
+
+        if let Some(relay) = self.relay.as_mut() {
+            relay.inject_connection_established(peer, connection, endpoint, failed_addresses);
+        }
+
+        if let Some(mdns) = self.mdns.as_mut() {
+            mdns.inject_connection_established(peer, connection, endpoint, failed_addresses);
+        }
+    }
+
+    fn inject_connection_closed(
+        &mut self,
+        peer: &PeerId,
+        connection: &ConnectionId,
+        _endpoint: &ConnectedPoint,
+        _handler: <Self::ProtocolsHandler as IntoProtocolsHandler>::Handler,
+    ) {
+        self.request_manager.on_connection_closed(*peer, connection);
+        let (mdns_handler, relay_handler) = match _handler {
+            Either::Left(Either::Left(_)) => (None, None),
+            Either::Left(Either::Right(handler)) => {
+                let (_, select) = handler.into_inner();
+                let (mdns_handler, relay_handler) = select.into_inner();
+                (Some(mdns_handler), Some(relay_handler))
+            }
+            Either::Right(Either::Left(handler)) => {
+                let (_, mdns_handler) = handler.into_inner();
+                (Some(mdns_handler), None)
+            }
+            Either::Right(Either::Right(handler)) => {
+                let (_, relay_handler) = handler.into_inner();
+                (None, Some(relay_handler))
+            }
+        };
+        if let Some(mh) = mdns_handler {
+            // Event can only occur if mdns is not `None`
+            self.mdns
+                .as_mut()
+                .unwrap()
+                .inject_connection_closed(peer, connection, _endpoint, mh);
+        }
+        if let Some(rh) = relay_handler {
+            // Event can only occur if relay is not `None`
+            self.relay
+                .as_mut()
+                .unwrap()
+                .inject_connection_closed(peer, connection, _endpoint, rh);
+        }
+    }
+
+    fn inject_address_change(
+        &mut self,
+        _peer: &PeerId,
+        _connection: &ConnectionId,
+        _old: &ConnectedPoint,
+        _new: &ConnectedPoint,
+    ) {
+        if let Some(relay) = self.relay.as_mut() {
+            relay.inject_address_change(_peer, _connection, _old, _new);
+        }
+
+        if let Some(mdns) = self.mdns.as_mut() {
+            mdns.inject_address_change(_peer, _connection, _old, _new);
+        }
+    }
+
+    fn inject_dial_failure(
+        &mut self,
+        peer_id: Option<PeerId>,
+        handler: Self::ProtocolsHandler,
+        error: &libp2p::swarm::DialError,
+    ) {
+        if let Some(peer) = peer_id {
+            self.request_manager.on_dial_failure(peer);
+        }
+        let (mdns_handler, relay_handler) = match handler {
+            IntoEitherHandler::Left(IntoEitherHandler::Left(_)) => (None, None),
+            IntoEitherHandler::Left(IntoEitherHandler::Right(handler)) => {
+                let (_, select) = handler.into_inner();
+                let (mdns_handler, relay_handler) = select.into_inner();
+                (Some(mdns_handler), Some(relay_handler))
+            }
+            IntoEitherHandler::Right(IntoEitherHandler::Left(handler)) => {
+                let (_, mdns_handler) = handler.into_inner();
+                (Some(mdns_handler), None)
+            }
+            IntoEitherHandler::Right(IntoEitherHandler::Right(handler)) => {
+                let (_, relay_handler) = handler.into_inner();
+                (None, Some(relay_handler))
+            }
+        };
+        if let Some(mh) = mdns_handler {
+            // Event can only occur if mdns is not `None`
+            self.mdns.as_mut().unwrap().inject_dial_failure(peer_id, mh, error);
+        }
+        if let Some(rh) = relay_handler {
+            // Event can only occur if relay is not `None`
+            self.relay.as_mut().unwrap().inject_dial_failure(peer_id, rh, error);
+        }
+    }
+
+    fn inject_listen_failure(
+        &mut self,
+        local_addr: &Multiaddr,
+        send_back_addr: &Multiaddr,
+        handler: Self::ProtocolsHandler,
+    ) {
+        let (mdns_handler, relay_handler) = match handler {
+            IntoEitherHandler::Left(IntoEitherHandler::Left(_)) => (None, None),
+            IntoEitherHandler::Left(IntoEitherHandler::Right(handler)) => {
+                let (_, select) = handler.into_inner();
+                let (mdns_handler, relay_handler) = select.into_inner();
+                (Some(mdns_handler), Some(relay_handler))
+            }
+            IntoEitherHandler::Right(IntoEitherHandler::Left(handler)) => {
+                let (_, mdns_handler) = handler.into_inner();
+                (Some(mdns_handler), None)
+            }
+            IntoEitherHandler::Right(IntoEitherHandler::Right(handler)) => {
+                let (_, relay_handler) = handler.into_inner();
+                (None, Some(relay_handler))
+            }
+        };
+        if let Some(mh) = mdns_handler {
+            // Event can only occur if mdns is not `None`
+            self.mdns
+                .as_mut()
+                .unwrap()
+                .inject_listen_failure(local_addr, send_back_addr, mh)
+        }
+        if let Some(rh) = relay_handler {
+            // Event can only occur if relay is not `None`
+            self.relay
+                .as_mut()
+                .unwrap()
+                .inject_listen_failure(local_addr, send_back_addr, rh)
+        }
+    }
+
+    fn inject_new_listener(&mut self, id: ListenerId) {
+        if let Some(mdns) = self.mdns.as_mut() {
+            mdns.inject_new_listener(id)
+        }
+        if let Some(relay) = self.relay.as_mut() {
+            relay.inject_new_listener(id)
+        }
+    }
+
+    fn inject_new_listen_addr(&mut self, _id: ListenerId, _addr: &Multiaddr) {
+        if let Some(mdns) = self.mdns.as_mut() {
+            mdns.inject_new_listen_addr(_id, _addr);
+        }
+        if let Some(relay) = self.relay.as_mut() {
+            relay.inject_new_listen_addr(_id, _addr);
+        }
+    }
+
+    fn inject_expired_listen_addr(&mut self, id: ListenerId, addr: &Multiaddr) {
+        if let Some(mdns) = self.mdns.as_mut() {
+            mdns.inject_expired_listen_addr(id, addr);
+        }
+        if let Some(relay) = self.relay.as_mut() {
+            relay.inject_expired_listen_addr(id, addr);
+        }
+    }
+
+    fn inject_listener_error(&mut self, id: ListenerId, err: &(dyn std::error::Error + 'static)) {
+        if let Some(mdns) = self.mdns.as_mut() {
+            mdns.inject_listener_error(id, err);
+        }
+        if let Some(relay) = self.relay.as_mut() {
+            relay.inject_listener_error(id, err);
+        }
+    }
+
+    fn inject_listener_closed(&mut self, id: ListenerId, reason: Result<(), &std::io::Error>) {
+        if let Some(mdns) = self.mdns.as_mut() {
+            mdns.inject_listener_closed(id, reason);
+        }
+        if let Some(relay) = self.relay.as_mut() {
+            relay.inject_listener_closed(id, reason);
+        }
+    }
+
+    fn inject_new_external_addr(&mut self, addr: &Multiaddr) {
+        if let Some(mdns) = self.mdns.as_mut() {
+            mdns.inject_new_external_addr(addr);
+        }
+        if let Some(relay) = self.relay.as_mut() {
+            relay.inject_new_external_addr(addr);
+        }
+    }
+
+    fn inject_expired_external_addr(&mut self, addr: &Multiaddr) {
+        if let Some(mdns) = self.mdns.as_mut() {
+            mdns.inject_expired_external_addr(addr);
+        }
+        if let Some(relay) = self.relay.as_mut() {
+            relay.inject_expired_external_addr(addr);
+        }
+    }
 }
 
 #[cfg(test)]
@@ -877,13 +1026,11 @@ mod test {
     use super::*;
     use crate::firewall::{PermissionValue, RequestPermissions, Rule, RuleDirection, VariantPermission};
     use futures::{channel::mpsc, StreamExt};
-    #[cfg(feature = "mdns")]
-    use libp2p::mdns::{Mdns, MdnsConfig};
-    #[cfg(feature = "relay")]
-    use libp2p::relay::{new_transport_and_behaviour, RelayConfig};
     use libp2p::{
         core::{identity, upgrade, PeerId, Transport},
+        mdns::{Mdns, MdnsConfig},
         noise::{Keypair as NoiseKeypair, NoiseConfig, X25519Spec},
+        relay::{new_transport_and_behaviour, RelayConfig},
         swarm::{Swarm, SwarmBuilder, SwarmEvent},
         tcp::TokioTcpConfig,
         yamux::YamuxConfig,
@@ -1074,7 +1221,7 @@ mod test {
         let peer = id_keys.public().to_peer_id();
         let noise_keys = NoiseKeypair::<X25519Spec>::new().into_authentic(&id_keys).unwrap();
         let transport = TokioTcpConfig::new();
-        #[cfg(feature = "relay")]
+
         let (transport, relay_behaviour) = new_transport_and_behaviour(RelayConfig::default(), transport);
         let transport = transport
             .upgrade(upgrade::Version::V1)
@@ -1084,19 +1231,12 @@ mod test {
 
         let mut cfg = NetBehaviourConfig::default();
         cfg.firewall.set_default(Some(Rule::AllowAll), RuleDirection::Both);
-        #[cfg(feature = "mdns")]
+
         let mdns = Mdns::new(MdnsConfig::default())
             .await
             .expect("Failed to create mdns behaviour.");
         let (dummy_tx, _) = mpsc::channel(10);
-        let behaviour = NetBehaviour::new(
-            cfg,
-            #[cfg(feature = "mdns")]
-            mdns,
-            #[cfg(feature = "relay")]
-            relay_behaviour,
-            dummy_tx,
-        );
+        let behaviour = NetBehaviour::new(cfg, Some(mdns), Some(relay_behaviour), dummy_tx);
         let builder = SwarmBuilder::new(transport, behaviour, peer).executor(Box::new(|fut| {
             tokio::spawn(fut);
         }));

--- a/p2p/src/behaviour.rs
+++ b/p2p/src/behaviour.rs
@@ -313,12 +313,20 @@ where
         self.request_manager.get_established_connections()
     }
 
+    // Whether the relay protocol is enabled.
+    pub fn is_relay_enabled(&self) -> bool {
+        self.relay.is_some()
+    }
+
     /// Add a relay to the list of relays that may be tried to use if a remote peer can not be reached directly.
     pub fn add_dialing_relay(
         &mut self,
         peer: PeerId,
         address: Option<Multiaddr>,
     ) -> Result<Option<Multiaddr>, RelayNotSupported> {
+        if self.relay.is_none() {
+            return Err(RelayNotSupported);
+        }
         Ok(self.addresses.add_relay(peer, address))
     }
 

--- a/p2p/src/interface.rs
+++ b/p2p/src/interface.rs
@@ -407,7 +407,7 @@ pub enum InitKeypair {
 /// - Request-timeout and Connection-timeout are 10s.
 /// - [`Mdns`][`libp2p::mdns`] protocol is enabled. **Note**: This also broadcasts our own address and id to the local
 ///   network.
-/// - [`Relay`][`libp2p::relay`] protocols is supported. *Note:* This also means that other peers can use our peer as
+/// - [`Relay`][`libp2p::relay`] protocol is supported. *Note:* This also means that other peers can use our peer as
 ///   relay.
 ///
 /// `StrongholdP2p` is build either via [`StrongholdP2pBuilder::build`] (requires feature **tcp-transport**) with a

--- a/p2p/src/interface.rs
+++ b/p2p/src/interface.rs
@@ -85,7 +85,7 @@ where
     }
 
     /// Get the [`PeerId`] of the local peer.
-    pub fn get_peer_id(&self) -> PeerId {
+    pub fn peer_id(&self) -> PeerId {
         self.local_peer_id
     }
 
@@ -520,7 +520,7 @@ where
     /// Whether the peer should support the [`Mdns`][libp2p::mdns] protocol for peer discovery in a local network.
     ///
     /// **Note**: Enabling Mdns broadcasts our own address and id to the local network.
-    pub fn with_mdns_supported(mut self, support_mdns_protocol: bool) -> Self {
+    pub fn with_mdns_support(mut self, support_mdns_protocol: bool) -> Self {
         self.support_mdns = support_mdns_protocol;
         self
     }
@@ -529,7 +529,7 @@ where
     /// relay peer.
     ///
     /// **Note:** enabling this protocol also means that other peers can use our peer as relay.
-    pub fn with_relay_supported(mut self, support_relay_protocol: bool) -> Self {
+    pub fn with_relay_support(mut self, support_relay_protocol: bool) -> Self {
         self.support_relay = support_relay_protocol;
         self
     }

--- a/p2p/src/interface.rs
+++ b/p2p/src/interface.rs
@@ -5,39 +5,38 @@ mod errors;
 mod msg_channel;
 mod swarm_task;
 mod types;
-use self::swarm_task::{SwarmOperation, SwarmTask};
+
+pub use errors::*;
+pub use msg_channel::{ChannelSinkConfig, EventChannel};
+use swarm_task::{SwarmOperation, SwarmTask};
+pub use types::*;
+
 use crate::{
     behaviour::{BehaviourEvent, EstablishedConnections, NetBehaviour, NetBehaviourConfig},
     firewall::{FirewallConfiguration, FirewallRequest, FirewallRules, Rule, RuleDirection},
-    Keypair,
+    Keypair, RelayNotSupported,
 };
-pub use errors::*;
+
 use futures::{
     channel::{mpsc, oneshot},
     future::poll_fn,
     AsyncRead, AsyncWrite, FutureExt,
 };
-#[cfg(feature = "mdns")]
-use libp2p::mdns::{Mdns, MdnsConfig};
-#[cfg(feature = "relay")]
-use libp2p::relay::{new_transport_and_behaviour, RelayConfig};
 use libp2p::{
     core::{
         connection::{ConnectionLimits, ListenerId},
         transport::Transport,
         upgrade, Executor, Multiaddr, PeerId,
     },
+    mdns::{Mdns, MdnsConfig},
     noise::{AuthenticKeypair, Keypair as NoiseKeypair, NoiseConfig, X25519Spec},
+    relay::{new_transport_and_behaviour, RelayConfig},
     swarm::SwarmBuilder,
     yamux::YamuxConfig,
 };
 #[cfg(feature = "tcp-transport")]
 use libp2p::{dns::TokioDnsConfig, tcp::TokioTcpConfig, websocket::WsConfig};
-pub use msg_channel::{ChannelSinkConfig, EventChannel};
-#[cfg(feature = "tcp-transport")]
-use std::io;
-use std::{borrow::Borrow, time::Duration};
-pub use types::*;
+use std::{borrow::Borrow, io, time::Duration};
 
 #[derive(Clone)]
 /// Interface for the stronghold-p2p library to create a swarm, handle events and perform operations.
@@ -109,7 +108,7 @@ where
     /// In case of a tcp-transport, the address `/ip4/0.0.0.0/tcp/0` can be set if an OS-assigned address should be
     /// used.
     ///
-    /// Note: Depending on the used transport, this may produce multiple listening addresses.
+    /// **Note**: Depending on the used transport, this may produce multiple listening addresses.
     /// This method only returns the first reported listening address for the new listener.
     /// All active listening addresses for each listener can be obtained from [`StrongholdP2p::get_listeners`]
     pub async fn start_listening(&mut self, address: Multiaddr) -> Result<Multiaddr, ListenErr> {
@@ -119,7 +118,6 @@ where
         rx_yield.await.unwrap()
     }
 
-    #[cfg(feature = "relay")]
     /// Start listening via a relay peer on an address following the scheme
     /// `<relay-addr>/<relay-id>/p2p-circuit/<local-id>`. This will establish a keep-alive connection to the relay,
     /// the relay will forward all requests to the local peer.
@@ -162,9 +160,8 @@ where
         rx_yield.await.unwrap()
     }
 
-    #[cfg(feature = "relay")]
     /// Stop listening via the given relay.
-    pub async fn stop_listening_relay(&mut self, relay: PeerId) {
+    pub async fn stop_listening_relay(&mut self, relay: PeerId) -> bool {
         let (tx_yield, rx_yield) = oneshot::channel();
         let command = SwarmOperation::StopListeningRelay { relay, tx_yield };
         self.send_command(command).await;
@@ -277,9 +274,12 @@ where
         rx_yield.await.unwrap()
     }
 
-    #[cfg(feature = "relay")]
     /// Add a relay to the list of relays that may be tried to use if a remote peer can not be reached directly.
-    pub async fn add_dialing_relay(&mut self, peer: PeerId, address: Option<Multiaddr>) -> Option<Multiaddr> {
+    pub async fn add_dialing_relay(
+        &mut self,
+        peer: PeerId,
+        address: Option<Multiaddr>,
+    ) -> Result<Option<Multiaddr>, RelayNotSupported> {
         let (tx_yield, rx_yield) = oneshot::channel();
         let command = SwarmOperation::AddDialingRelay {
             peer,
@@ -290,19 +290,24 @@ where
         rx_yield.await.unwrap()
     }
 
-    #[cfg(feature = "relay")]
     /// Remove a relay from the list of dialing relays.
-    pub async fn remove_dialing_relay(&mut self, peer: PeerId) {
+    // Returns `false` if the peer was not among the known relays.
+    //
+    // **Note**: Known relayed addresses for remote peers using this relay will not be influenced by this.
+    pub async fn remove_dialing_relay(&mut self, peer: PeerId) -> bool {
         let (tx_yield, rx_yield) = oneshot::channel();
         let command = SwarmOperation::RemoveDialingRelay { peer, tx_yield };
         self.send_command(command).await;
         rx_yield.await.unwrap()
     }
 
-    #[cfg(feature = "relay")]
     /// Configure whether it should be attempted to reach the remote via known relays, if it can not be reached via
     /// known addresses.
-    pub async fn set_relay_fallback(&mut self, peer: PeerId, use_relay_fallback: bool) {
+    pub async fn set_relay_fallback(
+        &mut self,
+        peer: PeerId,
+        use_relay_fallback: bool,
+    ) -> Result<(), RelayNotSupported> {
         let (tx_yield, rx_yield) = oneshot::channel();
         let command = SwarmOperation::SetRelayFallback {
             peer,
@@ -313,14 +318,18 @@ where
         rx_yield.await.unwrap()
     }
 
-    #[cfg(feature = "relay")]
     /// Dial the target via the specified relay.
     /// The `is_exclusive` parameter specifies whether other known relays should be used if using the set relay is not
     /// successful.
     ///
     /// Returns the relayed address of the local peer (`<relay-addr>/<relay-id>/p2p-circuit/<local-id>),
     /// if an address for the relay is known.
-    pub async fn use_specific_relay(&mut self, target: PeerId, relay: PeerId, is_exclusive: bool) -> Option<Multiaddr> {
+    pub async fn use_specific_relay(
+        &mut self,
+        target: PeerId,
+        relay: PeerId,
+        is_exclusive: bool,
+    ) -> Result<Option<Multiaddr>, RelayNotSupported> {
         let (tx_yield, rx_yield) = oneshot::channel();
         let command = SwarmOperation::UseSpecificRelay {
             target,
@@ -396,6 +405,10 @@ pub enum InitKeypair {
 /// - A new keypair is created and used, from which the [`PeerId`] of the local peer is derived.
 /// - No limit for simultaneous connections.
 /// - Request-timeout and Connection-timeout are 10s.
+/// - [`Mdns`][`libp2p::mdns`] protocol is enabled. **Note**: This also broadcasts our own address and id to the local
+///   network.
+/// - [`Relay`][`libp2p::relay`] protocols is supported. *Note:* This also means that other peers can use our peer as
+///   relay.
 ///
 /// `StrongholdP2p` is build either via [`StrongholdP2pBuilder::build`] (requires feature **tcp-transport**) with a
 /// pre-configured transport, or [`StrongholdP2pBuilder::build_with_transport`] with a custom transport.
@@ -421,6 +434,13 @@ where
 
     // Limit of simultaneous connections.
     connections_limit: Option<ConnectionLimits>,
+
+    /// Use Mdns protocol for peer discovery in the local network.
+    ///
+    /// Note: This also broadcasts our own address and id to the local network.
+    support_mdns: bool,
+
+    support_relay: bool,
 }
 
 impl<Rq, Rs, TRq> StrongholdP2pBuilder<Rq, Rs, TRq>
@@ -446,6 +466,8 @@ where
             ident: None,
             behaviour_config: Default::default(),
             connections_limit: None,
+            support_mdns: true,
+            support_relay: true,
         }
     }
 
@@ -495,6 +517,23 @@ where
         self
     }
 
+    /// Whether the peer should support the [`Mdns`][libp2p::mdns] protocol for peer discovery in a local network.
+    ///
+    /// **Note**: Enabling Mdns broadcasts our own address and id to the local network.
+    pub fn with_mdns_supported(mut self, support_mdns_protocol: bool) -> Self {
+        self.support_mdns = support_mdns_protocol;
+        self
+    }
+
+    /// Whether the peer should support the [`Relay`][libp2p::relay] protocol that allows dialing and listening via a
+    /// relay peer.
+    ///
+    /// **Note:** enabling this protocol also means that other peers can use our peer as relay.
+    pub fn with_relay_supported(mut self, support_relay_protocol: bool) -> Self {
+        self.support_relay = support_relay_protocol;
+        self
+    }
+
     #[cfg(feature = "tcp-transport")]
     /// [`Self::build_with_transport`] with a [`Transport`] based on TCP/IP that supports dns resolution and websockets.
     /// It uses [`tokio::spawn`] as executor, hence this method has to be called in the context of a tokio.rs runtime.
@@ -504,14 +543,14 @@ where
         let executor = |fut| {
             tokio::spawn(fut);
         };
-        Ok(self.build_with_transport(transport, executor).await)
+        self.build_with_transport(transport, executor).await
     }
 
     /// Create a new [`StrongholdP2p`] instance with an underlying [`Swarm`][libp2p::Swarm] that uses the provided
     /// transport.
     ///
     /// The transport is upgraded with:
-    /// - [Relay protocol][<https://docs.libp2p.io/concepts/circuit-relay/>] (requires *feature = "relay"*)
+    /// - [Relay protocol][<https://docs.libp2p.io/concepts/circuit-relay/>]
     /// - Authentication and encryption with the Noise-Protocol, using the XX-handshake
     /// - Yamux substream multiplexing
     ///
@@ -520,7 +559,11 @@ where
     /// operations on the swarm-task.
     /// Additionally, the executor is used to configure the
     /// [`SwarmBuilder::executor`][libp2p::swarm::SwarmBuilder::executor].
-    pub async fn build_with_transport<Tp, E>(self, transport: Tp, executor: E) -> StrongholdP2p<Rq, Rs, TRq>
+    pub async fn build_with_transport<Tp, E>(
+        self,
+        transport: Tp,
+        executor: E,
+    ) -> Result<StrongholdP2p<Rq, Rs, TRq>, io::Error>
     where
         Tp: Transport + Sized + Clone + Send + Sync + 'static,
         Tp::Output: AsyncRead + AsyncWrite + Unpin + Send + 'static,
@@ -538,27 +581,34 @@ where
             let peer_id = keypair.public().to_peer_id();
             (noise_keypair, peer_id)
         });
-        #[cfg(feature = "relay")]
-        let (transport, relay_behaviour) = new_transport_and_behaviour(RelayConfig::default(), transport);
-        let transport = transport
-            .upgrade(upgrade::Version::V1)
-            .authenticate(NoiseConfig::xx(noise_keypair).into_authenticated())
-            .multiplex(YamuxConfig::default())
-            .boxed();
-        #[cfg(feature = "mdns")]
-        let mdns = Mdns::new(MdnsConfig::default())
-            .await
-            .expect("Failed to create mdns behaviour.");
-        let behaviour = NetBehaviour::new(
-            self.behaviour_config,
-            #[cfg(feature = "mdns")]
-            mdns,
-            #[cfg(feature = "relay")]
-            relay_behaviour,
-            self.firewall_channel,
-        );
+        let relay;
+        let boxed_transport;
+        if self.support_relay {
+            let (relay_transport, relay_behaviour) = new_transport_and_behaviour(RelayConfig::default(), transport);
+            boxed_transport = relay_transport
+                .upgrade(upgrade::Version::V1)
+                .authenticate(NoiseConfig::xx(noise_keypair).into_authenticated())
+                .multiplex(YamuxConfig::default())
+                .boxed();
+            relay = Some(relay_behaviour)
+        } else {
+            boxed_transport = transport
+                .upgrade(upgrade::Version::V1)
+                .authenticate(NoiseConfig::xx(noise_keypair).into_authenticated())
+                .multiplex(YamuxConfig::default())
+                .boxed();
+            relay = None;
+        }
+        let mdns;
+        if self.support_mdns {
+            mdns = Some(Mdns::new(MdnsConfig::default()).await?);
+        } else {
+            mdns = None
+        };
+        let behaviour = NetBehaviour::new(self.behaviour_config, mdns, relay, self.firewall_channel);
 
-        let mut swarm_builder = SwarmBuilder::new(transport, behaviour, peer_id).executor(Box::new(executor.clone()));
+        let mut swarm_builder =
+            SwarmBuilder::new(boxed_transport, behaviour, peer_id).executor(Box::new(executor.clone()));
         if let Some(limit) = self.connections_limit {
             swarm_builder = swarm_builder.connection_limits(limit);
         }
@@ -572,9 +622,9 @@ where
         let swarm_task = SwarmTask::new(swarm, command_rx, self.requests_channel, self.events_channel);
         executor.exec(swarm_task.run().boxed());
 
-        StrongholdP2p {
+        Ok(StrongholdP2p {
             local_peer_id,
             command_tx,
-        }
+        })
     }
 }

--- a/p2p/src/interface/errors.rs
+++ b/p2p/src/interface/errors.rs
@@ -18,30 +18,40 @@ use libp2p::{
     swarm::DialError,
     Multiaddr, TransportError,
 };
-use std::{convert::TryFrom, fmt, io};
+use std::{convert::TryFrom, io};
+use thiserror::Error;
 
 /// Error on dialing a peer and establishing a connection.
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum DialErr {
     /// The peer is currently banned.
+    #[error("Peer is banned.")]
     Banned,
     /// The configured limit for simultaneous outgoing connections
     /// has been reached.
+    #[error("Connection limit: `{limit}`/`{current}`.")]
     ConnectionLimit { limit: u32, current: u32 },
     /// The peer being dialed is the local peer and thus the dial was aborted.
+    #[error("Tried to dial local peer id.")]
     LocalPeerId,
     /// No direct or relayed addresses for the peer are known.
+    #[error("No addresses known for peer.")]
     NoAddresses,
     /// Pending connection attempt has been aborted.
+    #[error(" Pending connection attempt has been aborted.")]
     Aborted,
     /// The peer identity obtained on the connection did not
     /// match the one that was expected or is otherwise invalid.
+    #[error("Invalid peer ID.")]
     InvalidPeerId,
     /// An I/O error occurred on the connection.
+    #[error("An I/O error occurred on the connection: `{0}`.")]
     ConnectionIo(io::Error),
     /// An error occurred while negotiating the transport protocol(s) on a connection.
+    #[error("An error occurred while negotiating the transport protocol(s) on a connection: `{0:?}`.")]
     Transport(Vec<(Multiaddr, TransportError<io::Error>)>),
     /// The communication system was shut down before the dialing attempt resolved.
+    #[error("The network task was shut down.")]
     Shutdown,
 }
 
@@ -65,59 +75,26 @@ impl TryFrom<DialError> for DialErr {
     }
 }
 
-impl fmt::Display for DialErr {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            DialErr::ConnectionLimit { limit, current } => {
-                write!(f, "Dial error: Connection limit: {}/{}.", current, limit)
-            }
-            DialErr::NoAddresses => write!(f, "Dial error: no addresses for peer."),
-            DialErr::LocalPeerId => write!(f, "Dial error: tried to dial local peer id."),
-            DialErr::Banned => write!(f, "Dial error: peer is banned."),
-            DialErr::Aborted => write!(f, "Dial error: Pending connection attempt has been aborted."),
-            DialErr::InvalidPeerId => write!(f, "Dial error: Invalid peer ID."),
-            DialErr::ConnectionIo(e) => write!(f, "Dial error: An I/O error occurred on the connection: {:?}.", e),
-            DialErr::Transport(e) => write!(
-                f,
-                "An error occurred while negotiating the transport protocol(s) on a connection: {:?}.",
-                e
-            ),
-            DialErr::Shutdown => write!(f, "Dial error: the network task was shut down."),
-        }
-    }
-}
-
-impl std::error::Error for DialErr {}
-
 /// Error on establishing a connection.
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum ConnectionErr {
     /// An I/O error occurred on the connection.
+    #[error("I/O error: `{0}`")]
     Io(io::Error),
     /// The peer identity obtained on the connection did not
     /// match the one that was expected or is otherwise invalid.
+    #[error("Invalid peer ID.")]
     InvalidPeerId,
     /// An error occurred while negotiating the transport protocol(s).
+    #[error("Transport error: `{0}`")]
     Transport(TransportErr),
     /// The connection was dropped because the connection limit
     /// for a peer has been reached.
+    #[error("Connection limit: `{limit}`/`{current}`.")]
     ConnectionLimit { limit: u32, current: u32 },
     /// Pending connection attempt has been aborted.
+    #[error("Pending connection attempt has been aborted.")]
     Aborted,
-}
-
-impl fmt::Display for ConnectionErr {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            ConnectionErr::Io(err) => write!(f, "Connection error: I/O error: {}", err),
-            ConnectionErr::InvalidPeerId => write!(f, "Connection error: Invalid peer ID."),
-            ConnectionErr::ConnectionLimit { current, limit } => {
-                write!(f, "Connection error: Connection limit: {}/{}.", current, limit)
-            }
-            ConnectionErr::Transport(e) => write!(f, "Connection error: Transport error: {}", e),
-            ConnectionErr::Aborted => write!(f, "Pending connection attempt has been aborted"),
-        }
-    }
 }
 
 impl From<PendingConnectionError<TransportError<io::Error>>> for ConnectionErr {
@@ -136,24 +113,15 @@ impl From<PendingConnectionError<TransportError<io::Error>>> for ConnectionErr {
     }
 }
 
-impl std::error::Error for ConnectionErr {}
-
 /// Error on the [Transport][libp2p::Transport].
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum TransportErr {
     /// The address is not supported.
+    #[error("Multiaddress not supported: `{0}`")]
     MultiaddrNotSupported(Multiaddr),
     /// An I/O Error occurred.
+    #[error("I/O error: `{0}`")]
     Io(io::Error),
-}
-
-impl fmt::Display for TransportErr {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            TransportErr::MultiaddrNotSupported(a) => write!(f, "Transport error: Multiaddress not supported: {}", a),
-            TransportErr::Io(err) => write!(f, "Transport error: I/O error: {}", err),
-        }
-    }
 }
 
 impl From<TransportError<io::Error>> for TransportErr {
@@ -165,14 +133,14 @@ impl From<TransportError<io::Error>> for TransportErr {
     }
 }
 
-impl std::error::Error for TransportErr {}
-
 /// Error on listening on an address.
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum ListenErr {
     /// Listening on the address failed on the transport layer.
+    #[error("Transport error: `{0}`")]
     Transport(TransportErr),
     /// The communication system was shut down before the listening attempt resolved.
+    #[error("The network task was shut down.")]
     Shutdown,
 }
 
@@ -182,27 +150,20 @@ impl From<TransportError<io::Error>> for ListenErr {
     }
 }
 
-impl fmt::Display for ListenErr {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            ListenErr::Transport(e) => write!(f, "Listen error: Transport Error: {}", e),
-            ListenErr::Shutdown => write!(f, "Listen error: the network task was shut down."),
-        }
-    }
-}
-
-impl std::error::Error for ListenErr {}
-
 /// Error on listening on a relayed address.
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum ListenRelayErr {
     /// The relay protocol is not supported.
+    #[error("Relay Protocol not enabled.")]
     ProtocolNotSupported,
     /// Establishing a connection to the relay failed.
+    #[error("Dial Relay Error: `{0}`")]
     DialRelay(DialErr),
     /// Listening on the address failed on the transport layer.
+    #[error("Transport error: `{0}`")]
     Transport(TransportErr),
     /// The communication system was shut down before the listening attempt resolved.
+    #[error("The network task was shut down.")]
     Shutdown,
 }
 
@@ -224,16 +185,3 @@ impl From<TransportError<io::Error>> for ListenRelayErr {
         ListenRelayErr::Transport(err.into())
     }
 }
-
-impl fmt::Display for ListenRelayErr {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            ListenRelayErr::ProtocolNotSupported => write!(f, "Listen on Relay error: Relay Protocol not supported"),
-            ListenRelayErr::DialRelay(e) => write!(f, "Listen on Relay error: Dial Relay Error: {}", e),
-            ListenRelayErr::Transport(e) => write!(f, "Listen on Relay error: Listening Error: {}", e),
-            ListenRelayErr::Shutdown => write!(f, "Listen on Relay error: the network task was shut down."),
-        }
-    }
-}
-
-impl std::error::Error for ListenRelayErr {}

--- a/p2p/src/interface/errors.rs
+++ b/p2p/src/interface/errors.rs
@@ -196,6 +196,8 @@ impl std::error::Error for ListenErr {}
 /// Error on listening on a relayed address.
 #[derive(Debug)]
 pub enum ListenRelayErr {
+    /// The relay protocol is not supported.
+    ProtocolNotSupported,
     /// Establishing a connection to the relay failed.
     DialRelay(DialErr),
     /// Listening on the address failed on the transport layer.
@@ -226,6 +228,7 @@ impl From<TransportError<io::Error>> for ListenRelayErr {
 impl fmt::Display for ListenRelayErr {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
+            ListenRelayErr::ProtocolNotSupported => write!(f, "Listen on Relay error: Relay Protocol not supported"),
             ListenRelayErr::DialRelay(e) => write!(f, "Listen on Relay error: Dial Relay Error: {}", e),
             ListenRelayErr::Transport(e) => write!(f, "Listen on Relay error: Listening Error: {}", e),
             ListenRelayErr::Shutdown => write!(f, "Listen on Relay error: the network task was shut down."),

--- a/p2p/src/interface/swarm_task.rs
+++ b/p2p/src/interface/swarm_task.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{behaviour::EstablishedConnections, firewall::FirewallRules};
+use crate::{behaviour::EstablishedConnections, firewall::FirewallRules, RelayNotSupported};
 use futures::{
     channel::{mpsc, oneshot},
     prelude::*,
@@ -42,7 +42,6 @@ pub enum SwarmOperation<Rq, Rs, TRq: Clone> {
         address: Multiaddr,
         tx_yield: oneshot::Sender<Result<Multiaddr, ListenErr>>,
     },
-    #[cfg(feature = "relay")]
     StartRelayedListening {
         relay: PeerId,
         relay_addr: Option<Multiaddr>,
@@ -58,10 +57,9 @@ pub enum SwarmOperation<Rq, Rs, TRq: Clone> {
         address: Multiaddr,
         tx_yield: oneshot::Sender<Ack>,
     },
-    #[cfg(feature = "relay")]
     StopListeningRelay {
         relay: PeerId,
-        tx_yield: oneshot::Sender<Ack>,
+        tx_yield: oneshot::Sender<bool>,
     },
 
     GetPeerAddrs {
@@ -79,29 +77,25 @@ pub enum SwarmOperation<Rq, Rs, TRq: Clone> {
         tx_yield: oneshot::Sender<Ack>,
     },
 
-    #[cfg(feature = "relay")]
     AddDialingRelay {
         peer: PeerId,
         address: Option<Multiaddr>,
-        tx_yield: oneshot::Sender<Option<Multiaddr>>,
+        tx_yield: oneshot::Sender<Result<Option<Multiaddr>, RelayNotSupported>>,
     },
-    #[cfg(feature = "relay")]
     RemoveDialingRelay {
         peer: PeerId,
-        tx_yield: oneshot::Sender<Ack>,
+        tx_yield: oneshot::Sender<bool>,
     },
-    #[cfg(feature = "relay")]
     SetRelayFallback {
         peer: PeerId,
         use_relay_fallback: bool,
-        tx_yield: oneshot::Sender<Ack>,
+        tx_yield: oneshot::Sender<Result<(), RelayNotSupported>>,
     },
-    #[cfg(feature = "relay")]
     UseSpecificRelay {
         target: PeerId,
         relay: PeerId,
         is_exclusive: bool,
-        tx_yield: oneshot::Sender<Option<Multiaddr>>,
+        tx_yield: oneshot::Sender<Result<Option<Multiaddr>, RelayNotSupported>>,
     },
 
     GetFirewallDefault {
@@ -184,7 +178,6 @@ where
     // Response channels for start-listening via a relay.
     // A result is returned once the associated listener reported it's first new listening address, or a listener error
     // occurred. Additionally, an error will be returned if the relay could not be connected.
-    #[cfg(feature = "relay")]
     await_relayed_listen: HashMap<ListenerId, (PeerId, oneshot::Sender<Result<Multiaddr, ListenRelayErr>>)>,
 }
 
@@ -210,7 +203,6 @@ where
             await_response: HashMap::new(),
             await_connection: HashMap::new(),
             await_listen: HashMap::new(),
-            #[cfg(feature = "relay")]
             await_relayed_listen: HashMap::new(),
         }
     }
@@ -316,7 +308,6 @@ where
                 if let Some(listener) = self.listeners.get_mut(listener_id) {
                     listener.addrs.push(address.clone());
                 }
-                #[cfg(feature = "relay")]
                 if let Some((_, result_tx)) = self.await_relayed_listen.remove(listener_id) {
                     let _ = result_tx.send(Ok(address.clone()));
                 }
@@ -390,7 +381,6 @@ where
                 let _ = tx_yield.send(connections);
             }
             SwarmOperation::StartListening { address, tx_yield } => self.start_listening(address, tx_yield),
-            #[cfg(feature = "relay")]
             SwarmOperation::StartRelayedListening {
                 relay,
                 relay_addr,
@@ -408,10 +398,9 @@ where
                 self.remove_listener(|l: &Listener| l.addrs.contains(&address));
                 let _ = tx_yield.send(());
             }
-            #[cfg(feature = "relay")]
             SwarmOperation::StopListeningRelay { relay, tx_yield } => {
-                self.remove_listener(|l: &Listener| l.uses_relay == Some(relay));
-                let _ = tx_yield.send(());
+                let had_relay = self.remove_listener(|l: &Listener| l.uses_relay == Some(relay));
+                let _ = tx_yield.send(had_relay);
             }
             SwarmOperation::GetPeerAddrs { peer, tx_yield } => {
                 let addrs = self.swarm.behaviour_mut().addresses_of_peer(&peer);
@@ -433,7 +422,6 @@ where
                 self.swarm.behaviour_mut().remove_address(&peer, &address);
                 let _ = tx_yield.send(());
             }
-            #[cfg(feature = "relay")]
             SwarmOperation::AddDialingRelay {
                 peer,
                 address,
@@ -442,21 +430,18 @@ where
                 let relayed_addr = self.swarm.behaviour_mut().add_dialing_relay(peer, address);
                 let _ = tx_yield.send(relayed_addr);
             }
-            #[cfg(feature = "relay")]
             SwarmOperation::RemoveDialingRelay { peer, tx_yield } => {
-                self.swarm.behaviour_mut().remove_dialing_relay(&peer);
-                let _ = tx_yield.send(());
+                let was_relay = self.swarm.behaviour_mut().remove_dialing_relay(&peer);
+                let _ = tx_yield.send(was_relay);
             }
-            #[cfg(feature = "relay")]
             SwarmOperation::SetRelayFallback {
                 peer,
                 use_relay_fallback,
                 tx_yield,
             } => {
-                self.swarm.behaviour_mut().set_relay_fallback(peer, use_relay_fallback);
-                let _ = tx_yield.send(());
+                let res = self.swarm.behaviour_mut().set_relay_fallback(peer, use_relay_fallback);
+                let _ = tx_yield.send(res);
             }
-            #[cfg(feature = "relay")]
             SwarmOperation::UseSpecificRelay {
                 target,
                 relay,
@@ -534,7 +519,6 @@ where
     }
 
     // Start listening on a relayed address.
-    #[cfg(feature = "relay")]
     fn start_relayed_listening(
         &mut self,
         relay: PeerId,
@@ -572,17 +556,22 @@ where
     }
 
     // Remove listeners based on the given condition.
-    fn remove_listener<F: Fn(&Listener) -> bool>(&mut self, condition_fn: F) {
+    //
+    // Return whether there was at least one listener that matches the condition.
+    fn remove_listener<F: Fn(&Listener) -> bool>(&mut self, condition_fn: F) -> bool {
+        let mut removed_one = false;
         let mut remove_listeners = Vec::new();
         for (id, listener) in self.listeners.iter() {
             if condition_fn(listener) {
                 remove_listeners.push(*id);
+                removed_one = true;
             }
         }
         for id in remove_listeners {
             let _ = self.listeners.remove(&id);
             let _ = self.swarm.remove_listener(id);
         }
+        removed_one
     }
 
     // Shutdown the task, send errors for all pending operations.
@@ -596,7 +585,6 @@ where
         for (_, tx_yield) in self.await_listen.drain() {
             let _ = tx_yield.send(Err(ListenErr::Shutdown));
         }
-        #[cfg(feature = "relay")]
         for (_, (_, tx_yield)) in self.await_relayed_listen.drain() {
             let _ = tx_yield.send(Err(ListenRelayErr::Shutdown));
         }

--- a/p2p/src/interface/types.rs
+++ b/p2p/src/interface/types.rs
@@ -265,7 +265,7 @@ impl fmt::Display for OutboundFailure {
 
 /// Possible failures occurring in the context of receiving an inbound request and sending a response.
 ///
-/// Note: If the firewall is configured to block per se all requests from the remote peer, the protocol for inbound
+/// **Note**: If the firewall is configured to block per se all requests from the remote peer, the protocol for inbound
 /// requests will not be supported in the first place, and inbound requests are rejected without emitting a failure.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum InboundFailure {

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -13,9 +13,7 @@ mod libp2p_reexport {
 }
 pub use libp2p_reexport::*;
 mod interface;
-#[cfg(feature = "relay")]
-pub use behaviour::assemble_relayed_addr;
-pub use behaviour::{firewall, EstablishedConnections, MessageProtocol};
+pub use behaviour::{assemble_relayed_addr, firewall, EstablishedConnections, MessageProtocol, RelayNotSupported};
 pub use interface::*;
 
 #[macro_export]

--- a/p2p/tests/test_builder_config.rs
+++ b/p2p/tests/test_builder_config.rs
@@ -1,0 +1,112 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use std::time::Duration;
+
+use p2p::{
+    assemble_relayed_addr, ChannelSinkConfig, DialErr, EventChannel, ListenErr, ListenRelayErr, PeerId, StrongholdP2p,
+    StrongholdP2pBuilder, TransportErr,
+};
+
+use futures::channel::mpsc;
+#[cfg(not(feature = "tcp-transport"))]
+use libp2p::tcp::TokioTcpConfig;
+
+fn builder() -> StrongholdP2pBuilder<(), ()> {
+    let (dummy_fw_tx, _) = mpsc::channel(10);
+    let (dummy_rq_channel, _) = EventChannel::new(10, ChannelSinkConfig::DropLatest);
+    StrongholdP2pBuilder::new(dummy_fw_tx, dummy_rq_channel, None)
+}
+
+async fn build(builder: StrongholdP2pBuilder<(), ()>) -> StrongholdP2p<(), ()> {
+    #[cfg(not(feature = "tcp-transport"))]
+    let peer = {
+        let executor = |fut| {
+            tokio::spawn(fut);
+        };
+        builder
+            .build_with_transport(TokioTcpConfig::new(), executor)
+            .await
+            .unwrap();
+    };
+    #[cfg(feature = "tcp-transport")]
+    let peer = builder.build().await.unwrap();
+    peer
+}
+
+#[tokio::test]
+async fn mdns_config() {
+    // Test both peers mdns disabled.
+    let mut dialer_a = build(builder().with_mdns_support(false)).await;
+    let mut dialer_b = build(builder().with_mdns_support(false)).await;
+    let mut listener_c = build(builder().with_mdns_support(true)).await;
+    let c_id = listener_c.peer_id();
+    listener_c
+        .start_listening("/ip4/0.0.0.0/tcp/0".parse().unwrap())
+        .await
+        .unwrap();
+    let mut listener_d = build(builder().with_mdns_support(true)).await;
+    let d_id = listener_d.peer_id();
+    listener_d
+        .start_listening("/ip4/0.0.0.0/tcp/0".parse().unwrap())
+        .await
+        .unwrap();
+
+    // Delay so that the mdns peers can get each others addresses.
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    // Test both peers mdns disabled
+    let err = dialer_a.connect_peer(c_id).await.unwrap_err();
+    assert!(matches!(err, DialErr::NoAddresses), "unexpected error: {}", err);
+
+    // Test dialing peer mdns disabled, listening peer mdns enabled
+    let err = dialer_a.connect_peer(d_id).await.unwrap_err();
+    assert!(matches!(err, DialErr::NoAddresses), "unexpected error: {}", err);
+
+    // Test dialing peer mdns enabled, listening peer mdns disabled
+    let err = dialer_b.connect_peer(c_id).await.unwrap_err();
+    assert!(matches!(err, DialErr::NoAddresses), "unexpected error: {}", err);
+
+    // Test both peers mdns enabled
+    let err = dialer_b.connect_peer(d_id).await.unwrap_err();
+    assert!(matches!(err, DialErr::NoAddresses), "unexpected error: {}", err);
+}
+
+#[tokio::test]
+async fn relay_config() {
+    let mut peer = build(builder().with_relay_support(false)).await;
+    let peer_id = peer.peer_id();
+    let mut relay = build(builder()).await;
+    let relay_id = relay.peer_id();
+    let relay_addr = relay
+        .start_listening("/ip4/0.0.0.0/tcp/0".parse().unwrap())
+        .await
+        .unwrap();
+    peer.add_address(relay_id, relay_addr.clone()).await;
+    let relayed_address = assemble_relayed_addr(peer_id, relay_id, relay_addr.clone());
+
+    // Check normal listening.
+    let res = peer.start_listening("/ip4/0.0.0.0/tcp/0".parse().unwrap()).await;
+    assert!(res.is_ok(), "unexpected error: {:?}", res);
+
+    // Relayed listening on any address.
+    let err = peer.start_relayed_listening(relay_id, None).await.unwrap_err();
+    assert!(
+        matches!(err, ListenRelayErr::ProtocolNotSupported),
+        "unexpected error: {}",
+        err
+    );
+
+    // Listening on a relayed address directly should fail.
+    let err = peer.start_listening(relayed_address.clone()).await.unwrap_err();
+    assert!(
+        matches!(err, ListenErr::Transport(TransportErr::MultiaddrNotSupported(ref addr)) if addr == &relayed_address),
+        "unexpected error: {}",
+        err
+    );
+
+    // Check that the config methods return errors.
+    assert!(peer.add_dialing_relay(relay_id, None).await.is_err());
+    assert!(peer.set_relay_fallback(PeerId::random(), true).await.is_err());
+    assert!(peer.use_specific_relay(PeerId::random(), relay_id, true).await.is_err());
+}

--- a/p2p/tests/test_dialing.rs
+++ b/p2p/tests/test_dialing.rs
@@ -39,7 +39,10 @@ async fn init_peer() -> (mpsc::Receiver<NetworkEvent>, TestPeer) {
         let executor = |fut| {
             tokio::spawn(fut);
         };
-        builder.build_with_transport(TokioTcpConfig::new(), executor).await
+        builder
+            .build_with_transport(TokioTcpConfig::new(), executor)
+            .await
+            .unwrap();
     };
     #[cfg(feature = "tcp-transport")]
     let peer = builder.build().await.unwrap();
@@ -89,9 +92,9 @@ impl TestSourceConfig {
             7 | 8 | 9 => UseRelay::NoRelay,
             _ => unreachable!(),
         };
-        let knows_direct_target_addr = cfg!(feature = "mdns").then(|| true).unwrap_or_else(|| rand_bool(5));
-        let knows_relayed_target_addr = cfg!(feature = "mdns").then(|| true).unwrap_or_else(|| rand_bool(5));
-        let knows_relay_addr = cfg!(feature = "mdns").then(|| true).unwrap_or_else(|| rand_bool(5));
+        let knows_direct_target_addr = rand_bool(5);
+        let knows_relayed_target_addr = rand_bool(5);
+        let knows_relay_addr = rand_bool(5);
         TestSourceConfig {
             knows_direct_target_addr,
             knows_relayed_target_addr,
@@ -279,9 +282,7 @@ impl TestConfig {
             }
         }
         // if mdns is enabled, there is a chance that the source received the target address via the mdns service
-        if !cfg!(feature = "mdns") {
-            assert!(res.is_err(), "Unexpected Event {:?} on config {}", res, config_str);
-        }
+        assert!(res.is_err(), "Unexpected Event {:?} on config {}", res, config_str);
     }
 
     async fn try_direct(&mut self, config_str: &str) -> bool {

--- a/p2p/tests/test_firewall.rs
+++ b/p2p/tests/test_firewall.rs
@@ -168,8 +168,8 @@ impl<'a> RulesTestConfig<'a> {
     }
 
     async fn configure_firewall(&mut self) {
-        let peer_a_id = self.peer_a.get_peer_id();
-        let peer_b_id = self.peer_b.get_peer_id();
+        let peer_a_id = self.peer_a.peer_id();
+        let peer_b_id = self.peer_b.peer_id();
         if let Some(peer_rule) = self.b_rule.as_ref() {
             self.peer_b
                 .set_peer_rule(peer_a_id, RuleDirection::Inbound, peer_rule.as_rule())
@@ -189,8 +189,8 @@ impl<'a> RulesTestConfig<'a> {
     }
 
     async fn test_request(&mut self) {
-        let peer_a_id = self.peer_a.get_peer_id();
-        let peer_b_id = self.peer_b.get_peer_id();
+        let peer_a_id = self.peer_a.peer_id();
+        let peer_b_id = self.peer_b.peer_id();
 
         let mut peer_a = self.peer_a.clone();
         let res_future = peer_a.send_request(peer_b_id, self.req.clone()).boxed();
@@ -274,8 +274,8 @@ impl<'a> RulesTestConfig<'a> {
     }
 
     async fn clean(self) {
-        let peer_a_id = self.peer_a.get_peer_id();
-        let peer_b_id = self.peer_b.get_peer_id();
+        let peer_a_id = self.peer_a.peer_id();
+        let peer_b_id = self.peer_b.peer_id();
         self.peer_b.remove_peer_rule(peer_a_id, RuleDirection::Both).await;
         self.peer_b.remove_firewall_default(RuleDirection::Both).await;
         self.peer_a.remove_peer_rule(peer_b_id, RuleDirection::Both).await;
@@ -287,7 +287,7 @@ impl<'a> RulesTestConfig<'a> {
 async fn firewall_permissions() {
     let (_, _, _, mut peer_a) = init_peer().await;
     let (_, mut b_rq_rx, mut b_event_rx, mut peer_b) = init_peer().await;
-    let peer_b_id = peer_b.get_peer_id();
+    let peer_b_id = peer_b.peer_id();
 
     let peer_b_addr = peer_b
         .start_listening("/ip4/0.0.0.0/tcp/0".parse().unwrap())
@@ -397,8 +397,8 @@ impl<'a> AskTestConfig<'a> {
     }
 
     async fn test_request_with_ask(&mut self) {
-        let peer_a_id = self.peer_a.get_peer_id();
-        let peer_b_id = self.peer_b.get_peer_id();
+        let peer_a_id = self.peer_a.peer_id();
+        let peer_b_id = self.peer_b.peer_id();
 
         let is_allowed = |rule: &FwRuleRes, approval: &FwApprovalRes| match rule {
             FwRuleRes::AllowAll => true,
@@ -561,8 +561,8 @@ impl<'a> AskTestConfig<'a> {
     }
 
     async fn clean(self) {
-        let peer_a_id = self.peer_a.get_peer_id();
-        let peer_b_id = self.peer_b.get_peer_id();
+        let peer_a_id = self.peer_a.peer_id();
+        let peer_b_id = self.peer_b.peer_id();
         self.peer_a.remove_peer_rule(peer_b_id, RuleDirection::Both).await;
         self.peer_b.remove_peer_rule(peer_a_id, RuleDirection::Both).await;
     }
@@ -572,7 +572,7 @@ impl<'a> AskTestConfig<'a> {
 async fn firewall_ask() {
     let (mut firewall_a, _, _, mut peer_a) = init_peer().await;
     let (mut firewall_b, mut b_rq_rx, mut b_event_rx, mut peer_b) = init_peer().await;
-    let peer_b_id = peer_b.get_peer_id();
+    let peer_b_id = peer_b.peer_id();
 
     let peer_b_addr = peer_b
         .start_listening("/ip4/0.0.0.0/tcp/0".parse().unwrap())

--- a/p2p/tests/test_firewall.rs
+++ b/p2p/tests/test_firewall.rs
@@ -63,7 +63,10 @@ async fn init_peer() -> NewPeer {
         let executor = |fut| {
             tokio::spawn(fut);
         };
-        builder.build_with_transport(TokioTcpConfig::new(), executor).await
+        builder
+            .build_with_transport(TokioTcpConfig::new(), executor)
+            .await
+            .unwrap()
     };
     #[cfg(feature = "tcp-transport")]
     let peer = builder.build().await.unwrap();

--- a/p2p/tests/test_interface.rs
+++ b/p2p/tests/test_interface.rs
@@ -49,7 +49,7 @@ async fn init_peer() -> (
 #[tokio::test]
 async fn test_send_req() {
     let (mut bob_request_rx, mut bob) = init_peer().await;
-    let bob_id = bob.get_peer_id();
+    let bob_id = bob.peer_id();
     let bob_addr = bob
         .start_listening("/ip4/0.0.0.0/tcp/0".parse().unwrap())
         .await

--- a/p2p/tests/test_interface.rs
+++ b/p2p/tests/test_interface.rs
@@ -39,7 +39,8 @@ async fn init_peer() -> (
         .build_with_transport(TokioTcpConfig::new(), |fut| {
             tokio::spawn(fut);
         })
-        .await;
+        .await
+        .unwrap();
     #[cfg(feature = "tcp-transport")]
     let peer = builder.build().await.unwrap();
     (rq_rx, peer)


### PR DESCRIPTION
# Description of change

Remove `relay` and `mdns` features that were used in the code to automatically implement certain behaviour, which is bad practice as features are additive (see  https://github.com/iotaledger/stronghold.rs/pull/210#issuecomment-885655547).
Instead enable / disable mdns and relay functionality on init via config flags in the `StrongholdP2pBuilder`, per default both are enabled in the builder.
In the Stronghold client, mdns and relay can be enabled/ disabled via the `NetworkConfig` when spawning the p2p-network actor. Per default, both are disabled for Stronghold.



## Type of change

- [x] Bug fix (a non-breaking change which fixes an issue)
- [x] Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Added new tests for mdns and relay configuration.

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
