### PR TITLE
feat(client): add procedure for copying a record

### DIFF
--- a/.changes/client_procedures_copy-record.md
+++ b/.changes/client_procedures_copy-record.md
@@ -1,0 +1,5 @@
+---
+"iota-stronghold": patch
+---
+
+- [[PR 297](https://github.com/iotaledger/stronghold.rs/pull/297)] Add `CopyRecord` procedure.

--- a/client/src/procedures.rs
+++ b/client/src/procedures.rs
@@ -5,9 +5,9 @@ mod primitives;
 mod types;
 
 pub use primitives::{
-    AeadAlg, AeadDecrypt, AeadEncrypt, BIP39Generate, BIP39Recover, Chain, ChainCode, Ed25519Sign, GenerateKey, Hash,
-    HashType, Hkdf, Hmac, KeyType, MnemonicLanguage, Pbkdf2Hmac, PrimitiveProcedure, PublicKey, Sha2Hash, Slip10Derive,
-    Slip10Generate, X25519DiffieHellman,
+    AeadAlg, AeadDecrypt, AeadEncrypt, BIP39Generate, BIP39Recover, Chain, ChainCode, CopyRecord, Ed25519Sign,
+    GenerateKey, Hash, HashType, Hkdf, Hmac, KeyType, MnemonicLanguage, Pbkdf2Hmac, PrimitiveProcedure, PublicKey,
+    Sha2Hash, Slip10Derive, Slip10Generate, X25519DiffieHellman,
 };
 pub use types::{
     CollectedOutput, FatalProcedureError, InputData, OutputKey, PersistOutput, PersistSecret, Procedure,


### PR DESCRIPTION
# Description of change

Add procedure for copying a secret from one location to another.
See #283 for more info; cc @PhilippGackstatter.

## Links to any relevant issues

Fixes issue #283 

## Type of change

- [x] Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Added test `procedure_tests::usecase_move_record`.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
