### PR TITLE
P2P: Feature-gate libp2p's `mdns` & remove `wasm-timer`

### DIFF
--- a/.changes/p2p-toggle-behaviour.md
+++ b/.changes/p2p-toggle-behaviour.md
@@ -1,0 +1,5 @@
+---
+"stronghold-p2p": patch
+---
+
+- [PR 295](https://github.com/iotaledger/stronghold.rs/pull/295): use `libp2p::swarm::toggle` to enable/ disable relay and mdns

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -73,7 +73,6 @@ tokio = {version = "1.9", features = ["rt-multi-thread"] }
 name = "p2p"
 required-features = ["p2p"]
 
-
 [[bench]]
 name = "benchmark"
 harness = false

--- a/client/src/interface.rs
+++ b/client/src/interface.rs
@@ -513,7 +513,7 @@ impl Stronghold {
             .await?
             .ok_or_else(|| SpawnNetworkError::LoadConfig(format!("No config found at key {:?}", key)))?;
         let config = bincode::deserialize(&config_bytes)
-            .map_err(|e| SpawnNetworkError::LoadConfig(format!("Deserializing state failed: {}", e.to_string())))?;
+            .map_err(|e| SpawnNetworkError::LoadConfig(format!("Deserializing state failed: {}", e)))?;
         self.spawn_p2p(config, keypair).await
     }
 

--- a/client/src/tests/fresh.rs
+++ b/client/src/tests/fresh.rs
@@ -33,7 +33,7 @@ pub fn hd_path() -> (String, Chain) {
     let mut is = vec![];
     while coinflip() {
         let i = random::<u32>() & 0x7fffff;
-        s.push_str(&format!("/{}'", i.to_string()));
+        s.push_str(&format!("/{}'", i));
         is.push(i);
     }
     (s, Chain::from_u32_hardened(is))

--- a/client/src/tests/interface_tests.rs
+++ b/client/src/tests/interface_tests.rs
@@ -565,11 +565,11 @@ async fn test_p2p_config() {
         .await
     {
         Ok(()) => {}
-        Err(e) => panic!("Unexpected error {}", e.to_string()),
+        Err(e) => panic!("Unexpected error {}", e),
     }
     let remote_addr = match remote_sh.start_listening(None).await.unwrap() {
         Ok(a) => a,
-        Err(e) => panic!("Unexpected error {}", e.to_string()),
+        Err(e) => panic!("Unexpected error {}", e),
     };
     let SwarmInfo {
         local_peer_id: remote_id,
@@ -591,7 +591,7 @@ async fn test_p2p_config() {
         .unwrap()
     {
         Ok(()) => {}
-        Err(e) => panic!("Unexpected error {}", e.to_string()),
+        Err(e) => panic!("Unexpected error {}", e),
     }
     // Spawn p2p that uses the new keypair
     match stronghold
@@ -602,13 +602,13 @@ async fn test_p2p_config() {
         .await
     {
         Ok(()) => {}
-        Err(e) => panic!("Unexpected error {}", e.to_string()),
+        Err(e) => panic!("Unexpected error {}", e),
     }
 
     // Start listening
     let addr = match stronghold.start_listening(None).await.unwrap() {
         Ok(addr) => addr,
-        Err(e) => panic!("Unexpected error {}", e.to_string()),
+        Err(e) => panic!("Unexpected error {}", e),
     };
     let SwarmInfo {
         local_peer_id,
@@ -625,13 +625,13 @@ async fn test_p2p_config() {
     // Add the remote's address info
     match stronghold.add_peer(remote_id, Some(remote_addr.clone())).await.unwrap() {
         Ok(_) => {}
-        Err(e) => panic!("Unexpected error {}", e.to_string()),
+        Err(e) => panic!("Unexpected error {}", e),
     }
     // Test that the firewall rule is effective
     let res = remote_sh.read_from_remote_store(peer_id, bytestring(10)).await;
     match res {
         Ok(_) => panic!("Request should be rejected."),
-        Err(P2pError::Local(e)) => panic!("Unexpected error {}", e.to_string()),
+        Err(P2pError::Local(e)) => panic!("Unexpected error {}", e),
         Err(P2pError::SendRequest(OutboundFailure::NotPermitted))
         | Err(P2pError::SendRequest(OutboundFailure::DialFailure))
         | Err(P2pError::SendRequest(OutboundFailure::Shutdown))
@@ -644,13 +644,13 @@ async fn test_p2p_config() {
     let store = bytestring(1024);
     match stronghold.stop_p2p(Some(store.clone())).await.unwrap() {
         Ok(()) => {}
-        Err(e) => panic!("Unexpected error {}", e.to_string()),
+        Err(e) => panic!("Unexpected error {}", e),
     }
 
     // Spawn p2p again and load the config. Use the same keypair to keep the same peer-id.
     match stronghold.spawn_p2p_load_config(store, Some(keys_location)).await {
         Ok(()) => {}
-        Err(e) => panic!("Unexpected error {}", e.to_string()),
+        Err(e) => panic!("Unexpected error {}", e),
     }
     let SwarmInfo { local_peer_id, .. } = stronghold.get_swarm_info().await.unwrap();
 
@@ -658,13 +658,13 @@ async fn test_p2p_config() {
     assert_eq!(local_peer_id, peer_id);
     match stronghold.add_peer(remote_id, None).await.unwrap() {
         Ok(_) => {}
-        Err(e) => panic!("Unexpected error {}", e.to_string()),
+        Err(e) => panic!("Unexpected error {}", e),
     }
     // Test that the firewall rule is still effective
     let res = remote_sh.read_from_remote_store(peer_id, bytestring(10)).await;
     match res {
         Ok(_) => panic!("Request should be rejected."),
-        Err(P2pError::Local(e)) => panic!("Unexpected error {}", e.to_string()),
+        Err(P2pError::Local(e)) => panic!("Unexpected error {}", e),
         Err(P2pError::SendRequest(OutboundFailure::NotPermitted))
         | Err(P2pError::SendRequest(OutboundFailure::DialFailure))
         | Err(P2pError::SendRequest(OutboundFailure::Shutdown))

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -15,7 +15,6 @@ homepage = "https://stronghold.docs.iota.org"
 name = "p2p"
 
 [dependencies]
-either = "1.6"
 futures = "0.3"
 libp2p = { version = "0.41.0", default-features = false, features = ["noise", "yamux", "mdns", "relay"] }
 pin-project = "1.0.8"

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -24,7 +24,7 @@ smallvec = "1.6.1"
 stronghold-derive = { path = "../derive", version = "0.2" }
 thiserror = "1.0.30"
 tokio = { version = "1.10", default-features = false, features = ["rt", "sync"] }
-wasm-timer = "0.2.5"
+instant = "0.1.11"
 
 [features]
 default = [ "tcp-transport", "mdns"]

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -16,7 +16,7 @@ name = "p2p"
 
 [dependencies]
 futures = "0.3"
-libp2p = { version = "0.41.0", default-features = false, features = ["noise", "yamux", "mdns", "relay"] }
+libp2p = { version = "0.41.0", default-features = false, features = ["noise", "yamux", "relay"] }
 pin-project = "1.0.8"
 serde = { version = "1.0", default-features = false, features = [ "alloc", "derive" ] }
 serde_json = { version = "1.0", default-features = false, features = [ "alloc" ] }
@@ -27,10 +27,11 @@ tokio = { version = "1.10", default-features = false, features = ["rt", "sync"] 
 wasm-timer = "0.2.5"
 
 [features]
-default = [ "tcp-transport"]
+default = [ "tcp-transport", "mdns"]
 tcp-transport = ["libp2p/tcp-tokio", "libp2p/dns-tokio", "libp2p/websocket"]
+mdns = ["libp2p/mdns"]
 
 [dev-dependencies]
 stronghold-utils = { path = "../utils", version = "0.3" }
 tokio = {version = "1.10", features = ["time", "macros"]}
-libp2p = { version = "0.41.0", default-features = false, features = ["tcp-tokio"] }
+libp2p = { version = "0.41.0", default-features = false, features = ["tcp-tokio", "mdns"] }

--- a/p2p/src/behaviour.rs
+++ b/p2p/src/behaviour.rs
@@ -971,9 +971,10 @@ mod test {
     use super::*;
     use crate::firewall::{PermissionValue, RequestPermissions, VariantPermission};
     use futures::{channel::mpsc, StreamExt};
+    #[cfg(feature = "mdns")]
+    use libp2p::mdns::{Mdns, MdnsConfig};
     use libp2p::{
         core::{identity, upgrade, PeerId, Transport},
-        mdns::{Mdns, MdnsConfig},
         noise::{Keypair as NoiseKeypair, NoiseConfig, X25519Spec},
         relay::{new_transport_and_behaviour, RelayConfig},
         swarm::{Swarm, SwarmBuilder, SwarmEvent},
@@ -1173,13 +1174,14 @@ mod test {
             .authenticate(NoiseConfig::xx(noise_keys).into_authenticated())
             .multiplex(YamuxConfig::default())
             .boxed();
-
+        #[cfg(feature = "mdns")]
         let mdns = Mdns::new(MdnsConfig::default())
             .await
             .expect("Failed to create mdns behaviour.");
         let (dummy_tx, _) = mpsc::channel(10);
         let behaviour = NetBehaviour::new(
             NetBehaviourConfig::default(),
+            #[cfg(feature = "mdns")]
             Some(mdns),
             Some(relay_behaviour),
             dummy_tx,

--- a/p2p/src/behaviour/handler.rs
+++ b/p2p/src/behaviour/handler.rs
@@ -20,6 +20,7 @@ use crate::{
     RequestId, RqRsMessage,
 };
 use futures::{channel::oneshot, future::BoxFuture, prelude::*, stream::FuturesUnordered};
+use instant::Instant;
 use libp2p::{
     core::upgrade::{NegotiationError, UpgradeError},
     swarm::{
@@ -40,7 +41,6 @@ use std::{
     task::{Context, Poll},
     time::Duration,
 };
-use wasm_timer::Instant;
 
 type ProtocolsHandlerEventType<Rq, Rs> = ProtocolsHandlerEvent<
     RequestProtocol<Rq, Rs>,

--- a/p2p/src/behaviour/request_manager/connections.rs
+++ b/p2p/src/behaviour/request_manager/connections.rs
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{RequestDirection, RequestId};
+use instant::Instant;
 use libp2p::core::{connection::ConnectionId, ConnectedPoint, PeerId};
 use std::collections::{hash_map::HashMap, HashSet};
-use wasm_timer::Instant;
 
 // Sent requests that have not yet received a response.
 #[derive(Debug)]


### PR DESCRIPTION
# Description of change

This PR contains two Wasm-related changes in the `stronghold-p2p` crate.

1. Remove `wasm-timer` and add `instant`. This is required for proper Wasm support because `libp2p` itself has [moved away from wasm-timer](https://github.com/libp2p/rust-libp2p/pull/2245).
2. Feature-gate libp2p's `mdns` feature, which is [not supported](https://github.com/libp2p/rust-libp2p/blob/e19391e966d64aad1839aa7781a275c64100c75a/Cargo.toml#L100) on Wasm targets.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested

No new functionality was added, so only existing tests were run. 

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
