### PR TITLE
feat(client): allow write snapshot with stored key

### DIFF
--- a/client/src/actors/snapshot.rs
+++ b/client/src/actors/snapshot.rs
@@ -44,6 +44,8 @@ pub mod returntypes {
 
 pub mod messages {
 
+    use crate::Location;
+
     use super::*;
 
     pub struct WriteSnapshot {
@@ -53,6 +55,17 @@ pub mod messages {
     }
 
     impl Message for WriteSnapshot {
+        type Result = Result<(), WriteError>;
+    }
+
+    pub struct WriteSnapshotStoredKey {
+        pub filename: Option<String>,
+        pub path: Option<PathBuf>,
+        pub key_location: Location,
+        pub key_client: ClientId,
+    }
+
+    impl Message for WriteSnapshotStoredKey {
         type Result = Result<(), WriteError>;
     }
 
@@ -131,6 +144,21 @@ impl Handler<messages::WriteSnapshot> for Snapshot {
 
         self.state = SnapshotState::default();
 
+        Ok(())
+    }
+}
+
+impl Handler<messages::WriteSnapshotStoredKey> for Snapshot {
+    type Result = Result<(), WriteError>;
+
+    fn handle(&mut self, msg: messages::WriteSnapshotStoredKey, _ctx: &mut Self::Context) -> Self::Result {
+        self.write_snapshot_with_stored_key(
+            msg.filename.as_deref(),
+            msg.path.as_deref(),
+            msg.key_location,
+            msg.key_client,
+        )?;
+        self.state = SnapshotState::default();
         Ok(())
     }
 }

--- a/client/src/actors/snapshot.rs
+++ b/client/src/actors/snapshot.rs
@@ -16,9 +16,9 @@ use crate::{
     internals,
     state::{
         secure::Store,
-        snapshot::{ReadError, Snapshot, SnapshotState, WriteError},
+        snapshot::{Snapshot, SnapshotState},
     },
-    Provider,
+    Provider, ReadError, WriteError, WriteWithKeyError,
 };
 use std::collections::HashMap;
 
@@ -66,7 +66,7 @@ pub mod messages {
     }
 
     impl Message for WriteSnapshotStoredKey {
-        type Result = Result<(), WriteError>;
+        type Result = Result<(), WriteWithKeyError>;
     }
 
     pub struct FillSnapshot {
@@ -149,7 +149,7 @@ impl Handler<messages::WriteSnapshot> for Snapshot {
 }
 
 impl Handler<messages::WriteSnapshotStoredKey> for Snapshot {
-    type Result = Result<(), WriteError>;
+    type Result = Result<(), WriteWithKeyError>;
 
     fn handle(&mut self, msg: messages::WriteSnapshotStoredKey, _ctx: &mut Self::Context) -> Self::Result {
         self.write_snapshot_with_stored_key(

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -39,7 +39,7 @@ mod tests;
 pub use crate::{
     interface::{ActorError, FatalEngineError, Stronghold, StrongholdResult},
     internals::Provider,
-    state::snapshot::{ReadError, WriteError},
+    state::snapshot::{ReadError, WriteError, WriteWithKeyError},
     utils::{Location, StrongholdFlags, VaultFlags},
 };
 pub use engine::{

--- a/client/src/tests/interface_tests.rs
+++ b/client/src/tests/interface_tests.rs
@@ -6,8 +6,9 @@ use crate::{
     actors::NetworkConfig,
     p2p::{identity::Keypair, PeerId, SwarmInfo},
     procedures::{PersistSecret, Slip10Derive, Slip10Generate},
+    tests::fresh,
 };
-use crate::{tests::fresh, ActorError, Location, RecordHint, Stronghold};
+use crate::{ActorError, Location, RecordHint, Stronghold};
 use stronghold_utils::random::bytestring;
 #[cfg(feature = "p2p")]
 use tokio::sync::{mpsc, oneshot};

--- a/engine/src/vault/types/utils.rs
+++ b/engine/src/vault/types/utils.rs
@@ -398,6 +398,12 @@ impl Debug for VaultId {
     }
 }
 
+impl Display for VaultId {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "{}", self.0.as_ref().base64())
+    }
+}
+
 impl Into<Vec<u8>> for VaultId {
     fn into(self) -> Vec<u8> {
         self.0 .0.to_vec()

--- a/engine/src/vault/view.rs
+++ b/engine/src/vault/view.rs
@@ -18,7 +18,7 @@ use super::{crypto_box::DecryptError, types::transactions::Transaction};
 
 #[derive(DeriveError, Debug)]
 pub enum VaultError<TProvErr: Debug, TProcErr: Debug = Infallible> {
-    #[error("vault `{0:?}` does not exist")]
+    #[error("vault `{0}` does not exist")]
     VaultNotFound(VaultId),
 
     #[error("record error: `{0:?}`")]


### PR DESCRIPTION
# Description of change

Provide method for writing the snapshot with a key that is stored in the vault.
Extract the key from the client in which it is stored in and use it as encryption key to write all data to the snapshot.

## Links to any relevant issues

Fixes issue #279.

## Type of change

- [x] Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Added new test `basic_tests::write_snapshot_with_stored_key`.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
