### PR TITLE
feat(client): persist p2p keypair in vault

### DIFF
--- a/.changes/persist-p2p-keypair.md
+++ b/.changes/persist-p2p-keypair.md
@@ -1,0 +1,7 @@
+---
+"iota-stronghold": patch
+---
+
+[[PR 285](https://github.com/iotaledger/stronghold.rs/pull/285)]
+Implement messages to write the keypair used for `StrongholdP2p` in the vault and derive the
+`PeerId` and a new noise `AuthenticKeypair` from it.

--- a/client/src/actors/secure.rs
+++ b/client/src/actors/secure.rs
@@ -174,6 +174,7 @@ mod p2p_messages {
 
     use super::*;
 
+    // Generate new keypair to use for `StrongholdP2p`.
     pub struct GenerateP2pKeypair {
         pub location: Location,
         pub hint: RecordHint,
@@ -193,6 +194,11 @@ mod p2p_messages {
         type Result = Result<(), ProcedureError>;
     }
 
+    // Derive a new noise keypair from a stored p2p-keypair.
+    // Returns the new keypair and the `PeerId` that is derived from the public
+    // key of the stored keypair.
+    // **Note**: The keypair differs for each new derivation, the `PeerId`
+    // is consistent.
     pub struct DeriveNoiseKeypair {
         pub p2p_keypair: Location,
     }

--- a/client/src/actors/secure.rs
+++ b/client/src/actors/secure.rs
@@ -21,6 +21,11 @@ use engine::{
         VaultError as EngineVaultError, VaultId,
     },
 };
+
+#[cfg(feature = "p2p")]
+use engine::runtime::GuardedVec;
+#[cfg(feature = "p2p")]
+use p2p::{AuthenticKeypair, Keypair, NoiseKeypair, PeerId};
 use std::collections::HashMap;
 use stronghold_utils::GuardDebug;
 
@@ -159,6 +164,41 @@ pub mod messages {
             DbView<internals::Provider>,
             Store,
         )>;
+    }
+}
+
+#[cfg(feature = "p2p")]
+mod p2p_messages {
+
+    use crate::Location;
+
+    use super::*;
+
+    pub struct GenerateP2pKeypair {
+        pub location: Location,
+        pub hint: RecordHint,
+    }
+
+    impl Message for GenerateP2pKeypair {
+        type Result = Result<(), ProcedureError>;
+    }
+
+    pub struct WriteP2pKeypair {
+        pub keypair: Keypair,
+        pub location: Location,
+        pub hint: RecordHint,
+    }
+
+    impl Message for WriteP2pKeypair {
+        type Result = Result<(), ProcedureError>;
+    }
+
+    pub struct DeriveNoiseKeypair {
+        pub p2p_keypair: Location,
+    }
+
+    impl Message for DeriveNoiseKeypair {
+        type Result = Result<(PeerId, AuthenticKeypair), ProcedureError>;
     }
 }
 
@@ -314,14 +354,59 @@ impl_handler!(
     }
 );
 
