### PR TITLE
fix(client): fix clippy::to_string_in_format_args

### DIFF
--- a/client/src/interface.rs
+++ b/client/src/interface.rs
@@ -513,7 +513,7 @@ impl Stronghold {
             .await?
             .ok_or_else(|| SpawnNetworkError::LoadConfig(format!("No config found at key {:?}", key)))?;
         let config = bincode::deserialize(&config_bytes)
-            .map_err(|e| SpawnNetworkError::LoadConfig(format!("Deserializing state failed: {}", e.to_string())))?;
+            .map_err(|e| SpawnNetworkError::LoadConfig(format!("Deserializing state failed: {}", e)))?;
         self.spawn_p2p(config, keypair).await
     }
 

--- a/client/src/tests/fresh.rs
+++ b/client/src/tests/fresh.rs
@@ -33,7 +33,7 @@ pub fn hd_path() -> (String, Chain) {
     let mut is = vec![];
     while coinflip() {
         let i = random::<u32>() & 0x7fffff;
-        s.push_str(&format!("/{}'", i.to_string()));
+        s.push_str(&format!("/{}'", i));
         is.push(i);
     }
     (s, Chain::from_u32_hardened(is))

--- a/client/src/tests/interface_tests.rs
+++ b/client/src/tests/interface_tests.rs
@@ -565,11 +565,11 @@ async fn test_p2p_config() {
         .await
     {
         Ok(()) => {}
-        Err(e) => panic!("Unexpected error {}", e.to_string()),
+        Err(e) => panic!("Unexpected error {}", e),
     }
     let remote_addr = match remote_sh.start_listening(None).await.unwrap() {
         Ok(a) => a,
-        Err(e) => panic!("Unexpected error {}", e.to_string()),
+        Err(e) => panic!("Unexpected error {}", e),
     };
     let SwarmInfo {
         local_peer_id: remote_id,
@@ -591,7 +591,7 @@ async fn test_p2p_config() {
         .unwrap()
     {
         Ok(()) => {}
-        Err(e) => panic!("Unexpected error {}", e.to_string()),
+        Err(e) => panic!("Unexpected error {}", e),
     }
     // Spawn p2p that uses the new keypair
     match stronghold
@@ -602,13 +602,13 @@ async fn test_p2p_config() {
         .await
     {
         Ok(()) => {}
-        Err(e) => panic!("Unexpected error {}", e.to_string()),
+        Err(e) => panic!("Unexpected error {}", e),
     }
 
     // Start listening
     let addr = match stronghold.start_listening(None).await.unwrap() {
         Ok(addr) => addr,
-        Err(e) => panic!("Unexpected error {}", e.to_string()),
+        Err(e) => panic!("Unexpected error {}", e),
     };
     let SwarmInfo {
         local_peer_id,
@@ -625,13 +625,13 @@ async fn test_p2p_config() {
     // Add the remote's address info
     match stronghold.add_peer(remote_id, Some(remote_addr.clone())).await.unwrap() {
         Ok(_) => {}
-        Err(e) => panic!("Unexpected error {}", e.to_string()),
+        Err(e) => panic!("Unexpected error {}", e),
     }
     // Test that the firewall rule is effective
     let res = remote_sh.read_from_remote_store(peer_id, bytestring(10)).await;
     match res {
         Ok(_) => panic!("Request should be rejected."),
-        Err(P2pError::Local(e)) => panic!("Unexpected error {}", e.to_string()),
+        Err(P2pError::Local(e)) => panic!("Unexpected error {}", e),
         Err(P2pError::SendRequest(OutboundFailure::NotPermitted))
         | Err(P2pError::SendRequest(OutboundFailure::DialFailure))
         | Err(P2pError::SendRequest(OutboundFailure::Shutdown))
@@ -644,13 +644,13 @@ async fn test_p2p_config() {
     let store = bytestring(1024);
     match stronghold.stop_p2p(Some(store.clone())).await.unwrap() {
         Ok(()) => {}
-        Err(e) => panic!("Unexpected error {}", e.to_string()),
+        Err(e) => panic!("Unexpected error {}", e),
     }
 
     // Spawn p2p again and load the config. Use the same keypair to keep the same peer-id.
     match stronghold.spawn_p2p_load_config(store, Some(keys_location)).await {
         Ok(()) => {}
-        Err(e) => panic!("Unexpected error {}", e.to_string()),
+        Err(e) => panic!("Unexpected error {}", e),
     }
     let SwarmInfo { local_peer_id, .. } = stronghold.get_swarm_info().await.unwrap();
 
@@ -658,13 +658,13 @@ async fn test_p2p_config() {
     assert_eq!(local_peer_id, peer_id);
     match stronghold.add_peer(remote_id, None).await.unwrap() {
         Ok(_) => {}
-        Err(e) => panic!("Unexpected error {}", e.to_string()),
+        Err(e) => panic!("Unexpected error {}", e),
     }
     // Test that the firewall rule is still effective
     let res = remote_sh.read_from_remote_store(peer_id, bytestring(10)).await;
     match res {
         Ok(_) => panic!("Request should be rejected."),
-        Err(P2pError::Local(e)) => panic!("Unexpected error {}", e.to_string()),
+        Err(P2pError::Local(e)) => panic!("Unexpected error {}", e),
         Err(P2pError::SendRequest(OutboundFailure::NotPermitted))
         | Err(P2pError::SendRequest(OutboundFailure::DialFailure))
         | Err(P2pError::SendRequest(OutboundFailure::Shutdown))


### PR DESCRIPTION
# Description of change

Fix cargo clippy lint `to_string_in_format_args` that was added in clippy v0.1.58.
