### PR TITLE
fix(*): fix clippy v0.1.59

### DIFF
--- a/client/examples/p2p/main.rs
+++ b/client/examples/p2p/main.rs
@@ -58,7 +58,7 @@ pub async fn show_swarm_info_command(stronghold: &mut iota_stronghold::Stronghol
         listeners,
         connections,
     } = stronghold.get_swarm_info().await?;
-    let addrs = listeners.into_iter().map(|l| l.addrs).flatten();
+    let addrs = listeners.into_iter().flat_map(|l| l.addrs);
     let peers = connections.into_iter().map(|(p, _)| p);
     let info = format!(
         "-----------\nSwarm Info:\n-----------\nPeer Id : {},\nAddresses: {:?},\nPeers: {:?}\n",

--- a/client/src/interface.rs
+++ b/client/src/interface.rs
@@ -336,12 +336,11 @@ impl Stronghold {
         // this feature resembles the functionality given by the former riker
         // system dependence. if there is a former client id path present,
         // the new actor is being changed into the former one ( see old ReloadData impl.)
-        let target;
-        if let Some(id) = former_client_id {
-            target = self.switch_client(id).await?;
+        let target = if let Some(id) = former_client_id {
+            self.switch_client(id).await?
         } else {
-            target = self.target().await?;
-        }
+            self.target().await?
+        };
 
         let mut key: [u8; 32] = [0u8; 32];
         let keydata = keydata.as_ref();
@@ -417,20 +416,17 @@ impl Stronghold {
     /// set via [`Stronghold::switch_actor_target`], before any following operations can be performed.
     pub async fn kill_stronghold(&mut self, client_path: Vec<u8>, kill_actor: bool) -> StrongholdResult<()> {
         let client_id = ClientId::load_from_path(&client_path.clone(), &client_path);
-        let client;
-        if kill_actor {
-            client = self
-                .registry
+        let client = if kill_actor {
+            self.registry
                 .send(RemoveClient { id: client_id })
                 .await?
-                .ok_or(ActorError::TargetNotFound)?;
+                .ok_or(ActorError::TargetNotFound)?
         } else {
-            client = self
-                .registry
+            self.registry
                 .send(GetClient { id: client_id })
                 .await?
-                .ok_or(ActorError::TargetNotFound)?;
-        }
+                .ok_or(ActorError::TargetNotFound)?
+        };
         client.send(ClearCache).await?;
         Ok(())
     }

--- a/client/src/procedures/primitives.rs
+++ b/client/src/procedures/primitives.rs
@@ -790,24 +790,23 @@ impl GenerateSecret for Pbkdf2Hmac {
     type Output = ();
 
     fn generate(self, _: Self::Input) -> Result<Products<Self::Output>, FatalProcedureError> {
-        let secret;
-        match self.ty {
+        let secret = match self.ty {
             Sha2Hash::Sha256 => {
                 let mut buffer = [0; SHA256_LEN];
                 PBKDF2_HMAC_SHA256(&self.password, &self.salt, self.count as usize, &mut buffer)?;
-                secret = buffer.to_vec()
+                buffer.to_vec()
             }
             Sha2Hash::Sha384 => {
                 let mut buffer = [0; SHA384_LEN];
                 PBKDF2_HMAC_SHA384(&self.password, &self.salt, self.count as usize, &mut buffer)?;
-                secret = buffer.to_vec()
+                buffer.to_vec()
             }
             Sha2Hash::Sha512 => {
                 let mut buffer = [0; SHA512_LEN];
                 PBKDF2_HMAC_SHA512(&self.password, &self.salt, self.count as usize, &mut buffer)?;
-                secret = buffer.to_vec()
+                buffer.to_vec()
             }
-        }
+        };
         Ok(Products { secret, output: () })
     }
 }

--- a/client/src/procedures/types.rs
+++ b/client/src/procedures/types.rs
@@ -544,7 +544,7 @@ pub struct Target {
 impl Target {
     pub fn random() -> Self {
         let location = Location::generic("TEMP".as_bytes(), random::bytestring(32));
-        let hint = RecordHint::new("".to_string()).unwrap();
+        let hint = RecordHint::new("").unwrap();
         Target { location, hint }
     }
 }

--- a/p2p/src/interface.rs
+++ b/p2p/src/interface.rs
@@ -708,11 +708,10 @@ where
                 .boxed();
             relay = None;
         }
-        let mdns;
-        if self.support_mdns {
-            mdns = Some(Mdns::new(MdnsConfig::default()).await?);
+        let mdns = if self.support_mdns {
+            Some(Mdns::new(MdnsConfig::default()).await?)
         } else {
-            mdns = None
+            None
         };
         let (address_info, mut firewall) = match self.state {
             Some(state) => (Some(state.address_info), state.firewall),


### PR DESCRIPTION
# Description of change

Fix lints from new Clippy version 0.1.59:
- clippy::needless-late-init
- clippy::unnecessary-to-owned
- clippy::map-flatten

