### PR TITLE
Client: document restriction for the amount of used vaults

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -66,7 +66,7 @@ p2p = ["stronghold-p2p", "futures"]
 [dev-dependencies]
 hex = "0.4.2"
 criterion = { version = "0.3.3", features = ["async_tokio"] }
-clap = { version = "3.0.0-beta.5", features = [ "yaml" ] }
+clap = { version = "3.0.0-rc.4", features = ["derive"]}
 tokio = {version = "1.9", features = ["rt-multi-thread"] }
 
 [[example]]

--- a/client/examples/cli/arguments.rs
+++ b/client/examples/cli/arguments.rs
@@ -20,7 +20,7 @@ pub struct ExampleApp {
 pub enum Commands {
     #[clap(about = "Write data to the unencrypted cache store")]
     Write {
-        #[clap(long, short = 'p', required = true, about = "the value you want to store.")]
+        #[clap(long, short = 'p', required = true, help = "the value you want to store.")]
         plain: String,
 
         #[clap(long, short = 'r', required = true)]
@@ -30,7 +30,7 @@ pub enum Commands {
             long,
             short = 'w',
             required = true,
-            about = "the password you want to use to encrypt/decrypt the snapshot."
+            help = "the password you want to use to encrypt/decrypt the snapshot."
         )]
         pass: String,
     },
@@ -46,7 +46,7 @@ pub enum Commands {
             long,
             short = 'w',
             required = true,
-            about = "the password you want to use to encrypt/decrypt the snapshot."
+            help = "the password you want to use to encrypt/decrypt the snapshot."
         )]
         pass: String,
     },
@@ -59,7 +59,7 @@ pub enum Commands {
             long,
             short = 'w',
             required = true,
-            about = "the password for the snapshot you want to load."
+            help = "the password for the snapshot you want to load."
         )]
         pass: String,
     },
@@ -67,7 +67,7 @@ pub enum Commands {
         about = "Lists the ids of the records inside of your stronghold's vault; lists the record path and the hint hash."
     )]
     List {
-        #[clap(long, short = 'w', required = true, about = "the password for the snapshot.")]
+        #[clap(long, short = 'w', required = true, help = "the password for the snapshot.")]
         pass: String,
 
         #[clap(long, short = 'r', required = true)]
@@ -75,7 +75,7 @@ pub enum Commands {
     },
     #[clap(about = "Read the data from a record in the unencrypted store.")]
     Read {
-        #[clap(long, short = 'w', required = true, about = "The password for the snapshot.")]
+        #[clap(long, short = 'w', required = true, help = "The password for the snapshot.")]
         pass: String,
 
         #[clap(long, short = 'r', required = true)]
@@ -91,10 +91,10 @@ pub enum Commands {
     },
     #[clap(about = "Revoke a record from the vault.")]
     Revoke {
-        #[clap(long = "pass", short = 'w', required = true, about = "The password for the snapshot")]
+        #[clap(long = "pass", short = 'w', required = true, help = "The password for the snapshot")]
         password: String,
 
-        #[clap(long = "record_path", short = 'i', required = true, about = "The id of the entry")]
+        #[clap(long = "record_path", short = 'i', required = true, help = "The id of the entry")]
         id: String,
     },
 
@@ -103,23 +103,18 @@ pub enum Commands {
         about = "Garbage collect the vault and remove revoked records."
     )]
     GarbageCollect {
-        #[clap(long, short = 'w', required = true, about = "The password for the snapshot.")]
+        #[clap(long, short = 'w', required = true, help = "The password for the snapshot.")]
         pass: String,
 
-        #[clap(long, short = 'i', required = true, about = "The id of the entry")]
+        #[clap(long, short = 'i', required = true, help = "The id of the entry")]
         id: String,
     },
     #[clap(about = "Revoke a record by id and perform a gargbage collect.")]
     Purge {
-        #[clap(long = "id", short = 'i', required = true, about = "The id of the entry")]
+        #[clap(long = "id", short = 'i', required = true, help = "The id of the entry")]
         id: String,
 
-        #[clap(
-            long = "pass",
-            short = 'w',
-            required = true,
-            about = "The password for the snapshot."
-        )]
+        #[clap(long = "pass", short = 'w', required = true, help = "The password for the snapshot.")]
         password: String,
     },
 
@@ -128,7 +123,7 @@ pub enum Commands {
         about = "Take ownership of an existing chain to give it to a new user."
     )]
     TakeOwnership {
-        #[clap(long = "pass", short = 'w', required = true, about = "The password for the snapshot")]
+        #[clap(long = "pass", short = 'w', required = true, help = "The password for the snapshot")]
         password: String,
     },
 }

--- a/client/examples/p2p/arguments.rs
+++ b/client/examples/p2p/arguments.rs
@@ -33,7 +33,7 @@ pub enum Commands {
         #[clap(
             long = "multiaddr",
             short = 'm',
-            about = r#"The multiaddress to listen on. Format "(/<protoName string>/<value string>)+" "#
+            help = r#"The multiaddress to listen on. Format "(/<protoName string>/<value string>)+" "#
         )]
         multiaddr: String,
     },