-// ----
-// impl for procedures
-// ---
-
 impl Handler<Procedure> for SecureClient {
     type Result = Result<CollectedOutput, ProcedureError>;
 
     fn handle(&mut self, proc: Procedure, _: &mut Self::Context) -> Self::Result {
         proc.run(self)
+    }
+}
+
+#[cfg(feature = "p2p")]
+impl Handler<p2p_messages::GenerateP2pKeypair> for SecureClient {
+    type Result = Result<(), ProcedureError>;
+
+    fn handle(&mut self, msg: p2p_messages::GenerateP2pKeypair, _ctx: &mut Self::Context) -> Self::Result {
+        let keypair = Keypair::generate_ed25519();
+        let bytes = keypair
+            .to_protobuf_encoding()
+            .map_err(|e| ProcedureError::Procedure(e.to_string().into()))?;
+        self.write_to_vault(&msg.location, msg.hint, bytes)?;
+        Ok(())
+    }
+}
+
+#[cfg(feature = "p2p")]
+impl Handler<p2p_messages::WriteP2pKeypair> for SecureClient {
+    type Result = Result<(), ProcedureError>;
+
+    fn handle(&mut self, msg: p2p_messages::WriteP2pKeypair, _ctx: &mut Self::Context) -> Self::Result {
+        let bytes = msg
+            .keypair
+            .to_protobuf_encoding()
+            .map_err(|e| ProcedureError::Procedure(e.to_string().into()))?;
+        self.write_to_vault(&msg.location, msg.hint, bytes)?;
+        Ok(())
+    }
+}
+
+#[cfg(feature = "p2p")]
+impl Handler<p2p_messages::DeriveNoiseKeypair> for SecureClient {
+    type Result = Result<(PeerId, AuthenticKeypair), ProcedureError>;
+
+    fn handle(&mut self, msg: p2p_messages::DeriveNoiseKeypair, _ctx: &mut Self::Context) -> Self::Result {
+        let mut id_keys = None;
+        let f = |guard: GuardedVec<u8>| {
+            let keys = Keypair::from_protobuf_encoding(&*guard.borrow()).map_err(|e| e.to_string())?;
+            let _ = id_keys.insert(keys);
+            Ok(())
+        };
+        self.get_guard(&msg.p2p_keypair, f)?;
+        let id_keys = id_keys.unwrap();
+        let keypair = NoiseKeypair::new()
+            .into_authentic(&id_keys)
+            .map_err(|e| ProcedureError::Procedure(e.to_string().into()))?;
+        let peer_id = PeerId::from_public_key(&id_keys.public());
+        Ok((peer_id, keypair))
     }
 }

--- a/client/src/procedures/types.rs
+++ b/client/src/procedures/types.rs
@@ -16,6 +16,7 @@ use serde::{Deserialize, Serialize};
 use std::{
     collections::{HashMap, HashSet},
     convert::{Infallible, TryFrom, TryInto},
+    fmt::Debug,
     ops::Deref,
     string::FromUtf8Error,
 };
@@ -242,10 +243,13 @@ pub enum ProcedureError {
     Procedure(#[from] FatalProcedureError),
 }
 
-impl From<VaultError<FatalProcedureError>> for ProcedureError {
-    fn from(e: VaultError<FatalProcedureError>) -> Self {
+impl<T> From<VaultError<T>> for ProcedureError
+where
+    T: Into<FatalProcedureError> + Debug,
+{
+    fn from(e: VaultError<T>) -> Self {
         match e {
-            VaultError::Procedure(e) => ProcedureError::Procedure(e),
+            VaultError::Procedure(e) => ProcedureError::Procedure(e.into()),
             other => ProcedureError::Engine(other.to_string().into()),
         }
     }
@@ -265,6 +269,12 @@ pub struct FatalProcedureError(String);
 impl From<crypto::Error> for FatalProcedureError {
     fn from(e: crypto::Error) -> Self {
         FatalProcedureError(e.to_string())
+    }
+}
+
+impl From<String> for FatalProcedureError {
+    fn from(e: String) -> Self {
+        FatalProcedureError(e)
     }
 }
 

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -6,10 +6,11 @@ mod libp2p_reexport {
     pub use libp2p::{
         core::{connection::ConnectionLimits, Executor},
         identity::Keypair,
-        noise::{AuthenticKeypair, Keypair as NoiseKeypair},
         swarm::DialError,
         Multiaddr, PeerId,
     };
+    pub type AuthenticKeypair = libp2p::noise::AuthenticKeypair<libp2p::noise::X25519Spec>;
+    pub type NoiseKeypair = libp2p::noise::Keypair<libp2p::noise::X25519Spec>;
 }
 pub use libp2p_reexport::*;
 mod interface;


### PR DESCRIPTION
# Description of change

Allow generating and storing the ed25519 [identity-keypair](https://docs.rs/libp2p/0.40.0/libp2p/identity/enum.Keypair.html) for p2p in the vault. The `PeerId` of the local Stronghold is derived from this keypair, hence it is desirable to persist it. Allow deriving a new authentic [noise-keypair](https://docs.rs/libp2p/0.40.0/libp2p/noise/struct.AuthenticKeypair.html) from the keypair, that is used for the authentication and noise-encryption on the transport layer.

## Links to any relevant issues

First step towards #281.

## Type of change

- [x] Enhancement (a non-breaking change which adds functionality)
