### PR TITLE
[Proposal] Improve stronghold interface

### DIFF
--- a/client/src/actors.rs
+++ b/client/src/actors.rs
@@ -15,8 +15,10 @@ pub use self::{
 };
 pub use self::{
     registry::{
-        messages::{GetAllClients, GetClient, GetSnapshot, GetTarget, RemoveClient, SpawnClient, SwitchTarget},
-        Registry,
+        messages::{
+            GetAllClients, GetClient, GetSnapshot, GetTarget, RemoveClient, SetAllClients, SpawnClient, SwitchTarget,
+        },
+        Registry, Registry2,
     },
     secure::{messages as secure_messages, RecordError, VaultError},
     snapshot::{messages as snapshot_messages, returntypes as snapshot_returntypes},

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -39,7 +39,7 @@ mod tests;
 pub use crate::{
     interface::{ActorError, FatalEngineError, Stronghold, StrongholdResult},
     internals::Provider,
-    state::snapshot::{ReadError, WriteError},
+    state::snapshot::{ReadError, SnapshotFile, WriteError},
     utils::{Location, StrongholdFlags, VaultFlags},
 };
 pub use engine::{

--- a/client/src/state/snapshot.rs
+++ b/client/src/state/snapshot.rs
@@ -43,12 +43,6 @@ impl Snapshot {
         self.state.0.contains_key(&cid)
     }
 
-    pub fn print_data(&self) {
-        for entry in self.state.0.keys() {
-            println!("client_id: {:?}", entry);
-        }
-    }
-
     /// Reads state from the specified named snapshot or the specified path
     /// TODO: Add associated data.
     pub fn read_from_snapshot(snapshot_file: SnapshotFile, key: Key) -> Result<Self, ReadError> {
@@ -122,7 +116,7 @@ impl SnapshotFile {
         Self::Path(path.into())
     }
 
-    fn to_path(self) -> std::io::Result<PathBuf> {
+    pub fn to_path(self) -> std::io::Result<PathBuf> {
         match self {
             SnapshotFile::Named(name) => snapshot::files::get_path(&name),
             SnapshotFile::Path(path) => Ok(path),
@@ -133,6 +127,12 @@ impl SnapshotFile {
 impl Default for SnapshotFile {
     fn default() -> Self {
         Self::Named("main".to_owned())
+    }
+}
+
+impl From<PathBuf> for SnapshotFile {
+    fn from(path: PathBuf) -> Self {
+        Self::Path(path)
     }
 }
 

--- a/client/src/tests/procedures_tests.rs
+++ b/client/src/tests/procedures_tests.rs
@@ -14,14 +14,14 @@ use stronghold_utils::random::{self, bytestring, string};
 
 use super::fresh;
 use crate::{
-    interface::Stronghold2,
+    interface::Snapshot,
     procedures::{
         AeadAlg, AeadDecrypt, AeadEncrypt, BIP39Generate, BIP39Recover, ChainCode, Ed25519Sign, GenerateKey, Hash,
         HashType, Hkdf, KeyType, MnemonicLanguage, OutputKey, PersistOutput, PersistSecret, ProcedureIo, ProcedureStep,
         PublicKey, Sha2Hash, Slip10Derive, Slip10Generate, X25519DiffieHellman,
     },
     state::secure::SecureClient,
-    Location, Stronghold,
+    Location, SnapshotFile, Stronghold,
 };
 
 async fn setup_stronghold() -> (Vec<u8>, Stronghold) {
@@ -103,7 +103,7 @@ async fn usecase_ed25519() {
 #[actix::test]
 async fn usecase_Slip10Derive_intermediate_keys() {
     let cp = fresh::bytestring(u8::MAX.into());
-    let sh = Stronghold2::new();
+    let sh = Snapshot::new(SnapshotFile::default());
 
     let client = sh.client(&cp).await.unwrap();
 

--- a/engine/src/snapshot/files.rs
+++ b/engine/src/snapshot/files.rs
@@ -45,6 +45,6 @@ fn verify_or_create(dir: &Path) -> io::Result<()> {
 
 /// Construct the path to a snapshot file with the specifed name (defaults to `main`) under
 /// the directory specified by the (`snapshot_dir`)[fn.snapshot_dir.html] function.
-pub fn get_path(name: Option<&str>) -> io::Result<PathBuf> {
-    snapshot_dir().map(|p| p.join(format!("{}.stronghold", name.unwrap_or("main"))))
+pub fn get_path(name: &str) -> io::Result<PathBuf> {
+    snapshot_dir().map(|p| p.join(format!("{}.stronghold", name)))
 }


### PR DESCRIPTION
# Description of change

The identity.rs and wallet.rs crates wrap stronghold in very similar ways. This led us to align on what our needs are and it appears that we could use the same wrapper crate, if it existed. I looked into creating that crate based on what we already have in identity.rs. During that process, I noticed some shortcomings in the current stronghold interface, that I would love to see fixed. Rather than fixing it by wrapping stronghold in a new crate, I tried to improve the interface itself. These are the problems I was trying to solve:

1. Because only one actor can be the target and it needs to be switched through the interface, there is an inherent bottleneck. Users who want to access stronghold with multiple clients concurrently need to wrap the `Stronghold` into a mutex, to ensure that switching the target _and_ a subsequent operation is one atomic operation. If mutually exclusive access is not guaranteed, another concurrent caller may switch the target to some other actor; a race condition. This target mechanism seems unnecessary, given that the underlying actor system already handles synchronization, and hinders usability and potentially performance.
2. Everything goes through the `Stronghold` type. Stronghold has a very powerful architecture, multiple levels deep, but all of it passes through a flat interface. That means the interface misses out on the benefits of the strong type system that Rust offers. For example, actors need to be managed explicitly, through spawn and kill operations. Method names tend to be long and are sometimes ambiguous, i.e. is that method operating on the store or vault? Due to the target mechanism, it's not immediately obvious what client we operate on, which makes stronghold code harder to read and learn.
3. Users need to manage passwords. Both identity.rs and wallet.rs have stronghold wrapper modules that take care of storing and clearing passwords, in order to read and write snapshots. These passwords are stored in unguarded memory. With #294 taking care of writing snapshots, the only place left were passwords are needed repeatedly is in `read_snapshot`. Stronghold should make it easy to do the right thing, and it would ideally only require the password from the user on startup, in order to decrypt the snapshot, and then never again.

To address these shortcomings, I refactored the interface, while keeping practically the same functionality. This is an example:

```rust
#[actix::test]
async fn stronghold_interface_example() -> Result<(), Box<dyn std::error::Error>> {
    let vault_path = b"vault".to_vec();
    let client_path = b"client";
    let key_data = [0xff; 32].to_vec();
    let file = SnapshotFile::named("testfile");

    let record_location = VaultLocation::counter(0);

    let store_loc = bytestring(4096);

    let mut snapshot: Snapshot = Snapshot::new(file.clone());
    let client: Client = snapshot.client(client_path).await?;
    let vault: Vault = client.vault(vault_path.clone());
    let store: Store = client.store();

    vault
        .write(
            record_location.clone(),
            b"test".to_vec(),
            RecordHint::new(b"first hint").unwrap(),
        )
        .await??;

    store.write(store_loc.clone(), b"test".to_vec(), None).await?;

    snapshot.write(&key_data).await??;

    std::mem::drop(client);
    std::mem::drop(snapshot);

    let mut snapshot = Snapshot::new(file.clone());
    snapshot.read(&key_data).await??;

    let client: Client = snapshot.client(client_path).await?;
    client.restore_state().await?;

    let store_data = client.store().read(store_loc.clone()).await?.unwrap();
    let vault_data = client
        .vault(vault_path)
        .read_secret(record_location.clone())
        .await?
        .unwrap();

    assert_eq!(store_data, b"test");
    assert_eq!(vault_data, b"test");

    Ok(())
}
```

This addresses the above-mentioned issues:

1. This interface exposes actors more directly via the `Client` type. One client is backed by one actor. `Stronghold::client` can be called multiple times with the same `client_path` to get another `Client` that is backed by the same actor, and the client is cloneable. This way, multiple clients can be created and used from different tasks and threads, granting the user more direct access to the power of the actor system. This design also gets rid of (most of) the synchronization that callers have to do, because the actor system itself already handles that. That improves performance (fewer locks needed) and, perhaps more importantly, usability.
2. Calling `Stronghold::client` conceptually does a `get_or_init` operation for the actor, in order to avoid having to explicitly spawn an actor. Moreover, a client represents a running actor, so `TargetNotFound` errors become unnecessary (however, they are still in the code for short-on-time reasons). Additionally, the interface gains a `Vault` and `Store` type, which can be created on a client. In this interface, it's unambiguous whether you operate on a store or a vault, and the interface is easier to read and reason about. For example, it's clear which client a store or vault belongs to, while in the current interface one has to find the last call to `switch_actor_target` to find out.
3. In the current approach, the `ReadFromSnapshot` actor message does two things: find the actor state of the passed `client_id` in the in-memory snapshot state and return it, or read the snapshot state from file into memory and then return the actor state. These two concerns can be separated into separate actor messages. In the refactored interface, `Stronghold::read_snapshot` reads the file from disk, requiring the key for decryption. Then, a client can call `Client::restore_state` to copy the data from the snapshot into the actor, but without requiring the password. Now the password is only required until the snapshot has been read. Any subsequent call to `restore_state` uses what is already in-memory. If someone actually needs to read actor states from different snapshots, they have to call `Stronghold::read_snapshot` and `Client::restore_state` multiple times, which is roughly the same amount of effort as the current interface requires - and that seems fine. Crucially, this approach makes life much simpler for those that only use a single snapshot (like identity.rs and (I believe) wallet.rs).

So those are all the nice parts about the refactor. What follows are the challenging parts.

## Actor state

If actors are referenced from `Client`s, then once all clients have gone away, we would like to also remove the actor from the `Registry`, simply to clean up and reduce the number of `GetData` and `FillSnapshot` roundtrips we need to make when writing a snapshot. I went through several ideas before arriving at something that was sort of acceptable.
The registry ideally only holds active actors. In the current interface, it's the user's responsibility to spawn and kill actors when appropriate. With the introduction of the `Client`, we cannot explicitly kill an actor by implementing something like `fn kill(self)` on `Client`, because one can get multiple `Client`s backed by the same actor from stronghold using `Stronghold::client`. So it's always possible to have multiple clients that use the same underlying actor. If a `Client` represents a running actor and we have `let client2 = client1.clone()`, then `client1.kill()` would leave a `client2` in an undefined state. Here are some ideas to fix that, and the problems with those...

1. However we detect it, when the last client (internally holding an `Addr`) to an actor is cleaned up, we would like to write the actor's data to the `SnapshotState`. Then, `write_snapshot` only needs to take the data and write it to disk. By only storing `WeakAddr`s in the registry itself, all clients can hold strong references (`Addr`) to actors. (A weak address doesn't prevent an actor from being dropped, unless one or more strong `Addr`s are still held.) Even if we figure out when an appropriate time is to move the data from the actor to the snapshot, running it is very tricky. Due to the lack of an `AsyncDrop`, copying the data can only be done in the sync `Drop` impl. One idea is to send a single `do_send` (sync) message to the `Snapshot` actor, which itself gets the data from the actor and fills the snapshot. That also involves async operations in the sync `handle`, which I tried running with `ctx.wait` but ended up with a deadlock. Similarly, the same should be possible by implementing `Actor::stopping` and transfer the data there. Since that would have access to the actor itself, the data could be copied and sent off with `do_send`, however no errors could be handled. Considering that stronghold manages private keys, a solution needs to be more resilient. So even when `AsyncDrop` lands, the lack of error handling or being able to return them, remains a problem.
2. Another option is to use strong references in the registry and make us of weak addresses to figure out what actors are still alive. During `write_snapshot`, all addresses in the registry are downgraded to `WeakAddr`s, and then attempted to be upgraded to strong addresses again. If the upgrade fails, we know that no other references to the actor exist and we can remove the client from the registry. Because the registry stores strong addresses, even if all `Client`s for an actor have gone away, the data isn't lost. `write_snapshot` writes the data to disk, and only then allows the unreferenced actors to be deallocated. The cool part is that the user doesn't need to explicitly kill an actor, and can't forget to kill it, it is automatically dropped as soon as it's no longer needed. This is basically the lazy version of option 1.
   This solution technically works, but it requires the `Stronghold` to not be `Clone` and `write_snapshot` to take `&mut self`. From my understanding, the down- and upgrading cannot be done on the actor thread, because an actor handler is an atomic operation from actix' point of view, and thus the actix runner will never observe that the last reference to an actor has been removed; preventing deallocation. This means the down- and upgrading needs to happen outside the actor thread, i.e. within `Stronghold::write_snapshot`, but in one atomic operation. That's why `&mut self` and the absence of `Clone` are required.
3. Live with the downsides of option 2, i.e. the non-cloneable `Stronghold`, and let users deal with it. They will have to wrap it in an `Arc<Mutex<Stronghold>>` in order to use it concurrently. Single-threaded users on the other hand don't have to deal with it specially. Since one of the primary reasons for doing all this was to make stronghold easier to use from concurrent contexts, I'm not super happy about this. I still think it would be an overall improvement, though, because once a `Client` has been obtained, that client can be used from any task or thread. (This is the currently implemented solution.)
4. Option 2, but add an internal lock to `Stronghold` itself and take care of the problem for the users. We need to lock whenever we do an operation that involves clients, so in `Stronghold::client` and `Stronghold::write_snapshot`. 
5. Don't bother dealing with all that automatic handling of copying actor state to snapshots and let users deal with it explicitly. That is, they have to remember to call `client.save_state()` when they want state to be persisted. This is simple to implement for the library, but seems like a footgun and makes stronghold harder to use correctly.

## Procedures

In the example, there is a new type called `VaultLocation`. It is basically a `Location` but without the `vault_path`, because that is implicit when we call `Vault::write`, for example. The procedures all use `Location`, and it's much harder to replace those occurrences. It would be nice if we could call `vault.execute_procedure(...)` with procedures that only contain `VaultLocation`s and the `Location` is figured out from the vault context. I haven't looked into how procedures work in detail, but one way to do it may be by injecting the vault path into the `State` and requiring the procedures to call `State::location(&self, vault_location: VaultLocation) -> Location` in order to convert it. Admittedly, slightly more annoying to code. If procedures are contained to one vault, then "cross-vault" procedures would no longer be possible, at least not trivially. So if it was ever a feature, for example, to be able to read from vault1 and write into vault2, then this would not be a viable API.

Alternatively, the `execute_procedure` method can move to the `Client`, and work exactly like it currently does. API-wise it's a bit confusing to have `VaultLocation` *and* `Location` in the public interface, but it would work.

## Remote

This is the part I looked into the least, for time reasons. I believe most of the p2p management methods could probably work the same as it does now. There doesn't seem to be an explicit way to spawn an actor on a remote stronghold, so I'm unsure if a `RemoteClient`, `RemoteVault` and `RemoteStore` are feasible. In my opinion, it's fine if the remote and non-remote APIs do not exactly mirror each other. I would imagine, though, that a `RemoteClient` would be a nice encapsulation for policies. For example, a `Stronghold::remote_client` method would only return a `RemoteClient` instance if the current peer has access according to the policies.

Slightly related: The current remote methods like `write_remote_vault` are part of the `Stronghold` type and seem to be only additional features, but not standalone ones. Maybe I've missed something, but that wouldn't compile to Wasm, because it would also compile the entire stronghold library. Ideally, the library itself would also be feature-gated, and the p2p feature could be enabled by itself, so we could use a `RemoteStronghold` type that only requires `stronghold-p2p`.

### More Open Questions

- When I said the new interface has practically the same functionality as the current API, this is what I mean: There is this `former_client_path` feature in `read_snapshot`. I'm very unsure what this is useful for, but this is no longer present in the new API. `read_snapshot(client_path0, Some(client_path1), ...)` seems to simply act as if `read_snapshot(client_path1, None, ...)` had been called.

Most of what I propose can be built on top of the current interface, but with increased complexity and less performance. If nothing else, what I would _really_ like to see merged is the restore state functionality without requiring the password. Also, this is obviously not a ready-to-merge PR, as the P2P stuff is completely unaddressed at the moment. It is primarily meant to inspire discussion.

Disclaimer: I want to improve stronghold and figured instead of just giving feedback, I'll try to improve it myself, because I know you are busy with other things right now. I worked on this partly for fun, partly to learn more about stronghold internals, and partly to make life over in identity.rs and wallet.rs simpler. Merging this would be a significant change somewhat shortly before 1.0, so I can understand if that is considered too risky. Put another way: I don't expect this to be merged, but would be happy nonetheless, if it was.

Looking forward to any thoughts or comments!

## Type of change

Choose a type of change, and delete any options that are not relevant.

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested

Added and modified tests in `interface_tests`.

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
