### PR TITLE
chore(*): patch iota-crypto v0.7.0 -> v0.8.0

### DIFF
--- a/.changes/patch-iota-crypto-v0.8.0.md
+++ b/.changes/patch-iota-crypto-v0.8.0.md
@@ -1,0 +1,5 @@
+---
+"iota-stronghold": patch
+"stronghold-engine": patch
+---
+Patch crypto.rs version v0.7 -> v0.8.

--- a/.changes/proc-api.md
+++ b/.changes/proc-api.md
@@ -1,0 +1,6 @@
+---
+"iota-stronghold": minor
+"stronghold-derive": minor
+---
+[[PR 258](https://github.com/iotaledger/stronghold.rs/pull/258)]
+Implement API for the Stronghold Procedures, see PR 258 for details.

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -31,17 +31,19 @@ path = "../engine"
 version = "0.4"
 
 [dependencies.iota-crypto]
-version = "0.7.0"
+version = "0.8.0"
 features = [
 "aes",
 "random",
 "ed25519",
 "sha",
 "hmac",
+"blake2b",
 "bip39-en",
 "bip39-jp",
 "slip10",
-"chacha"
+"chacha",
+"x25519",
 ]
 
 [dependencies.stronghold-p2p]

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -36,7 +36,7 @@ optional = true
 default-features = false
 
 [dependencies.iota-crypto]
-version = "0.7.0"
+version = "0.8.0"
 features = [ "random", "chacha", "hmac", "sha", "x25519", "blake2b" ]
 
 [dev-dependencies]


### PR DESCRIPTION
# Description of change

Patch iota-crypto version v0.7.0 -> v0.8.0. Resolves #286 and #287.