### PR TITLE
P2p: add examples and improve docs

### DIFF
--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -54,7 +54,7 @@ pub use engine::{
 pub mod p2p {
     pub use crate::{
         actors::{
-            network_messages::{ShRequest, SwarmInfo},
+            network_messages::{ShRequest, ShResult, SwarmInfo},
             NetworkConfig,
         },
         interface::{P2pError, P2pResult, SpawnNetworkError},

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -33,6 +33,8 @@ default = [ "tcp-transport"]
 tcp-transport = ["libp2p/tcp-tokio", "libp2p/dns-tokio", "libp2p/websocket"]
 
 [dev-dependencies]
-stronghold-utils = { path = "../utils", version = "0.3" }
+actix-rt = "2.5"
+iota_stronghold = { path = "../client" , features = ["p2p"]}
+stronghold-utils = { path = "../utils"}
 tokio = {version = "1.10", features = ["time", "macros", "io-std", "io-util"]}
 libp2p = { version = "0.41.0", default-features = false, features = ["tcp-tokio"] }

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -19,7 +19,6 @@ either = "1.6"
 futures = "0.3"
 libp2p = { version = "0.41.0", default-features = false, features = ["noise", "yamux", "mdns", "relay"] }
 pin-project = "1.0.8"
-regex = "1.5"
 serde = { version = "1.0", default-features = false, features = [ "alloc", "derive" ] }
 serde_json = { version = "1.0", default-features = false, features = [ "alloc" ] }
 smallvec = "1.6.1"
@@ -35,6 +34,7 @@ tcp-transport = ["libp2p/tcp-tokio", "libp2p/dns-tokio", "libp2p/websocket"]
 [dev-dependencies]
 actix-rt = "2.5"
 iota_stronghold = { path = "../client" , features = ["p2p"] }
+regex = "1.5"
 stronghold-utils = { path = "../utils", version = "0.3.0" }
 tokio = {version = "1.10", features = ["time", "macros", "io-std", "io-util"] }
 libp2p = { version = "0.41.0", default-features = false, features = ["tcp-tokio"] }

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -19,6 +19,7 @@ either = "1.6"
 futures = "0.3"
 libp2p = { version = "0.41.0", default-features = false, features = ["noise", "yamux", "mdns", "relay"] }
 pin-project = "1.0.8"
+regex = "1.5"
 serde = { version = "1.0", default-features = false, features = [ "alloc", "derive" ] }
 serde_json = { version = "1.0", default-features = false, features = [ "alloc" ] }
 smallvec = "1.6.1"
@@ -33,5 +34,5 @@ tcp-transport = ["libp2p/tcp-tokio", "libp2p/dns-tokio", "libp2p/websocket"]
 
 [dev-dependencies]
 stronghold-utils = { path = "../utils", version = "0.3" }
-tokio = {version = "1.10", features = ["time", "macros"]}
+tokio = {version = "1.10", features = ["time", "macros", "io-std", "io-util"]}
 libp2p = { version = "0.41.0", default-features = false, features = ["tcp-tokio"] }

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -34,7 +34,7 @@ tcp-transport = ["libp2p/tcp-tokio", "libp2p/dns-tokio", "libp2p/websocket"]
 
 [dev-dependencies]
 actix-rt = "2.5"
-iota_stronghold = { path = "../client" , features = ["p2p"]}
-stronghold-utils = { path = "../utils"}
-tokio = {version = "1.10", features = ["time", "macros", "io-std", "io-util"]}
+iota_stronghold = { path = "../client" , features = ["p2p"] }
+stronghold-utils = { path = "../utils", version = "0.3.0" }
+tokio = {version = "1.10", features = ["time", "macros", "io-std", "io-util"] }
 libp2p = { version = "0.41.0", default-features = false, features = ["tcp-tokio"] }

--- a/p2p/examples/dynamic-firewall.rs
+++ b/p2p/examples/dynamic-firewall.rs
@@ -103,9 +103,11 @@ async fn on_user_input(
     input: String,
 ) -> Result<(), Box<dyn Error>> {
     let peer_regex = "-p\\s+(?P<target>[[:alnum:]]{32,64})";
-    let peer: PeerId = match Regex::new(peer_regex).expect("Valid regex").captures(&input) {
+    let peer: PeerId = match Regex::new(peer_regex).expect("Valid regex.").captures(&input) {
         Some(capture) => {
-            let target = capture.name("target").expect("Target was captured.");
+            let target = capture
+                .name("target")
+                .expect("Regex should only match strings with a 'target' capture group.");
             match PeerId::from_str(target.as_str()) {
                 Ok(id) => id,
                 Err(_) => {
@@ -120,9 +122,12 @@ async fn on_user_input(
         }
     };
     let type_regex = "-m (?P<msg>\"[^\"]*\"|\\S+)";
-    let request = match Regex::new(type_regex).expect("Valid regex").captures(&input) {
+    let request = match Regex::new(type_regex).expect("Valid regex.").captures(&input) {
         Some(capture) => {
-            let msg = capture.name("msg").expect("Message was captured.").as_str();
+            let msg = capture
+                .name("msg")
+                .expect("Regex should only match strings with a 'msg' capture group.")
+                .as_str();
             Request::Message(msg.into())
         }
         None => Request::Ping,

--- a/p2p/examples/dynamic-firewall.rs
+++ b/p2p/examples/dynamic-firewall.rs
@@ -74,6 +74,8 @@ use serde::{Deserialize, Serialize};
 use std::{borrow::Borrow, error::Error, marker::PhantomData, str::FromStr, time::Duration};
 use tokio::io::{stdin, AsyncBufReadExt, BufReader, Lines, Stdin};
 
+const RETRY_USER_INPUT_MAX: usize = 3;
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, RequestPermissions)]
 enum Request {
     Ping,
@@ -205,7 +207,7 @@ async fn on_firewall_request(
                     }
                     _ => {
                         tries += 1;
-                        if tries < 3 {
+                        if tries < RETRY_USER_INPUT_MAX {
                             println!("Invalid input. Please enter one of the following: yes/no/ask/ping")
                         } else {
                             println!("Invalid input. Aborting.");
@@ -235,7 +237,7 @@ async fn on_firewall_request(
                     "no" => break approval_tx.send(false).unwrap(),
                     _ => {
                         tries += 1;
-                        if tries < 3 {
+                        if tries < RETRY_USER_INPUT_MAX {
                             println!("Invalid input. Please enter one of the following: yes/no")
                         } else {
                             println!("Invalid input. Aborting.");

--- a/p2p/examples/dynamic-firewall.rs
+++ b/p2p/examples/dynamic-firewall.rs
@@ -1,0 +1,279 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! This example demonstrates a dynamic usage of the Stronghold-P2p firewall.
+//! Instead setting fixed rules, it dynamically asks the user to set firewall rules for each peer that connects.
+//!
+//! There are two different types of requests we can send to a remote:
+//! - Ping: `-p <remote-peer-id>` -> A Pong will automatically be sent back as response
+//! - Message `-p <remote-peer-id> -m <message>` -> Remote has 20s time to type a response message.
+//!
+//! Per default all outbound requests are permitted, and no rules are set for inbound requests.
+//! When a Alice then would like to send a request to Bob for the first time, Bob is prompted to set
+//! a general firewall rule for requests from Alice. The following options are provided
+//! - yes: Permit all requests from Alice
+//! - no: Reject all requests from Alice
+//! - ping: Only allow type _Ping_, but not _Message_.
+//! - ask: Ask for individual approval for each request
+//! In case of ask, Bob will be prompted for each request, including the current one, to manually approve or
+//! reject.
+//!
+//! To test this example, run it in two terminal windows T1 & T2.
+//! It will each print the peer id of the local peer, which can be used to reach this peer.
+//! T1:
+//! ```sh
+//! Local Peer Id: 12D3KooWRgJG7no2snYqGM8jwABTs952KFb6GHghzz1vRw7T5Cmd
+//! ```
+//! T2:
+//! ```sh
+//! Local Peer Id: 12D3KooWG364edSdRCv5LG5adzsAdE3vafYqc5rGHCYpvT7dmHPa
+//! ```
+//!
+//! Because mDNS is enabled in this example, peers aromatically learn the listening addresses of other peers
+//! in the same network, that is used to dial this peer.
+//!
+//!
+//! In T1 run
+//! ```sh
+//! -p 12D3KooWG364edSdRCv5LG5adzsAdE3vafYqc5rGHCYpvT7dmHPa -m "test message"
+//! ```
+//! the id being the one that was printed in T2.
+//!
+//! In the second terminal, it will ask for the firewall rules:
+//! T2:
+//! ```sh
+//! Peer 12D3KooWRgJG7no2snYqGM8jwABTs952KFb6GHghzz1vRw7T5Cmd connected. Allow requests from them?: (yes/no/ask/ping)
+//! > ask
+//!
+//! # Ask for individual approval due to rule "Ask"
+//! Received Request with type Message from peer 12D3KooWRgJG7no2snYqGM8jwABTs952KFb6GHghzz1vRw7T5Cmd. Permit?: (yes/no)
+//! > yes
+//!
+//! # The actual message is shown
+//! Received Message from peer 12D3KooWRgJG7no2snYqGM8jwABTs952KFb6GHghzz1vRw7T5Cmd:
+//! "test message".
+//! > test response
+//! ```
+//!
+//! The response will then be printed in T1:
+//! ```sh
+//! Response: test response
+//! ```
+//! Note: While waiting for a response T1 is blocking.
+
+use futures::{channel::mpsc, FutureExt, StreamExt};
+use p2p::{
+    firewall::{
+        permissions::{FirewallPermission, PermissionValue, RequestPermissions, VariantPermission},
+        FirewallRequest, FirewallRules, Rule,
+    },
+    ChannelSinkConfig, EventChannel, PeerId, ReceiveRequest, RequestDirection, StrongholdP2p,
+};
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+use std::{borrow::Borrow, error::Error, marker::PhantomData, str::FromStr, time::Duration};
+use tokio::io::{stdin, AsyncBufReadExt, BufReader, Lines, Stdin};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, RequestPermissions)]
+enum Request {
+    Ping,
+    Message(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+enum Response {
+    Pong,
+    Message(String),
+}
+
+// Permit only messages of type "Ping". See `p2p::firewall:permissions` module for more info.
+fn allow_only_ping(request: &RequestPermission) -> bool {
+    let allowed_variant = FirewallPermission::none().add_permissions([&RequestPermission::Ping.permission()]);
+    allowed_variant.permits(&request.permission())
+}
+
+// Handle user input through stdin.
+// Expect either of:
+// - `-p <peer-id>`: Send a ping
+// - `-p <peer-id> -m <message>`: Send a message
+async fn on_user_input(
+    stronghold: &mut StrongholdP2p<Request, Response, RequestPermission>,
+    input: String,
+) -> Result<(), Box<dyn Error>> {
+    let peer_regex = "-p\\s+(?P<target>[[:alnum:]]{32,64})";
+    let peer: PeerId = match Regex::new(peer_regex).expect("Valid regex").captures(&input) {
+        Some(capture) => {
+            let target = capture.name("target").expect("Target was captured.");
+            match PeerId::from_str(target.as_str()) {
+                Ok(id) => id,
+                Err(_) => {
+                    println!("Invalid Peer Id");
+                    return Ok(());
+                }
+            }
+        }
+        None => {
+            println!("Please include a target via \"-p <peer-id>\"");
+            return Ok(());
+        }
+    };
+    let type_regex = "-m (?P<msg>\"[^\"]*\"|\\S+)";
+    let request = match Regex::new(type_regex).expect("Valid regex").captures(&input) {
+        Some(capture) => {
+            let msg = capture.name("msg").expect("Message was captured.").as_str();
+            Request::Message(msg.into())
+        }
+        None => Request::Ping,
+    };
+    // Send request and wait for response
+    match stronghold.send_request(peer, request).await {
+        Ok(res) => match res {
+            Response::Pong => println!("Pong"),
+            Response::Message(msg) => println!("Response: {}", msg),
+        },
+        Err(e) => println!("Request failed: {}", e),
+    }
+    Ok(())
+}
+
+// Handle an approved inbound request.
+async fn on_inbound_request(
+    stdin: &mut Lines<BufReader<Stdin>>,
+    request: ReceiveRequest<Request, Response>,
+) -> Result<(), Box<dyn Error>> {
+    let ReceiveRequest {
+        peer,
+        request,
+        response_tx,
+        ..
+    } = request;
+    match request {
+        Request::Ping => {
+            println!("Received Ping from peer {}.", peer);
+            // Send Pong back.
+            match response_tx.send(Response::Pong) {
+                Ok(()) => println!("Sent Pong back."),
+                Err(_) => println!("Sending Pong back failed."),
+            }
+        }
+        Request::Message(msg) => {
+            println!("Received Message from peer {}:\n{}.", peer, msg);
+            futures::select_biased! {
+                stdin_input = stdin.next_line().fuse() => {
+                    let line = stdin_input?.unwrap_or_default();
+                    // Send response message back.
+                    match response_tx.send(Response::Message(line)) {
+                        Ok(()) => println!("Sent message back."),
+                        Err(_) => println!("Sending message back failed.")
+                    }
+                }
+                _ = tokio::time::sleep(Duration::from_secs(20)).fuse() => {
+                    println!("Timeout sending a response.");
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+// Handle a request from the firewall to ask for rules or individual approval.
+async fn on_firewall_request(
+    stdin: &mut Lines<BufReader<Stdin>>,
+    request: FirewallRequest<RequestPermission>,
+) -> Result<(), Box<dyn Error>> {
+    match request {
+        // Ask for rules that should be set for inbound requests from this peer.
+        FirewallRequest::PeerSpecificRule { peer, rule_tx } => {
+            println!("Peer {} connected. Allow requests from them?: (yes/no/ask/ping)", peer);
+            let mut tries = 0;
+            loop {
+                // Return rule through `rule_tx` oneshot channel.
+                // This rule will now apply for all inbound requests from this peer.
+                // Skip setting a rule for outbound requests, as it is per default already set to `AllowAll`.
+                match stdin.next_line().await?.unwrap().as_str() {
+                    "yes" => break rule_tx.send(FirewallRules::new(Some(Rule::AllowAll), None)).unwrap(),
+                    "no" => break rule_tx.send(FirewallRules::new(Some(Rule::RejectAll), None)).unwrap(),
+                    "ask" => break rule_tx.send(FirewallRules::new(Some(Rule::Ask), None)).unwrap(),
+                    "ping" => {
+                        // Create rule that only permits ping-messages.
+                        let rule: Rule<RequestPermission> = Rule::Restricted {
+                            restriction: allow_only_ping,
+                            _maker: PhantomData,
+                        };
+                        rule_tx.send(FirewallRules::new(Some(rule), None)).unwrap();
+                        break;
+                    }
+                    _ => {
+                        tries += 1;
+                        if tries < 3 {
+                            println!("Invalid input. Please enter one of the following: yes/no/ask/ping")
+                        } else {
+                            println!("Invalid input. Aborting.");
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+        // Ask for individual approval of a request because `Rule::Ask` has been set
+        FirewallRequest::RequestApproval {
+            peer,
+            direction,
+            request,
+            approval_tx,
+        } => {
+            assert_eq!(direction, RequestDirection::Inbound);
+            println!(
+                "Received Request with type {:?} from peer {}. Permit?: (yes/no)",
+                request, peer
+            );
+            let mut tries = 0;
+            loop {
+                // Return response through `approval_tx` oneshot channel.
+                match stdin.next_line().await?.unwrap().as_str() {
+                    "yes" => break approval_tx.send(true).unwrap(),
+                    "no" => break approval_tx.send(false).unwrap(),
+                    _ => {
+                        tries += 1;
+                        if tries < 3 {
+                            println!("Invalid input. Please enter one of the following: yes/no")
+                        } else {
+                            println!("Invalid input. Aborting.");
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    // Channel for rule- / approval- requests from the firewall.
+    let (firewall_tx, mut firewall_rx) = mpsc::channel(10);
+    // Channel through which approved inbound requests are forwarded.
+    let (request_tx, mut request_rx) = EventChannel::new(10, ChannelSinkConfig::Block);
+
+    let mut stronghold = StrongholdP2p::new(firewall_tx, request_tx, None).await?;
+    stronghold.start_listening("/ip4/0.0.0.0/tcp/0".parse()?).await?;
+    println!("Local Peer Id: {}", stronghold.peer_id());
+
+    let mut stdin = BufReader::new(stdin()).lines();
+    loop {
+        futures::select! {
+            stdin_input = stdin.next_line().fuse() => match stdin_input? {
+                Some(line) => on_user_input(&mut stronghold, line).await?,
+                None => break,
+            },
+            request = request_rx.select_next_some() => {
+                on_inbound_request(&mut stdin, request).await?;
+            }
+            request = firewall_rx.select_next_some() => {
+                on_firewall_request(&mut stdin, request).await?;
+            }
+        }
+    }
+    Ok(())
+}

--- a/p2p/examples/stronghold.rs
+++ b/p2p/examples/stronghold.rs
@@ -1,0 +1,142 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! # Communication with a Stronghold server
+//!
+//! This example provides a basic PoC that shows how stronghold-p2p can be used to communicate with a remote
+//! Stronghold server, without a local Stronghold running.
+//!
+//! Note: because we are also mocking the remote stronghold, we need to use `actix_rt` as runtime. If the remote
+//! stronghold would actually run on a different system, the network of the local_client could use a any
+//! runtime.
+
+use futures::{
+    channel::{mpsc, oneshot},
+    FutureExt,
+};
+use iota_stronghold::Location;
+use p2p::{Multiaddr, PeerId};
+use std::error::Error;
+
+// Mock remote Stronghold
+mod remote_stronghold {
+    use super::*;
+    use futures::future::pending;
+    use iota_stronghold::{
+        p2p::{NetworkConfig, Rule},
+        Stronghold,
+    };
+
+    pub async fn run(address_tx: oneshot::Sender<(PeerId, Multiaddr)>) -> Result<(), Box<dyn Error>> {
+        let mut stronghold = Stronghold::init_stronghold_system("client".into(), Vec::new()).await?;
+        stronghold.spawn_p2p(NetworkConfig::default(), None).await?;
+        stronghold.set_firewall_rule(Rule::AllowAll, Vec::new(), true).await?;
+        let addr = stronghold.start_listening(None).await??;
+        let peer_id = stronghold.get_swarm_info().await?.local_peer_id;
+        address_tx.send((peer_id, addr)).unwrap();
+        println!("Started remote Stronghold.");
+        let _ = pending::<()>().await;
+        Ok(())
+    }
+}
+
+// Local client that is using the remote Stronghold to generate a key and sign messages.
+mod local_client {
+    use super::*;
+    use iota_stronghold::{
+        p2p::{ShRequest, ShResult},
+        procedures::{Ed25519Sign, GenerateKey, KeyType, OutputKey, PersistOutput, PersistSecret},
+        Location, RecordHint,
+    };
+    use p2p::{ChannelSinkConfig, EventChannel, StrongholdP2p};
+
+    async fn setup_network(
+        stronghold_id: PeerId,
+        stronghold_addr: Multiaddr,
+    ) -> Result<StrongholdP2p<ShRequest, ShResult>, Box<dyn Error>> {
+        let (firewall_tx, _) = mpsc::channel(0);
+        let (request_tx, _) = EventChannel::new(0, ChannelSinkConfig::Block);
+        let mut network = StrongholdP2p::new(firewall_tx, request_tx, None).await?;
+        // Add address info of remote Stronghold.
+        network.add_address(stronghold_id, stronghold_addr).await;
+        println!("\nStarted new client.");
+        Ok(network)
+    }
+
+    // Spawn new peer, connect to remote Stronghold and generate a new Ed25519 keypair.
+    pub async fn generate_key(
+        stronghold_id: PeerId,
+        stronghold_addr: Multiaddr,
+        location: Location,
+    ) -> Result<(), Box<dyn Error>> {
+        let mut network = setup_network(stronghold_id, stronghold_addr).await?;
+        println!("Generating new ed25519 keypair at location: {:?}", location);
+        let key_hint = RecordHint::new("key").unwrap();
+        let generate_key = GenerateKey::new(KeyType::Ed25519).write_secret(location, key_hint);
+        let res = network
+            .send_request(stronghold_id, ShRequest::Procedure(generate_key.into()))
+            .await?;
+        match res {
+            ShResult::Proc(res) => {
+                res?;
+            }
+            _ => unreachable!("ShRequest::Procedure always returns ShResult::Proc"),
+        }
+        Ok(())
+    }
+
+    // Spawn new peer, connect to remote Stronghold and use the previously generated keypair to sign a message.
+    pub async fn sign_message(
+        stronghold_id: PeerId,
+        stronghold_addr: Multiaddr,
+        location: Location,
+        message: String,
+    ) -> Result<(), Box<dyn Error>> {
+        let mut network = setup_network(stronghold_id, stronghold_addr).await?;
+        println!(
+            "Signing message {:?} with key stored in location: {:?}",
+            message, location
+        );
+        let msg_bytes: Vec<u8> = message.into();
+        let sign_message = Ed25519Sign::new(msg_bytes, location).store_output(OutputKey::new("signed"));
+        let res = network
+            .send_request(stronghold_id, ShRequest::Procedure(sign_message.into()))
+            .await?;
+        match res {
+            ShResult::Proc(res) => {
+                let signed: Vec<u8> = res?.single_output().unwrap();
+                println!("Signed message: {:?}", signed);
+                Ok(())
+            }
+            _ => unreachable!("ShRequest::Procedure always returns ShResult::Proc"),
+        }
+    }
+}
+
+#[actix_rt::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let (info_tx, info_rx) = oneshot::channel::<(PeerId, Multiaddr)>();
+    let local = async {
+        let (stronghold_id, stronghold_addr) = info_rx.await.unwrap();
+        let key_location = Location::generic("v0", "r0");
+        // Write a new key into the remote vault
+        local_client::generate_key(stronghold_id, stronghold_addr.clone(), key_location.clone())
+            .await
+            .unwrap();
+        // Use the generated key to sign multiple messages.
+        // In this example it is spawning a new client on each operations to demonstrate that they are stateless.
+        for i in 0..3 {
+            let message = format!("message {}", i);
+            local_client::sign_message(stronghold_id, stronghold_addr.clone(), key_location.clone(), message)
+                .await
+                .unwrap();
+        }
+    };
+    futures::select! {
+        // Run the local clients
+        _ = local.fuse() => {},
+        // Run the remote Stronghold
+        _ = remote_stronghold::run(info_tx).fuse() => {}
+    }
+    Ok(())
+}

--- a/p2p/src/behaviour/firewall.rs
+++ b/p2p/src/behaviour/firewall.rs
@@ -1,9 +1,8 @@
 // Copyright 2020-2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-mod permissions;
+pub mod permissions;
 use crate::{serde::SerdeFirewallConfig, RequestDirection};
-pub use permissions::*;
 
 use core::fmt;
 use futures::channel::oneshot;

--- a/p2p/src/behaviour/firewall/permissions.rs
+++ b/p2p/src/behaviour/firewall/permissions.rs
@@ -1,6 +1,75 @@
 // Copyright 2020-2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+//! Trait and macros that may be used in the firewall rule [`Rule::Restricted`] to restrict request
+//! enums based on the variant.
+//!
+//! A [`PermissionValue`] value is a u32 integer value that is some power of 2, e.g. 1, 2, 4, 8, ..etc.
+//! Following the same concept as Unix permissions multiple  [`PermissionValue`] can be added to a sum
+//! [`FirewallPermission`], that unambiguously identifies what [`PermissionValue`]s were set.
+//!
+//! The [`VariantPermission`] can be implemented for a request enum to give each variant a different
+//! [`PermissionValue`]. It can be derived with the [`RequestPermissions`] macro, which:
+//! 1. implements [`PermissionValue`] for the type
+//! 2. generates a trimmed version of the type (`<type-name>Permissions`) that has the same variants
+//!    but without values:
+//!
+//! ```
+//! # use p2p::{
+//! #   firewall::{
+//! #       permissions::{FirewallPermission, PermissionValue, RequestPermissions, VariantPermission},
+//! #       FirewallRules, Rule,
+//! #   },
+//! #   ChannelSinkConfig, EventChannel, StrongholdP2p, StrongholdP2pBuilder,
+//! # };
+//! # use futures::channel::mpsc;
+//! # use std::{borrow::Borrow, error::Error, marker::PhantomData};
+//! # use serde::{Serialize, Deserialize};
+//! # type MessageResponse = String;
+//! #
+//! # async fn test() -> Result<(), Box<dyn Error>> {
+//! // The derive macro generates:
+//! // ```
+//! // enum MessagePermission {
+//! //     Ping,
+//! //     Message,
+//! //     Other,
+//! // }
+//! // ```
+//! //
+//! #[derive(Debug, RequestPermissions, Serialize, Deserialize)]
+//! enum Message {
+//!     Ping,
+//!     Message(String),
+//!     Other(Vec<u8>),
+//! }
+//!
+//! assert_eq!(MessagePermission::Ping.permission(), 1);
+//! assert_eq!(MessagePermission::Message.permission(), 2);
+//! assert_eq!(MessagePermission::Other.permission(), 4);
+//!
+//! // Create rule that only permits ping-messages.
+//! let rule: Rule<MessagePermission> = Rule::Restricted {
+//!     restriction: |rq: &MessagePermission| {
+//!         let allowed_variant = FirewallPermission::none().add_permissions([&MessagePermission::Ping.permission()]);
+//!         allowed_variant.permits(&rq.permission())
+//!     },
+//!     _maker: PhantomData,
+//! };
+//!
+//! # let (firewall_tx, firewall_rx) = mpsc::channel(10);
+//! # let (request_tx, request_rx) = EventChannel::new(10, ChannelSinkConfig::BufferLatest);
+//! #
+//! let builder = StrongholdP2pBuilder::new(firewall_tx, request_tx, None)
+//!     .with_firewall_default(FirewallRules::new(Some(rule), None));
+//!
+//! // Use `MessagePermissions` in StrongholdP2p as type for firewall requests.
+//! let p2p: StrongholdP2p<Message, MessageResponse, MessagePermission> = builder.build().await?;
+//! #
+//! # Ok(())
+//! # }
+//! ```
+
 pub use stronghold_derive::RequestPermissions;
 
 /// The permission value for request variants.
@@ -9,8 +78,13 @@ pub use stronghold_derive::RequestPermissions;
 pub struct PermissionValue(u32);
 
 impl PermissionValue {
-    /// Create a new permission value for an index, the value equals 2 to the power of the index.
+    /// Create a new permission value for an index, the value equals 2^index.
     /// Max allowed index is 31, otherwise [`None`] will be returned.
+    ///
+    /// E.g.
+    /// - PermissionValue::new(0) -> PermissionValue(1)
+    /// - PermissionValue::new(1) -> PermissionValue(2)
+    /// - PermissionValue::new(2) -> PermissionValue(4)
     pub fn new(index: u8) -> Option<Self> {
         if index < 32 {
             let value = 1u32 << index;

--- a/p2p/src/interface.rs
+++ b/p2p/src/interface.rs
@@ -43,6 +43,64 @@ use std::{borrow::Borrow, io, time::Duration};
 /// operations on the swarm.
 ///
 /// Refer to [`StrongholdP2pBuilder`] for more information on the default configuration.
+///
+/// ```
+/// # use serde::{Serialize, Deserialize};
+/// # use p2p::{ChannelSinkConfig, EventChannel, StrongholdP2p};
+/// # use futures::channel::mpsc;
+/// # use std::borrow::Borrow;
+/// #
+/// // Type of the requests send to the remote.
+/// #[derive(Debug, PartialEq, Serialize, Deserialize)]
+/// enum Request {
+///     Ping,
+///     Message(String),
+/// }
+///
+/// // Trimmed version of the request that is used for validation in the firewall.
+/// // In case of `Rule::Ask` this is the message that is bubbled up through the
+/// // firewall channel.
+/// //
+/// // This type is optional but may be needed because e.g. the actual request can not
+/// // be cloned, or shouldn't expose details to the receiving side of the firewall-channel.
+/// #[derive(Debug, Clone)]
+/// enum RequestType {
+///     Ping,
+///     Message,
+/// }
+///
+/// impl Borrow<RequestType> for Request {
+///     fn borrow(&self) -> &RequestType {
+///         match self {
+///             Request::Ping => &RequestType::Ping,
+///             Request::Message(..) => &RequestType::Message,
+///         }
+///     }
+/// }
+///
+/// // Type of the response send back.
+/// #[derive(Debug, PartialEq, Serialize, Deserialize)]
+/// enum Response {
+///     Pong,
+///     Message(String),
+/// }
+///
+/// // Channel used for dynamic rules:
+/// // - If a peer connected for which no rules are present (no default & not peer-specific):
+/// //   Allows the user to send back the rules that should be set for this peer.
+/// // - If the firewall `Rule` is set to `Rule::Ask`:
+/// //   Asks for individual approval for this specific request.
+/// let (firewall_tx, firewall_rx) = mpsc::channel(10);
+///
+/// // Channel trough which inbound requests are forwarded.
+/// let (request_tx, request_rx) = EventChannel::new(10, ChannelSinkConfig::BufferLatest);
+///
+/// // Optional channel through which current events in the network are sent, e.g.
+/// // peers connecting / disconnecting, listener events or non-fatal failures.
+/// let (events_tx, events_rx) = EventChannel::new(10, ChannelSinkConfig::BufferLatest);
+///
+/// let p2p = StrongholdP2p::<Request, Response, RequestType>::new(firewall_tx, request_tx, Some(events_tx));
+/// ```
 pub struct StrongholdP2p<Rq, Rs, TRq = Rq>
 where
     // Request message type
@@ -88,7 +146,7 @@ where
 
     /// Send a new request to a remote peer.
     ///
-    /// This will attempt to establish a connection to the remote via one of the known addresses, if there is no active
+    /// This will attempt to establish a connection to the remote via one of the known addresses if there is no active
     /// connection.
     pub async fn send_request(&mut self, peer: PeerId, request: Rq) -> Result<Rs, OutboundFailure> {
         let (tx_yield, rx_yield) = oneshot::channel();
@@ -390,12 +448,15 @@ where
 /// Use existing keypair for authentication on the transport layer.
 ///
 /// The local [`PeerId`] is derived from public key of the IdKeys.
-/// If this is not the case, remote Peers will reject the communication.
 pub enum InitKeypair {
     /// Identity Keys that are used to derive the noise keypair and peer id.
     IdKeys(Keypair),
     /// Use authenticated noise-keypair.
-    /// **Note**: The peer-id has to be derived from the same keypair that is used to create the noise-keypair.
+    ///
+    /// **Note**:
+    /// The `peer_id` has to be derived from the same keypair that is used to create the noise-keypair.
+    /// Remote Peers will always observe us from the derived [`PeerId`], even if we set a different one
+    /// here.
     Authenticated {
         peer_id: PeerId,
         noise_keypair: AuthenticKeypair<X25519Spec>,
@@ -580,6 +641,30 @@ where
     /// operations on the swarm-task.
     /// Additionally, the executor is used to configure the
     /// [`SwarmBuilder::executor`][libp2p::swarm::SwarmBuilder::executor].
+    ///
+    /// ```
+    /// # use p2p::{
+    ///     firewall::FirewallRules,
+    ///     ChannelSinkConfig, EventChannel,  StrongholdP2p, StrongholdP2pBuilder
+    /// };
+    /// # use futures::channel::mpsc;
+    /// # use std::error::Error;
+    /// use libp2p::tcp::TokioTcpConfig;
+    /// #
+    /// # async fn test() -> Result<(), Box<dyn Error>> {
+    /// let (firewall_tx, firewall_rx) = mpsc::channel(10);
+    /// let (request_tx, request_rx) = EventChannel::new(10, ChannelSinkConfig::BufferLatest);
+    ///
+    /// let builder = StrongholdP2pBuilder::new(firewall_tx, request_tx, None)
+    ///     .with_firewall_default(FirewallRules::allow_all());
+    /// let p2p: StrongholdP2p<String, String> = builder
+    ///     .build_with_transport(TokioTcpConfig::new(), |fut| {
+    ///          tokio::spawn(fut);
+    ///     })
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
     pub async fn build_with_transport<Tp, E>(
         self,
         transport: Tp,

--- a/p2p/src/interface.rs
+++ b/p2p/src/interface.rs
@@ -85,7 +85,7 @@ use std::{borrow::Borrow, io, time::Duration};
 ///     Message(String),
 /// }
 ///
-/// // Channel used for dynamic rules:
+/// // Channel used for dynamic firewall rules:
 /// // - If a peer connected for which no rules are present (no default & not peer-specific):
 /// //   Allows the user to send back the rules that should be set for this peer.
 /// // - If the firewall `Rule` is set to `Rule::Ask`:
@@ -466,8 +466,10 @@ pub enum InitKeypair {
 /// Builder for new `StrongholdP2p`.
 ///
 /// Default behaviour:
-/// - No firewall rules are set. In case of inbound / outbound requests, a [`FirewallRequest::PeerSpecificRule`] request
-///   is sent through the `firewall_channel` to specify the rules for this peer.
+/// - All outbound requests are permitted
+/// - No firewall rules for inbound requests are set. In case of an inbound requests, a
+///   [`FirewallRequest::PeerSpecificRule`] request is sent through the `firewall_channel` to specify the rules for this
+///   peer.
 /// - A new keypair is created and used, from which the [`PeerId`] of the local peer is derived.
 /// - No limit for simultaneous connections.
 /// - Request-timeout and Connection-timeout are 10s.
@@ -531,6 +533,7 @@ where
         requests_channel: EventChannel<ReceiveRequest<Rq, Rs>>,
         events_channel: Option<EventChannel<NetworkEvent>>,
     ) -> Self {
+        let default_rules = FirewallRules::new(None, Some(Rule::AllowAll));
         StrongholdP2pBuilder {
             firewall_channel,
             requests_channel,
@@ -538,7 +541,7 @@ where
             ident: None,
             behaviour_config: Default::default(),
             connections_limit: None,
-            default_rules: None,
+            default_rules: Some(default_rules),
             support_mdns: true,
             support_relay: true,
             state: None,

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-mod behaviour;
+pub mod behaviour;
 mod libp2p_reexport {
     pub use libp2p::{core::Executor, identity, swarm::DialError, Multiaddr, PeerId};
     pub type AuthenticKeypair = libp2p::noise::AuthenticKeypair<libp2p::noise::X25519Spec>;

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -1,6 +1,19 @@
 // Copyright 2020-2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+//! # Stronghold-P2p
+//!
+//! This crate implements a secure P2P-communication layer for [`Stronghold`][iota_stronghold::Stronghold],
+//! which enables permissioned use of remote strongholds for creating services like remote signing.
+//! However, while being significantly influenced by Stronghold's use-case, it is not dependent on the Stronghold crate
+//! itself and may be used independently.
+//!
+//! Stronghold-P2p is using the libp2p networking framework.
+//! On top of libp2p's protocols for describing how and what data is send through the network, the [`StrongholdP2p`]
+//! interface provides an additional layer of abstraction and manages the network polling and all interaction in a
+//! separate task. Futhermore, it integrates a firewall with which rules can be set to restrict requests and/ or ask for
+//! dynamic approval before forwarding them.
+
 pub mod behaviour;
 mod libp2p_reexport {
     pub use libp2p::{core::Executor, identity, swarm::DialError, Multiaddr, PeerId};

--- a/p2p/tests/test_firewall.rs
+++ b/p2p/tests/test_firewall.rs
@@ -11,8 +11,8 @@ use futures::{
 use libp2p::tcp::TokioTcpConfig;
 use p2p::{
     firewall::{
-        FirewallPermission, FirewallRequest, FirewallRules, PermissionValue, RequestPermissions, Rule, RuleDirection,
-        VariantPermission,
+        permissions::{FirewallPermission, PermissionValue, RequestPermissions, VariantPermission},
+        FirewallRequest, FirewallRules, Rule, RuleDirection,
     },
     ChannelSinkConfig, EventChannel, InboundFailure, NetworkEvent, OutboundFailure, PeerId, ReceiveRequest,
     RequestDirection, StrongholdP2p, StrongholdP2pBuilder,


### PR DESCRIPTION
# Description of change

Add two examples:
1. Demonstrate how the stronghold-p2p firewall may be used to set dynamic rules for each individual peer once they connect, and restrict permitted requests based on the type of request.
2. Showcase how a standalone stronghold-p2p peer (without a local Stronghold) can interact with a remote Stronghold through p2p. cc @PhilippGackstatter

Enhance docs.

_Note: This PR cherry-picks 420ecb04b07b055109539fda2fb877712cc98597 and fe7867b0135a5b0678e0d1a39c710818507aa704 from #301 to fix the checks._

## Type of change

- [x] Documentation Fix
