### PR TITLE
GitHub workflow: add engine/runtime to clippy & fmt check

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        project: [engine, client, products/commandline, derive, utils, p2p]
+        project: [engine, engine/runtime, client, products/commandline, derive, utils, p2p]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        project: [engine, client, products/commandline, derive, utils, p2p]
+        project: [engine, engine/runtime, client, products/commandline, derive, utils, p2p]
 
     steps:
       - uses: actions/checkout@v2

--- a/engine/runtime/.license_template
+++ b/engine/runtime/.license_template
@@ -1,1 +1,2 @@
-../.license_template
+// Copyright {20\d{2}(-20\d{2})?} IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
# Description of change

While working on #325 I noticed that the runtime is not included in the clippy and format workflows, because it is its own crate and not part of the engine.
This PR adds it to the clippy and format checks.


@nothingismagick  was there a specific reason that is was originally not included / do you see an issue with this change? 