--- a/client/src/actors/p2p.rs
+++ b/client/src/actors/p2p.rs
@@ -281,7 +281,7 @@ impl_handler!(RemoveDialingRelay => bool, |network, msg| {
 /// - [`Mdns`][`libp2p::mdns`] protocol is disabled. **Note**: Enabling mdns will broadcast our own address and id to
 ///   the local network.
 /// - [`Relay`][`libp2p::relay`] functionality is disabled.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct NetworkConfig {
     request_timeout: Option<Duration>,
     connection_timeout: Option<Duration>,
@@ -331,19 +331,6 @@ impl NetworkConfig {
     pub fn load_state(mut self, state: BehaviourState<ShRequest>) -> Self {
         self.state = Some(state);
         self
-    }
-}
-
-impl Default for NetworkConfig {
-    fn default() -> Self {
-        NetworkConfig {
-            request_timeout: None,
-            connection_timeout: None,
-            connections_limit: None,
-            enable_mdns: false,
-            enable_relay: false,
-            state: None,
-        }
     }
 }
 

--- a/client/src/tests/basic_tests.rs
+++ b/client/src/tests/basic_tests.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{utils::LoadFromPath, Location, RecordHint, Stronghold};
+use crate::{state::secure::SecureClient, utils::LoadFromPath, Location, RecordHint, Stronghold};
 use crypto::macs::hmac::HMAC_SHA512;
 
 use engine::vault::{ClientId, VaultId};
@@ -187,6 +187,16 @@ async fn test_write_read_snapshot() {
             .await
             .unwrap_or_else(|e| panic!("Actor error: {}", e))
             .unwrap_or_else(|e| panic!("Write vault error: {}", e));
+    }
+
+    let ids = stronghold.list_hints_and_ids("path").await.unwrap();
+
+    for i in 0..20 {
+        let loc = Location::counter::<_, usize>("path", i);
+        let expect_id = SecureClient::resolve_location(loc).1;
+        let (_, hint) = ids.iter().find(|(id, _)| *id == expect_id).unwrap();
+        let expect_hint = RecordHint::new(format!("test {:?}", i)).unwrap();
+        assert_eq!(*hint, expect_hint);
     }
 
     stronghold

--- a/client/src/utils/types.rs
+++ b/client/src/utils/types.rs
@@ -8,6 +8,12 @@ use serde::{Deserialize, Serialize};
 /// be used to get the head of the version chain by passing in `None` as the counter index. Otherwise, counter records
 /// are referenced through their associated index.  On Read, the `None` location is the latest record in the version
 /// chain while on Write, the `None` location is the next record in the version chain.
+///
+/// **Note: For each used vault an encryption key is created and protected through the [libsodium](https://doc.libsodium.org/memory_management)
+/// memory protection API. Many systems place limits on the amount of memory that may be locked by a process, which may
+/// result in the system panicking if the upper bound is reached!
+/// For users that write a large number of secrets into Stronghold, we strongly advise against writing each record in a
+/// separate vault, but instead group them into a limited number of different vaults.**
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum Location {
     Generic { vault_path: Vec<u8>, record_path: Vec<u8> },

--- a/engine/runtime/src/types.rs
+++ b/engine/runtime/src/types.rs
@@ -1,6 +1,8 @@
 // Copyright 2020-2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+#![allow(clippy::missing_safety_doc)]
+
 mod bytes;
 mod const_eq;
 mod rand;

--- a/engine/src/snapshot/compression/decoder.rs
+++ b/engine/src/snapshot/compression/decoder.rs
@@ -93,7 +93,7 @@ impl<'a> Lz4Decoder<'a> {
             literal += self.read_int()?;
         }
 
-        Self::output(&mut self.output, Self::take_internal(&mut self.input, literal)?);
+        Self::output(self.output, Self::take_internal(&mut self.input, literal)?);
 
         Ok(())
     }

--- a/p2p/src/behaviour/addresses.rs
+++ b/p2p/src/behaviour/addresses.rs
@@ -29,7 +29,7 @@ impl Default for PeerAddress {
 }
 
 // Known relays and peer addresses.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(try_from = "SerdeAddressInfo")]
 #[serde(into = "SerdeAddressInfo")]
 pub struct AddressInfo {
@@ -38,15 +38,6 @@ pub struct AddressInfo {
 
     // Known relays to use as fallback for dialing.
     pub relays: SmallVec<[PeerId; 10]>,
-}
-
-impl Default for AddressInfo {
-    fn default() -> Self {
-        AddressInfo {
-            peers: HashMap::new(),
-            relays: SmallVec::new(),
-        }
-    }
 }
 
 impl AddressInfo {

--- a/p2p/src/behaviour/request_manager/connections.rs
+++ b/p2p/src/behaviour/request_manager/connections.rs
@@ -7,21 +7,12 @@ use std::collections::{hash_map::HashMap, HashSet};
 use wasm_timer::Instant;
 
 // Sent requests that have not yet received a response.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct PendingResponses {
     // Outbound request sent to remote, waiting for an inbound response.
     pub outbound_requests: HashSet<RequestId>,
     // Inbound requests received from remote, waiting for an outbound response.
     pub inbound_requests: HashSet<RequestId>,
-}
-
-impl Default for PendingResponses {
-    fn default() -> Self {
-        PendingResponses {
-            outbound_requests: Default::default(),
-            inbound_requests: Default::default(),
-        }
-    }
 }
 
 /// Information about the connection with a remote peer as maintained in the ConnectionManager.
@@ -41,7 +32,7 @@ impl Default for EstablishedConnections {
 }
 
 // Active connections to a remote peer and pending responses on each connection.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct PeerConnectionManager {
     // Currently active connections for each peer.
     established: HashMap<PeerId, EstablishedConnections>,
@@ -51,10 +42,7 @@ pub struct PeerConnectionManager {
 
 impl PeerConnectionManager {
     pub fn new() -> Self {
-        PeerConnectionManager {
-            established: Default::default(),
-            pending_responses: Default::default(),
-        }
+        PeerConnectionManager::default()
     }
 
     // Check if the local peer currently has at least one active connection to the remote.

--- a/products/commandline/Cargo.toml
+++ b/products/commandline/Cargo.toml
@@ -12,7 +12,7 @@ license = "Apache-2.0"
 readme = "README.md"
 
 [dependencies]
-clap = { version = "3.0.0-beta.5", features = [ "yaml" ] }
+clap = { version = "2.34.0", features = [ "yaml" ] }
 futures = "0.3"
 bincode = "1.3.1"
 serde = { version = "1.0.114", features = [ "derive" ] }

--- a/products/commandline/src/cli.yml
+++ b/products/commandline/src/cli.yml
@@ -10,7 +10,7 @@ subcommands:
             short: p
             long: plain
             value_name: plaintext
-            about: a plaintext value that you want to encrypt.
+            help: a plaintext value that you want to encrypt.
             required: true
             takes_value: true
         - rpath:
@@ -23,7 +23,7 @@ subcommands:
             short: w
             long: pass
             value_name: password
-            about: the password you want to use to encrypt/decrypt the snapshot.
+            help: the password you want to use to encrypt/decrypt the snapshot.
             required: true
             takes_value: true
   - write:
@@ -33,7 +33,7 @@ subcommands:
             short: p
             long: plain
             value_name: plaintext
-            about: a value you want to store. 
+            help: a value you want to store. 
             required: true
             takes_value: true
         - rpath:
@@ -46,7 +46,7 @@ subcommands:
             short: w
             long: pass
             value_name: password
-            about: the password you want to use to encrypt/decrypt the snapshot.
+            help: the password you want to use to encrypt/decrypt the snapshot.
             required: true
             takes_value: true
   - snapshot:
@@ -61,7 +61,7 @@ subcommands:
         - password:
             short: w
             long: pass
-            about: the password for the snapshot you want to load.
+            help: the password for the snapshot you want to load.
             required: true
             takes_value: true
   - list:
@@ -71,7 +71,7 @@ subcommands:
             short: w
             long: pass
             value_name: password
-            about: the password for the snapshot.
+            help: the password for the snapshot.
             required: true
             takes_value: true
         - rpath:
@@ -88,7 +88,7 @@ subcommands:
             short: w
             long: pass
             value_name: password
-            about: the password for the snapshot.
+            help: the password for the snapshot.
             required: true
             takes_value: true
         - rpath:
@@ -104,14 +104,14 @@ subcommands:
             short: w
             long: pass
             value_name: password
-            about: the password for the snapshot.
+            help: the password for the snapshot.
             required: true
             takes_value: true
         - rpath:
             short: rid
             long: record_path
             value_name: id
-            about: the id of the entry
+            help: the id of the entry
             required: true
             takes_value: true
   - garbage_collect:
@@ -121,14 +121,14 @@ subcommands:
             short: w
             long: pass
             value_name: password
-            about: the password for the snapshot.
+            help: the password for the snapshot.
             required: true
             takes_value: true
         - rpath:
             short: rid
             long: record_path
             value_name: id
-            about: the id of the entry
+            help: the id of the entry
             required: true
             takes_value: true
   - purge:
@@ -138,13 +138,13 @@ subcommands:
             short: w
             long: pass
             value_name: password
-            about: the password for the snapshot.
+            help: the password for the snapshot.
             required: true
             takes_value: true
         - id:
             short: i
             long: id
             value_name: id
-            about: the id of the entry
+            help: the id of the entry
             required: true
             takes_value: true


### PR DESCRIPTION
# Description of change

Follow up on issue #268: for now add a comment to the code to document that there is an upper bound for the number of vaults that can be used. Eventually it should check during runtime if the upper bound of locked memory is reached **before** trying to lock additional memory.

Apart from that add some smaller fixes more `procedure_tests` and deals with clippy v0.1.57.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- [x] Bug fix (a non-breaking change which fixes an issue)
- [x] Documentation Fix
