### PR TITLE
test(client): Restrict length of random key

### DIFF
--- a/.changes/refactor-error-types.md
+++ b/.changes/refactor-error-types.md
@@ -1,0 +1,13 @@
+---
+"iota-stronghold": minor
+"stronghold-engine": minor
+---
+
+
+[[PR 269](https://github.com/iotaledger/stronghold.rs/pull/269)]
+Refactor Error types in engine and client:
+- Add differentiated error types for the different methods
+- Avoid unwraps in the engine
+- Remove the single, crate-wide used error types of engine and client
+- Remove `anyhow` Error types in client and bubble up the actual error instead
+- Add nested Result type alias `StrongholdResult<T> = Result<T, ActorError>` for interface errors

--- a/client/src/tests/interface_tests.rs
+++ b/client/src/tests/interface_tests.rs
@@ -11,8 +11,6 @@ use crate::{
     tests::fresh,
     ProcResult, Procedure, ResultMessage, SLIP10DeriveInput,
 };
-#[cfg(feature = "p2p")]
-use stronghold_utils::random::random;
 
 #[actix::test]
 async fn test_stronghold() {
@@ -413,12 +411,12 @@ async fn test_stronghold_p2p() {
     let (remote_ready_tx, mut remote_ready_rx) = mpsc::channel(1);
     let (local_ready_tx, mut local_ready_rx) = mpsc::channel(1);
 
-    let key1 = bytestring(random());
+    let key1 = bytestring(1024);
     let data1 = b"some data".to_vec();
     let key1_clone = key1.clone();
     let data1_clone = data1.clone();
 
-    let key2 = bytestring(random());
+    let key2 = bytestring(1024);
     let data2 = b"some second data".to_vec();
     let key2_clone = key2.clone();
     let data2_clone = data2.clone();
@@ -463,7 +461,7 @@ async fn test_stronghold_p2p() {
         local_ready_tx.send(()).await.unwrap();
 
         // test writing and reading from local
-        let key3 = bytestring(random());
+        let key3 = bytestring(1024);
         let original_data3 = b"some third data".to_vec();
         local_stronghold
             .write_to_remote_store(peer_id, key3.clone(), original_data3.clone(), None)


### PR DESCRIPTION
# Description of change

Fix test in client: for the key a Vec with a random length was used. 
Since this length can be up to `usize::Max`, it tried to allocate more memory than available, hence causing:
```
...
memory allocation of 11744374998907113874 bytes failed
error: test failed, to rerun pass '-p iota_stronghold --lib'

Caused by:
  process didn't exit successfully: `/home/runner/work/stronghold.rs/stronghold.rs/target/debug/deps/iota_stronghold-f2cb821b8be1a728` (signal: 6, SIGABRT: process abort signal)
```
With this PR, the key will have a max length of 1024B.

Amend Changelog of #269.

Wrap the String message of fatal vault errors in newtype `FatalEngineError`.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- [x] Bug fix (a non-breaking change which fixes an issue)

