### PR TITLE
feat(p2p): use libp2p::swarm::toggle for optional mdns/relay

### DIFF
--- a/.changes/p2p-toggle-behaviour.md
+++ b/.changes/p2p-toggle-behaviour.md
@@ -1,0 +1,5 @@
+---
+"stronghold-p2p": patch
+---
+
+- [PR 295](https://github.com/iotaledger/stronghold.rs/pull/295): use `libp2p::swarm::toggle` to enable/ disable relay and mdns

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -15,7 +15,6 @@ homepage = "https://stronghold.docs.iota.org"
 name = "p2p"
 
 [dependencies]
-either = "1.6"
 futures = "0.3"
 libp2p = { version = "0.41.0", default-features = false, features = ["noise", "yamux", "mdns", "relay"] }
 pin-project = "1.0.8"


### PR DESCRIPTION
# Description of change

 Use the `libp2p::swarm::toggle::Toggle` for optional network behaviour protocols Mdns and Relay.

## Type of change

- [x] Bug fix (a non-breaking change which fixes an issue)
- [x] Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Tested via existing tests.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
