### PR TITLE
Persist config and keypair of stronghold-p2p in client

### DIFF
--- a/.changes/persist-p2p-config.md
+++ b/.changes/persist-p2p-config.md
@@ -1,0 +1,9 @@
+---
+"iota-stronghold": patch
+"stronghold-p2p": patch
+---
+
+[[PR 290](https://github.com/iotaledger/stronghold.rs/pull/290)]
+- Persist the state of stronghold-p2p in the `SecureClient` by serializing the `NetworkConfig` and writing it to the store.
+- Allow loading stored states into the `NetworkActor` on init.
+- Allow reuse of same `Keypair` that is stored in the vault.

--- a/client/examples/p2p/main.rs
+++ b/client/examples/p2p/main.rs
@@ -30,7 +30,6 @@ use arguments::*;
 pub use clap::Parser;
 use iota_stronghold::p2p::{Multiaddr, NetworkConfig, SwarmInfo};
 pub use iota_stronghold::Stronghold;
-use p2p::firewall::Rule;
 pub use std::error::Error;
 
 /// Returns a list of all available peers
@@ -52,7 +51,7 @@ pub async fn list_peers_command(stronghold: &mut iota_stronghold::Stronghold) ->
 
 /// Displays the swarm info of this stronghold instance
 pub async fn show_swarm_info_command(stronghold: &mut iota_stronghold::Stronghold) -> Result<(), Box<dyn Error>> {
-    stronghold.spawn_p2p(Rule::AllowAll, NetworkConfig::default()).await?;
+    stronghold.spawn_p2p(NetworkConfig::default()).await?;
 
     let SwarmInfo {
         local_peer_id,
@@ -77,7 +76,7 @@ pub async fn start_listening_command(
     let multiaddress: Multiaddr = multiaddr.parse()?;
 
     // spawn network actor
-    let network = stronghold.spawn_p2p(Rule::AllowAll, NetworkConfig::default()).await;
+    let network = stronghold.spawn_p2p(NetworkConfig::default()).await;
     println!("Network actor spawned: {:?}", network);
 
     // start listening

--- a/client/examples/p2p/main.rs
+++ b/client/examples/p2p/main.rs
@@ -51,7 +51,7 @@ pub async fn list_peers_command(stronghold: &mut iota_stronghold::Stronghold) ->
 
 /// Displays the swarm info of this stronghold instance
 pub async fn show_swarm_info_command(stronghold: &mut iota_stronghold::Stronghold) -> Result<(), Box<dyn Error>> {
-    stronghold.spawn_p2p(NetworkConfig::default()).await?;
+    stronghold.spawn_p2p(NetworkConfig::default(), None).await?;
 
     let SwarmInfo {
         local_peer_id,
@@ -76,7 +76,7 @@ pub async fn start_listening_command(
     let multiaddress: Multiaddr = multiaddr.parse()?;
 
     // spawn network actor
-    let network = stronghold.spawn_p2p(NetworkConfig::default()).await;
+    let network = stronghold.spawn_p2p(NetworkConfig::default(), None).await;
     println!("Network actor spawned: {:?}", network);
 
     // start listening

--- a/client/src/actors.rs
+++ b/client/src/actors.rs
@@ -11,6 +11,7 @@ mod snapshot;
 pub use self::{
     p2p::{messages as network_messages, NetworkActor, NetworkConfig},
     registry::p2p_messages::{GetNetwork, InsertNetwork, RemoveNetwork},
+    secure::p2p_messages as client_p2p_messages,
 };
 pub use self::{
     registry::{

--- a/client/src/actors.rs
+++ b/client/src/actors.rs
@@ -10,7 +10,7 @@ mod snapshot;
 #[cfg(feature = "p2p")]
 pub use self::{
     p2p::{messages as network_messages, NetworkActor, NetworkConfig},
-    registry::p2p_messages::{GetNetwork, InsertNetwork, StopNetwork},
+    registry::p2p_messages::{GetNetwork, InsertNetwork, RemoveNetwork},
 };
 pub use self::{
     registry::{

--- a/client/src/actors/registry.rs
+++ b/client/src/actors/registry.rs
@@ -89,10 +89,10 @@ pub mod p2p_messages {
         type Result = Option<Addr<NetworkActor>>;
     }
 
-    pub struct StopNetwork;
+    pub struct RemoveNetwork;
 
-    impl Message for StopNetwork {
-        type Result = bool;
+    impl Message for RemoveNetwork {
+        type Result = Option<Addr<NetworkActor>>;
     }
 }
 
@@ -200,12 +200,12 @@ impl Handler<p2p_messages::GetNetwork> for Registry {
 }
 
 #[cfg(feature = "p2p")]
-impl Handler<p2p_messages::StopNetwork> for Registry {
-    type Result = bool;
+impl Handler<p2p_messages::RemoveNetwork> for Registry {
+    type Result = Option<Addr<NetworkActor>>;
 
-    fn handle(&mut self, _: p2p_messages::StopNetwork, _: &mut Self::Context) -> Self::Result {
+    fn handle(&mut self, _: p2p_messages::RemoveNetwork, _: &mut Self::Context) -> Self::Result {
         // Dropping the only address of the network actor will stop the actor.
         // Upon stopping the actor, its `StrongholdP2p` instance will be dropped, which results in a graceful shutdown.
-        self.network.take().is_some()
+        self.network.take()
     }
 }

--- a/client/src/actors/secure.rs
+++ b/client/src/actors/secure.rs
@@ -25,7 +25,7 @@ use engine::{
 #[cfg(feature = "p2p")]
 use engine::runtime::GuardedVec;
 #[cfg(feature = "p2p")]
-use p2p::{AuthenticKeypair, Keypair, NoiseKeypair, PeerId};
+use p2p::{identity::Keypair, AuthenticKeypair, NoiseKeypair, PeerId};
 use std::collections::HashMap;
 use stronghold_utils::GuardDebug;
 

--- a/client/src/actors/secure.rs
+++ b/client/src/actors/secure.rs
@@ -168,7 +168,7 @@ pub mod messages {
 }
 
 #[cfg(feature = "p2p")]
-mod p2p_messages {
+pub mod p2p_messages {
 
     use crate::Location;
 

--- a/client/src/interface.rs
+++ b/client/src/interface.rs
@@ -29,7 +29,7 @@ use crate::{
 };
 use engine::vault::{ClientId, RecordHint, RecordId};
 #[cfg(feature = "p2p")]
-use p2p::{DialErr, InitKeypair, Keypair, ListenErr, ListenRelayErr, OutboundFailure, RelayNotSupported};
+use p2p::{identity::Keypair, DialErr, InitKeypair, ListenErr, ListenRelayErr, OutboundFailure, RelayNotSupported};
 
 use actix::prelude::*;
 use serde::{Deserialize, Serialize};

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -60,7 +60,8 @@ pub mod p2p {
         interface::{P2pError, P2pResult, SpawnNetworkError},
     };
     pub use p2p::{
-        firewall::Rule, DialErr, ListenErr, ListenRelayErr, Multiaddr, OutboundFailure, PeerId, RelayNotSupported,
+        firewall::Rule, identity, DialErr, ListenErr, ListenRelayErr, Multiaddr, OutboundFailure, PeerId,
+        RelayNotSupported,
     };
 }
 

--- a/client/src/tests/interface_tests.rs
+++ b/client/src/tests/interface_tests.rs
@@ -397,7 +397,6 @@ async fn test_stronghold_p2p() {
         procedures::{PersistSecret, Slip10Derive, Slip10Generate},
         tests::fresh,
     };
-    use p2p::firewall::Rule;
     use tokio::sync::{mpsc, oneshot};
 
     let system = actix::System::current();
@@ -432,7 +431,7 @@ async fn test_stronghold_p2p() {
             .await
             .unwrap_or_else(|e| panic!("Could not create a stronghold instance: {}", e));
         local_stronghold
-            .spawn_p2p(Rule::AllowAll, NetworkConfig::default())
+            .spawn_p2p(NetworkConfig::default())
             .await
             .unwrap_or_else(|e| panic!("Could not spawn p2p: {}", e));
 
@@ -496,7 +495,7 @@ async fn test_stronghold_p2p() {
             .await
             .unwrap_or_else(|e| panic!("Could not create a stronghold instance: {}", e));
         remote_stronghold
-            .spawn_p2p(Rule::AllowAll, NetworkConfig::default())
+            .spawn_p2p(NetworkConfig::default())
             .await
             .unwrap_or_else(|e| panic!("Could not create a stronghold instance: {}", e));
 

--- a/client/src/tests/interface_tests.rs
+++ b/client/src/tests/interface_tests.rs
@@ -431,7 +431,7 @@ async fn test_stronghold_p2p() {
             .await
             .unwrap_or_else(|e| panic!("Could not create a stronghold instance: {}", e));
         local_stronghold
-            .spawn_p2p(NetworkConfig::default())
+            .spawn_p2p(NetworkConfig::default(), None)
             .await
             .unwrap_or_else(|e| panic!("Could not spawn p2p: {}", e));
 
@@ -495,7 +495,7 @@ async fn test_stronghold_p2p() {
             .await
             .unwrap_or_else(|e| panic!("Could not create a stronghold instance: {}", e));
         remote_stronghold
-            .spawn_p2p(NetworkConfig::default())
+            .spawn_p2p(NetworkConfig::default(), None)
             .await
             .unwrap_or_else(|e| panic!("Could not create a stronghold instance: {}", e));
 

--- a/p2p/src/behaviour.rs
+++ b/p2p/src/behaviour.rs
@@ -1033,7 +1033,7 @@ where
     }
 }
 
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BehaviourState<TRq: Clone> {
     pub firewall: FirewallConfiguration<TRq>,
     pub address_info: AddressInfo,

--- a/p2p/src/behaviour.rs
+++ b/p2p/src/behaviour.rs
@@ -123,24 +123,21 @@ pub enum BehaviourEvent<Rq, Rs> {
 pub struct RelayNotSupported;
 
 /// Configuration of the [`NetBehaviour`].
-pub struct NetBehaviourConfig<TRq: Clone> {
+pub struct NetBehaviourConfig {
     /// Supported versions of the `MessageProtocol`.
     pub supported_protocols: SmallVec<[MessageProtocol; 2]>,
     /// Timeout for inbound and outbound requests.
     pub request_timeout: Duration,
     /// Keep-alive timeout of idle connections.
     pub connection_timeout: Duration,
-    /// Configuration for the firewall that checks every outbound and inbound request.
-    pub firewall: FirewallConfiguration<TRq>,
 }
 
-impl<TRq: Clone> Default for NetBehaviourConfig<TRq> {
+impl Default for NetBehaviourConfig {
     fn default() -> Self {
         Self {
             supported_protocols: smallvec![MessageProtocol::new_version(1, 0, 0)],
             connection_timeout: Duration::from_secs(10),
             request_timeout: Duration::from_secs(10),
-            firewall: FirewallConfiguration::default(),
         }
     }
 }
@@ -203,10 +200,12 @@ where
 {
     /// Create a new instance of a NetBehaviour to customize the [`Swarm`][libp2p::Swarm].
     pub fn new(
-        config: NetBehaviourConfig<TRq>,
+        config: NetBehaviourConfig,
         mdns: Option<Mdns>,
         relay: Option<Relay>,
         permission_req_channel: mpsc::Sender<FirewallRequest<TRq>>,
+        firewall: FirewallConfiguration<TRq>,
+        address_info: Option<AddressInfo>,
     ) -> Self {
         NetBehaviour {
             mdns,
@@ -217,8 +216,8 @@ where
             next_request_id: RequestId::new(1),
             next_inbound_id: Arc::new(AtomicU64::new(1)),
             request_manager: RequestManager::new(),
-            addresses: AddressInfo::default(),
-            firewall: config.firewall,
+            addresses: address_info.unwrap_or_default(),
+            firewall,
             permission_req_channel,
             pending_rule_rqs: FuturesUnordered::default(),
             pending_approval_rqs: FuturesUnordered::default(),
@@ -1036,8 +1035,8 @@ where
 
 #[derive(Clone, Serialize, Deserialize)]
 pub struct BehaviourState<TRq: Clone> {
-    firewall: FirewallConfiguration<TRq>,
-    address_info: AddressInfo,
+    pub firewall: FirewallConfiguration<TRq>,
+    pub address_info: AddressInfo,
 }
 
 #[cfg(test)]
@@ -1045,7 +1044,7 @@ mod test {
     use core::panic;
 
     use super::*;
-    use crate::firewall::{PermissionValue, RequestPermissions, Rule, RuleDirection, VariantPermission};
+    use crate::firewall::{PermissionValue, RequestPermissions, VariantPermission};
     use futures::{channel::mpsc, StreamExt};
     use libp2p::{
         core::{identity, upgrade, PeerId, Transport},
@@ -1250,14 +1249,18 @@ mod test {
             .multiplex(YamuxConfig::default())
             .boxed();
 
-        let mut cfg = NetBehaviourConfig::default();
-        cfg.firewall.set_default(Some(Rule::AllowAll), RuleDirection::Both);
-
         let mdns = Mdns::new(MdnsConfig::default())
             .await
             .expect("Failed to create mdns behaviour.");
         let (dummy_tx, _) = mpsc::channel(10);
-        let behaviour = NetBehaviour::new(cfg, Some(mdns), Some(relay_behaviour), dummy_tx);
+        let behaviour = NetBehaviour::new(
+            NetBehaviourConfig::default(),
+            Some(mdns),
+            Some(relay_behaviour),
+            dummy_tx,
+            FirewallConfiguration::allow_all(),
+            None,
+        );
         let builder = SwarmBuilder::new(transport, behaviour, peer).executor(Box::new(|fut| {
             tokio::spawn(fut);
         }));

--- a/p2p/src/behaviour/firewall.rs
+++ b/p2p/src/behaviour/firewall.rs
@@ -91,7 +91,7 @@ impl RuleDirection {
 }
 
 /// Rule configuration for inbound and outbound requests.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct FirewallRules<TRq: Clone> {
     /// Rule for inbound requests.
     pub inbound: Option<Rule<TRq>>,
@@ -133,7 +133,7 @@ impl<TRq: Clone> FirewallRules<TRq> {
 /// If there are neither default rules, nor a peer specific rule for a request from/ to a peer,
 /// a [`FirewallRequest::PeerSpecificRule`] will be sent through the firewall-channel that is passed to
 /// `StrongholdP2p`.
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(try_from = "SerdeFirewallConfig")]
 #[serde(into = "SerdeFirewallConfig")]
 pub struct FirewallConfiguration<TRq: Clone> {

--- a/p2p/src/behaviour/firewall.rs
+++ b/p2p/src/behaviour/firewall.rs
@@ -109,7 +109,7 @@ impl<TRq: Clone> FirewallRules<TRq> {
     }
 
     /// Create a new instance that permits all inbound and outbound requests.
-    pub fn permit_all() -> Self {
+    pub fn allow_all() -> Self {
         FirewallRules {
             inbound: Some(Rule::AllowAll),
             outbound: Some(Rule::AllowAll),

--- a/p2p/src/behaviour/firewall.rs
+++ b/p2p/src/behaviour/firewall.rs
@@ -2,11 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 mod permissions;
-use crate::RequestDirection;
+use crate::{serde::SerdeFirewallConfig, RequestDirection};
+pub use permissions::*;
+
 use core::fmt;
 use futures::channel::oneshot;
 use libp2p::PeerId;
-pub use permissions::*;
+use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, fmt::Debug, marker::PhantomData};
 
 /// Requests for approval and rules that are not covered by the current [`FirewallConfiguration`].
@@ -131,11 +133,14 @@ impl<TRq: Clone> FirewallRules<TRq> {
 /// If there are neither default rules, nor a peer specific rule for a request from/ to a peer,
 /// a [`FirewallRequest::PeerSpecificRule`] will be sent through the firewall-channel that is passed to
 /// `StrongholdP2p`.
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(try_from = "SerdeFirewallConfig")]
+#[serde(into = "SerdeFirewallConfig")]
 pub struct FirewallConfiguration<TRq: Clone> {
     /// Default rules that are used if there are no peer-specific ones for a peer.
-    default: FirewallRules<TRq>,
+    pub default: FirewallRules<TRq>,
     /// Peer specific rules.
-    peer_rules: HashMap<PeerId, FirewallRules<TRq>>,
+    pub peer_rules: HashMap<PeerId, FirewallRules<TRq>>,
 }
 
 impl<TRq: Clone> Default for FirewallConfiguration<TRq> {

--- a/p2p/src/interface.rs
+++ b/p2p/src/interface.rs
@@ -23,11 +23,7 @@ use futures::{
     AsyncRead, AsyncWrite, FutureExt,
 };
 use libp2p::{
-    core::{
-        connection::{ConnectionLimits, ListenerId},
-        transport::Transport,
-        upgrade, Executor, Multiaddr, PeerId,
-    },
+    core::{connection::ListenerId, transport::Transport, upgrade, Executor, Multiaddr, PeerId},
     mdns::{Mdns, MdnsConfig},
     noise::{AuthenticKeypair, Keypair as NoiseKeypair, NoiseConfig, X25519Spec},
     relay::{new_transport_and_behaviour, RelayConfig},
@@ -379,7 +375,7 @@ where
     // Export the firewall configuration and address info.
     pub async fn export_state(&mut self) -> BehaviourState<TRq> {
         let (tx_yield, rx_yield) = oneshot::channel();
-        let command = SwarmOperation::ExportState { tx_yield };
+        let command = SwarmOperation::ExportConfig { tx_yield };
         self.send_command(command).await;
         rx_yield.await.unwrap()
     }
@@ -649,7 +645,7 @@ where
         let mut swarm_builder =
             SwarmBuilder::new(boxed_transport, behaviour, peer_id).executor(Box::new(executor.clone()));
         if let Some(limit) = self.connections_limit {
-            swarm_builder = swarm_builder.connection_limits(limit);
+            swarm_builder = swarm_builder.connection_limits(limit.into());
         }
         let swarm = swarm_builder.build();
         let local_peer_id = *swarm.local_peer_id();

--- a/p2p/src/interface.rs
+++ b/p2p/src/interface.rs
@@ -12,7 +12,7 @@ use swarm_task::{SwarmOperation, SwarmTask};
 pub use types::*;
 
 use crate::{
-    behaviour::{BehaviourEvent, EstablishedConnections, NetBehaviour, NetBehaviourConfig},
+    behaviour::{BehaviourEvent, BehaviourState, EstablishedConnections, NetBehaviour, NetBehaviourConfig},
     firewall::{FirewallConfiguration, FirewallRequest, FirewallRules, Rule, RuleDirection},
     Keypair, RelayNotSupported,
 };
@@ -372,6 +372,14 @@ where
     pub async fn get_connections(&mut self) -> Vec<(PeerId, EstablishedConnections)> {
         let (tx_yield, rx_yield) = oneshot::channel();
         let command = SwarmOperation::GetConnections { tx_yield };
+        self.send_command(command).await;
+        rx_yield.await.unwrap()
+    }
+
+    // Export the firewall configuration and address info.
+    pub async fn export_state(&mut self) -> BehaviourState<TRq> {
+        let (tx_yield, rx_yield) = oneshot::channel();
+        let command = SwarmOperation::ExportState { tx_yield };
         self.send_command(command).await;
         rx_yield.await.unwrap()
     }

--- a/p2p/src/interface.rs
+++ b/p2p/src/interface.rs
@@ -14,7 +14,7 @@ pub use types::*;
 use crate::{
     behaviour::{BehaviourEvent, BehaviourState, EstablishedConnections, NetBehaviour, NetBehaviourConfig},
     firewall::{FirewallConfiguration, FirewallRequest, FirewallRules, Rule, RuleDirection},
-    Keypair, RelayNotSupported,
+    RelayNotSupported,
 };
 
 use futures::{
@@ -24,6 +24,7 @@ use futures::{
 };
 use libp2p::{
     core::{connection::ListenerId, transport::Transport, upgrade, Executor, Multiaddr, PeerId},
+    identity::Keypair,
     mdns::{Mdns, MdnsConfig},
     noise::{AuthenticKeypair, Keypair as NoiseKeypair, NoiseConfig, X25519Spec},
     relay::{new_transport_and_behaviour, RelayConfig},

--- a/p2p/src/interface/swarm_task.rs
+++ b/p2p/src/interface/swarm_task.rs
@@ -140,7 +140,7 @@ pub enum SwarmOperation<Rq, Rs, TRq: Clone> {
         tx_yield: oneshot::Sender<Ack>,
     },
 
-    ExportState {
+    ExportConfig {
         tx_yield: oneshot::Sender<BehaviourState<TRq>>,
     },
 }
@@ -508,7 +508,7 @@ where
                 self.swarm.unban_peer_id(peer);
                 let _ = tx_yield.send(());
             }
-            SwarmOperation::ExportState { tx_yield } => {
+            SwarmOperation::ExportConfig { tx_yield } => {
                 let state = self.swarm.behaviour_mut().export_state();
                 let _ = tx_yield.send(state);
             }

--- a/p2p/src/interface/types.rs
+++ b/p2p/src/interface/types.rs
@@ -16,11 +16,11 @@
 use crate::{behaviour::BehaviourEvent, ConnectionErr};
 use futures::channel::oneshot;
 use libp2p::{
-    core::connection::{ConnectedPoint, ConnectionError},
+    core::connection::{ConnectedPoint, ConnectionError, ConnectionLimits as Libp2pConnectionLimits},
     swarm::SwarmEvent,
     Multiaddr, PeerId,
 };
-use serde::{de::DeserializeOwned, Serialize};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use smallvec::SmallVec;
 use std::{convert::TryFrom, fmt, io, num::NonZeroU32};
 
@@ -291,3 +291,69 @@ impl fmt::Display for InboundFailure {
 }
 
 impl std::error::Error for OutboundFailure {}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ConnectionLimits {
+    max_pending_incoming: Option<u32>,
+    max_pending_outgoing: Option<u32>,
+    max_established_incoming: Option<u32>,
+    max_established_outgoing: Option<u32>,
+    max_established_per_peer: Option<u32>,
+    max_established_total: Option<u32>,
+}
+
+impl From<ConnectionLimits> for Libp2pConnectionLimits {
+    fn from(l: ConnectionLimits) -> Self {
+        Libp2pConnectionLimits::default()
+            .with_max_pending_incoming(l.max_pending_incoming)
+            .with_max_pending_outgoing(l.max_pending_outgoing)
+            .with_max_established_incoming(l.max_established_incoming)
+            .with_max_established_outgoing(l.max_established_outgoing)
+            .with_max_established_per_peer(l.max_established_per_peer)
+            .with_max_established(l.max_established_total)
+    }
+}
+
+impl ConnectionLimits {
+    /// Configures the maximum number of concurrently incoming connections being established.
+    pub fn with_max_pending_incoming(mut self, limit: Option<u32>) -> Self {
+        self.max_pending_incoming = limit;
+        self
+    }
+
+    /// Configures the maximum number of concurrently outgoing connections being established.
+    pub fn with_max_pending_outgoing(mut self, limit: Option<u32>) -> Self {
+        self.max_pending_outgoing = limit;
+        self
+    }
+
+    /// Configures the maximum number of concurrent established inbound connections.
+    pub fn with_max_established_incoming(mut self, limit: Option<u32>) -> Self {
+        self.max_established_incoming = limit;
+        self
+    }
+
+    /// Configures the maximum number of concurrent established outbound connections.
+    pub fn with_max_established_outgoing(mut self, limit: Option<u32>) -> Self {
+        self.max_established_outgoing = limit;
+        self
+    }
+
+    /// Configures the maximum number of concurrent established connections (both
+    /// inbound and outbound).
+    ///
+    /// Note: This should be used in conjunction with
+    /// [`ConnectionLimits::with_max_established_incoming`] to prevent possible
+    /// eclipse attacks (all connections being inbound).
+    pub fn with_max_established(mut self, limit: Option<u32>) -> Self {
+        self.max_established_total = limit;
+        self
+    }
+
+    /// Configures the maximum number of concurrent established connections per peer,
+    /// regardless of direction (incoming or outgoing).
+    pub fn with_max_established_per_peer(mut self, limit: Option<u32>) -> Self {
+        self.max_established_per_peer = limit;
+        self
+    }
+}

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -3,7 +3,7 @@
 
 mod behaviour;
 mod libp2p_reexport {
-    pub use libp2p::{core::Executor, identity::Keypair, swarm::DialError, Multiaddr, PeerId};
+    pub use libp2p::{core::Executor, identity, swarm::DialError, Multiaddr, PeerId};
     pub type AuthenticKeypair = libp2p::noise::AuthenticKeypair<libp2p::noise::X25519Spec>;
     pub type NoiseKeypair = libp2p::noise::Keypair<libp2p::noise::X25519Spec>;
 }

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -3,12 +3,7 @@
 
 mod behaviour;
 mod libp2p_reexport {
-    pub use libp2p::{
-        core::{connection::ConnectionLimits, Executor},
-        identity::Keypair,
-        swarm::DialError,
-        Multiaddr, PeerId,
-    };
+    pub use libp2p::{core::Executor, identity::Keypair, swarm::DialError, Multiaddr, PeerId};
     pub type AuthenticKeypair = libp2p::noise::AuthenticKeypair<libp2p::noise::X25519Spec>;
     pub type NoiseKeypair = libp2p::noise::Keypair<libp2p::noise::X25519Spec>;
 }

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -12,10 +12,15 @@ mod libp2p_reexport {
     pub type AuthenticKeypair = libp2p::noise::AuthenticKeypair<libp2p::noise::X25519Spec>;
     pub type NoiseKeypair = libp2p::noise::Keypair<libp2p::noise::X25519Spec>;
 }
-pub use libp2p_reexport::*;
 mod interface;
-pub use behaviour::{assemble_relayed_addr, firewall, EstablishedConnections, MessageProtocol, RelayNotSupported};
+mod serde;
+
+pub use behaviour::{
+    assemble_relayed_addr, firewall, AddressInfo, BehaviourState, EstablishedConnections, MessageProtocol,
+    RelayNotSupported,
+};
 pub use interface::*;
+pub use libp2p_reexport::*;
 
 #[macro_export]
 macro_rules! unwrap_or_return (

--- a/p2p/src/serde.rs
+++ b/p2p/src/serde.rs
@@ -1,0 +1,176 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    behaviour::{AddressInfo, PeerAddress},
+    firewall::{FirewallConfiguration, FirewallRules, Rule},
+};
+
+use libp2p::core::{multihash, PeerId};
+use serde::{Deserialize, Serialize};
+use smallvec::SmallVec;
+use std::{
+    collections::HashMap,
+    convert::{TryFrom, TryInto},
+    marker::PhantomData,
+};
+
+#[derive(Serialize, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct SerdePeerId(Vec<u8>);
+
+impl From<PeerId> for SerdePeerId {
+    fn from(peer_id: PeerId) -> Self {
+        SerdePeerId(peer_id.to_bytes())
+    }
+}
+
+impl TryFrom<SerdePeerId> for PeerId {
+    type Error = multihash::Error;
+    fn try_from(peer_id: SerdePeerId) -> Result<Self, Self::Error> {
+        PeerId::from_bytes(&peer_id.0)
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct SerdeAddressInfo {
+    peers: HashMap<SerdePeerId, PeerAddress>,
+    relays: Vec<SerdePeerId>,
+}
+
+impl From<AddressInfo> for SerdeAddressInfo {
+    fn from(info: AddressInfo) -> Self {
+        let relays = info.relays.into_iter().map(SerdePeerId::from).collect();
+        let peers = info.peers.into_iter().map(|(k, v)| (SerdePeerId::from(k), v)).collect();
+        SerdeAddressInfo { peers, relays }
+    }
+}
+
+impl TryFrom<SerdeAddressInfo> for AddressInfo {
+    type Error = multihash::Error;
+
+    fn try_from(info: SerdeAddressInfo) -> Result<Self, Self::Error> {
+        let mut peers = HashMap::new();
+        for (k, v) in info.peers {
+            let peer_id = PeerId::try_from(k)?;
+            peers.insert(peer_id, v);
+        }
+        let mut relays = SmallVec::new();
+        for peer in info.relays {
+            let peer_id = PeerId::try_from(peer)?;
+            relays.push(peer_id)
+        }
+        Ok(AddressInfo { peers, relays })
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+pub enum SerdeRule {
+    AllowAll,
+    RejectAll,
+    Ask,
+    Restricted,
+}
+
+impl SerdeRule {
+    pub fn into_rule_with_restriction<TRq, F>(self, restriction: F) -> Rule<TRq, F>
+    where
+        F: Fn(&TRq) -> bool,
+    {
+        Rule::try_from(self).unwrap_or(Rule::Restricted {
+            restriction,
+            _maker: PhantomData,
+        })
+    }
+}
+
+impl<TRq, F> From<Rule<TRq, F>> for SerdeRule
+where
+    F: Fn(&TRq) -> bool,
+{
+    fn from(rule: Rule<TRq, F>) -> Self {
+        match rule {
+            Rule::AllowAll => SerdeRule::AllowAll,
+            Rule::RejectAll => SerdeRule::RejectAll,
+            Rule::Ask => SerdeRule::Ask,
+            Rule::Restricted { .. } => SerdeRule::Restricted,
+        }
+    }
+}
+
+impl<TRq, F> TryFrom<SerdeRule> for Rule<TRq, F>
+where
+    F: Fn(&TRq) -> bool,
+{
+    type Error = ();
+    fn try_from(rule: SerdeRule) -> Result<Self, Self::Error> {
+        match rule {
+            SerdeRule::AllowAll => Ok(Rule::AllowAll),
+            SerdeRule::RejectAll => Ok(Rule::RejectAll),
+            SerdeRule::Ask => Ok(Rule::Ask),
+            SerdeRule::Restricted => Err(()),
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct SerdeFirewallRules {
+    inbound: Option<SerdeRule>,
+    outbound: Option<SerdeRule>,
+}
+
+impl<TRq: Clone> From<FirewallRules<TRq>> for SerdeFirewallRules {
+    fn from(rules: FirewallRules<TRq>) -> Self {
+        SerdeFirewallRules {
+            inbound: rules.inbound.map(|r| r.into()),
+            outbound: rules.outbound.map(|r| r.into()),
+        }
+    }
+}
+
+impl<TRq: Clone> From<SerdeFirewallRules> for FirewallRules<TRq> {
+    fn from(rules: SerdeFirewallRules) -> Self {
+        FirewallRules {
+            inbound: rules.inbound.and_then(|r| r.try_into().ok()),
+            outbound: rules.outbound.and_then(|r| r.try_into().ok()),
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct SerdeFirewallConfig {
+    default: SerdeFirewallRules,
+    peer_rules: HashMap<SerdePeerId, SerdeFirewallRules>,
+}
+
+impl<TRq: Clone> From<FirewallConfiguration<TRq>> for SerdeFirewallConfig {
+    fn from(config: FirewallConfiguration<TRq>) -> Self {
+        let default = config.default.into();
+        let peer_rules = config
+            .peer_rules
+            .into_iter()
+            .filter_map(|(k, v)| {
+                let rules = SerdeFirewallRules::from(v);
+                if rules.inbound.is_some() || rules.outbound.is_some() {
+                    Some((SerdePeerId::from(k), rules))
+                } else {
+                    None
+                }
+            })
+            .collect();
+        SerdeFirewallConfig { default, peer_rules }
+    }
+}
+
+impl<TRq: Clone> TryFrom<SerdeFirewallConfig> for FirewallConfiguration<TRq> {
+    type Error = multihash::Error;
+
+    fn try_from(config: SerdeFirewallConfig) -> Result<Self, Self::Error> {
+        let default = config.default.into();
+        let mut peer_rules = HashMap::new();
+        for (k, v) in config.peer_rules.into_iter() {
+            let peer_id = PeerId::try_from(k)?;
+            peer_rules.insert(peer_id, v.into());
+        }
+        Ok(FirewallConfiguration { default, peer_rules })
+    }
+}

--- a/p2p/tests/test_dialing.rs
+++ b/p2p/tests/test_dialing.rs
@@ -8,8 +8,8 @@ use futures::{
 #[cfg(not(feature = "tcp-transport"))]
 use libp2p::tcp::TokioTcpConfig;
 use p2p::{
-    assemble_relayed_addr, firewall::FirewallConfiguration, ChannelSinkConfig, EventChannel, Multiaddr, NetworkEvent,
-    PeerId, StrongholdP2p, StrongholdP2pBuilder,
+    assemble_relayed_addr, firewall::FirewallRules, ChannelSinkConfig, EventChannel, Multiaddr, NetworkEvent, PeerId,
+    StrongholdP2p, StrongholdP2pBuilder,
 };
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
@@ -29,7 +29,7 @@ async fn init_peer() -> (mpsc::Receiver<NetworkEvent>, TestPeer) {
     let (dummy_rq_channel, _) = EventChannel::new(10, ChannelSinkConfig::DropLatest);
     let (event_channel, event_rx) = EventChannel::new(10, ChannelSinkConfig::Block);
     let builder = StrongholdP2pBuilder::new(dummy_fw_tx, dummy_rq_channel, Some(event_channel))
-        .with_firewall_config(FirewallConfiguration::allow_all())
+        .with_firewall_default(FirewallRules::allow_all())
         .with_mdns_support(false)
         .with_connection_timeout(Duration::from_millis(1));
     #[cfg(not(feature = "tcp-transport"))]

--- a/p2p/tests/test_interface.rs
+++ b/p2p/tests/test_interface.rs
@@ -5,8 +5,7 @@ use futures::{channel::mpsc, future::join, StreamExt};
 #[cfg(not(feature = "tcp-transport"))]
 use libp2p::tcp::TokioTcpConfig;
 use p2p::{
-    firewall::FirewallConfiguration, ChannelSinkConfig, EventChannel, ReceiveRequest, StrongholdP2p,
-    StrongholdP2pBuilder,
+    firewall::FirewallRules, ChannelSinkConfig, EventChannel, ReceiveRequest, StrongholdP2p, StrongholdP2pBuilder,
 };
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
@@ -33,7 +32,7 @@ async fn init_peer() -> (
     let builder = StrongholdP2pBuilder::new(dummy_tx, request_channel, None)
         .with_connection_timeout(Duration::from_secs(1))
         .with_request_timeout(Duration::from_secs(1))
-        .with_firewall_config(FirewallConfiguration::allow_all());
+        .with_firewall_default(FirewallRules::allow_all());
     #[cfg(not(feature = "tcp-transport"))]
     let peer = builder
         .build_with_transport(TokioTcpConfig::new(), |fut| {


### PR DESCRIPTION
# Description of change

Persist the state of stronghold-p2p in the client by serializing the `NetworkConfig` and writing it to the store.
Allow loading stored states into the network actor on init.
Allow reuse of same `Keypair` (for authentication and encryption of the p2p transport layer) that is stored in the vault, to keep the same `PeerId` over multiple sessions.

**Note**: Firewall rules of type `Rule::Restricted` can not be serialized and hence are skipped when serializing the config.
This is not optimal, but at the current point there's no real solution for this.

## Links to any relevant issues

Fixes issue #281 .

## Type of change

- [x] Enhancement (a non-breaking change which adds functionality)
- [x] Documentation Fix

## How the change has been tested

Added new test `interface_tests::test_p2p_config`.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
