### PR TITLE
Feat/snapshot state in memory

### DIFF
--- a/client/benches/benchmark.rs
+++ b/client/benches/benchmark.rs
@@ -33,7 +33,7 @@ fn init_read_snap(stronghold: Stronghold, key_data: &[u8]) -> Stronghold {
     let mut stronghold = init_read_vault(stronghold);
 
     system
-        .block_on(stronghold.write_all_to_snapshot(&key_data.to_vec(), Some("bench_read".into()), None))
+        .block_on(stronghold.write_snapshot(&key_data.to_vec(), Some("bench_read".into()), None))
         .unwrap()
         .unwrap();
 
@@ -67,7 +67,7 @@ fn bench_write_snapshot(c: &mut Criterion) {
     let key_data = b"abcdefghijklmnopqrstuvwxyz012345".to_vec();
 
     c.bench_function("Write to snapshot", |b| {
-        b.iter(|| system.block_on(stronghold.write_all_to_snapshot(&key_data, Some("bench".into()), None)));
+        b.iter(|| system.block_on(stronghold.write_snapshot(&key_data, Some("bench".into()), None)));
     });
 }
 
@@ -78,15 +78,7 @@ fn bench_read_from_snapshot(c: &mut Criterion) {
     let mut stronghold = init_read_snap(stronghold, &key_data);
 
     c.bench_function("Read from snapshot", |b| {
-        b.iter(|| {
-            system.block_on(stronghold.read_snapshot(
-                b"path".to_vec(),
-                None,
-                &key_data,
-                Some("bench_read".into()),
-                None,
-            ))
-        });
+        b.iter(|| system.block_on(stronghold.read_snapshot(&key_data, Some("bench_read".into()), None, None)));
     });
 }
 

--- a/client/examples/cli/main.rs
+++ b/client/examples/cli/main.rs
@@ -39,10 +39,11 @@ async fn write_to_store_command(
 
     if snapshot.exists() {
         stronghold
-            .read_snapshot(client_path, None, &key.to_vec(), Some("commandline".to_string()), None)
+            .read_snapshot(&key.to_vec(), Some("commandline".to_string()), None, None)
             .await
             .unwrap()
             .unwrap();
+        stronghold.load_client(client_path, None).await.unwrap().unwrap();
     }
 
     stronghold
@@ -51,7 +52,7 @@ async fn write_to_store_command(
         .unwrap();
 
     stronghold
-        .write_all_to_snapshot(&key.to_vec(), Some("commandline".to_string()), None)
+        .write_snapshot(&key.to_vec(), Some("commandline".to_string()), None)
         .await
         .unwrap()
         .unwrap();
@@ -75,10 +76,11 @@ async fn encrypt_command(
 
     if snapshot.exists() {
         stronghold
-            .read_snapshot(client_path, None, &key.to_vec(), Some("commandline".to_string()), None)
+            .read_snapshot(&key.to_vec(), Some("commandline".to_string()), None, None)
             .await
             .unwrap()
             .unwrap();
+        stronghold.load_client(client_path, None).await.unwrap().unwrap();
     }
 
     stronghold
@@ -93,7 +95,7 @@ async fn encrypt_command(
         .unwrap();
 
     stronghold
-        .write_all_to_snapshot(&key.to_vec(), Some("commandline".to_string()), None)
+        .write_snapshot(&key.to_vec(), Some("commandline".to_string()), None)
         .await
         .unwrap()
         .unwrap();
@@ -123,12 +125,13 @@ async fn snapshot_command(
 
     if input.exists() {
         stronghold
-            .read_snapshot(client_path, None, &key.to_vec(), None, Some(input))
+            .read_snapshot(&key.to_vec(), Some("commandline".to_string()), Some(input), None)
             .await
             .unwrap()
             .unwrap();
+        stronghold.load_client(client_path, None).await.unwrap().unwrap();
         stronghold
-            .write_all_to_snapshot(&key.to_vec(), Some("commandline".to_string()), None)
+            .write_snapshot(&key.to_vec(), Some("commandline".to_string()), None)
             .await
             .unwrap()
             .unwrap();
@@ -154,10 +157,11 @@ async fn list_command(
 
     if snapshot.exists() {
         stronghold
-            .read_snapshot(client_path, None, &key.to_vec(), Some("commandline".to_string()), None)
+            .read_snapshot(&key.to_vec(), Some("commandline".to_string()), None, None)
             .await
             .unwrap()
             .unwrap();
+        stronghold.load_client(client_path, None).await.unwrap().unwrap();
 
         let list = stronghold
             .list_hints_and_ids(Location::generic(path, path).vault_path().to_vec())
@@ -189,10 +193,11 @@ async fn read_from_store_command(
 
     if snapshot.exists() {
         stronghold
-            .read_snapshot(client_path, None, &key.to_vec(), Some("commandline".to_string()), None)
+            .read_snapshot(&key.to_vec(), Some("commandline".to_string()), None, None)
             .await
             .unwrap()
             .unwrap();
+        stronghold.load_client(client_path, None).await.unwrap().unwrap();
 
         let data = stronghold.read_from_store(rpath.into()).await.unwrap();
 
@@ -221,14 +226,15 @@ async fn delete_from_store_command(
 
     if snapshot.exists() {
         stronghold
-            .read_snapshot(client_path, None, &key.to_vec(), Some("commandline".to_string()), None)
+            .read_snapshot(&key.to_vec(), Some("commandline".to_string()), None, None)
             .await
             .unwrap()
             .unwrap();
+        stronghold.load_client(client_path, None).await.unwrap().unwrap();
 
         stronghold.delete_from_store(rpath.into()).await.unwrap();
         stronghold
-            .write_all_to_snapshot(&key.to_vec(), Some("commandline".to_string()), None)
+            .write_snapshot(&key.to_vec(), Some("commandline".to_string()), None)
             .await
             .unwrap()
             .unwrap();
@@ -257,10 +263,11 @@ async fn revoke_command(
 
     if snapshot.exists() {
         stronghold
-            .read_snapshot(client_path, None, &key.to_vec(), Some("commandline".to_string()), None)
+            .read_snapshot(&key.to_vec(), Some("commandline".to_string()), None, None)
             .await
             .unwrap()
             .unwrap();
+        stronghold.load_client(client_path, None).await.unwrap().unwrap();
         stronghold
             .delete_data(Location::generic(id, id), false)
             .await
@@ -268,7 +275,7 @@ async fn revoke_command(
             .unwrap();
 
         stronghold
-            .write_all_to_snapshot(&key.to_vec(), Some("commandline".to_string()), None)
+            .write_snapshot(&key.to_vec(), Some("commandline".to_string()), None)
             .await
             .unwrap()
             .unwrap();
@@ -296,10 +303,11 @@ async fn garbage_collect_vault_command(
 
     if snapshot.exists() {
         stronghold
-            .read_snapshot(client_path, None, &key.to_vec(), Some("commandline".to_string()), None)
+            .read_snapshot(&key.to_vec(), Some("commandline".to_string()), None, None)
             .await
             .unwrap()
             .unwrap();
+        stronghold.load_client(client_path, None).await.unwrap().unwrap();
 
         let location = Location::generic(id, id);
         stronghold
@@ -314,7 +322,7 @@ async fn garbage_collect_vault_command(
         println!("{:?}", list);
 
         stronghold
-            .write_all_to_snapshot(&key.to_vec(), Some("commandline".to_string()), None)
+            .write_snapshot(&key.to_vec(), Some("commandline".to_string()), None)
             .await
             .unwrap()
             .unwrap();
@@ -343,10 +351,11 @@ async fn purge_command(
 
     if snapshot.exists() {
         stronghold
-            .read_snapshot(client_path, None, &key.to_vec(), Some("commandline".to_string()), None)
+            .read_snapshot(&key.to_vec(), Some("commandline".to_string()), None, None)
             .await
             .unwrap()
             .unwrap();
+        stronghold.load_client(client_path, None).await.unwrap().unwrap();
         let location = Location::generic(id, id);
         stronghold.delete_data(location.clone(), true).await.unwrap().unwrap();
         let list = stronghold
@@ -357,7 +366,7 @@ async fn purge_command(
         println!("{:?}", list);
 
         stronghold
-            .write_all_to_snapshot(&key.to_vec(), Some("commandline".to_string()), None)
+            .write_snapshot(&key.to_vec(), Some("commandline".to_string()), None)
             .await
             .unwrap()
             .unwrap();

--- a/client/src/actors/secure.rs
+++ b/client/src/actors/secure.rs
@@ -277,7 +277,7 @@ pub mod testing {
             data.extend_from_slice(&*guarded_data);
             Ok(())
         });
-        self.keystore.entry_or_insert_key(vid, key);
+        self.keystore.insert_key(vid, key);
 
         match res {
             Ok(()) => Some(data),
@@ -309,7 +309,7 @@ impl_handler!(messages::CheckRecord, bool, (self, msg, _ctx), {
     return match self.keystore.take_key(vault_id) {
         Some(key) => {
             let res = self.db.contains_record(&key, vault_id, record_id);
-            self.keystore.entry_or_insert_key(vault_id, key);
+            self.keystore.insert_key(vault_id, key);
             res
         }
         None => false,
@@ -337,7 +337,7 @@ impl_handler!(messages::ListIds, Vec<(RecordId, RecordHint)>, (self, msg, _ctx),
     };
 
     let list = self.db.list_hints_and_ids(&key, vault_id);
-    self.keystore.entry_or_insert_key(vault_id, key);
+    self.keystore.insert_key(vault_id, key);
     list
 });
 

--- a/client/src/interface.rs
+++ b/client/src/interface.rs
@@ -13,14 +13,14 @@ use crate::{
             CheckRecord, CheckVault, ClearCache, DeleteFromStore, GarbageCollect, GetData, ListIds, Procedures,
             ReadFromStore, ReloadData, RevokeData, WriteToStore, WriteToVault,
         },
-        snapshot_messages::{FillSnapshot, ReadFromSnapshot, WriteSnapshot},
+        snapshot_messages::{FillSnapshot, LoadFromSnapshotState, ReadSnapshot, WriteSnapshot},
         GetAllClients, GetClient, GetSnapshot, GetTarget, RecordError, Registry, RemoveClient, SpawnClient,
         SwitchTarget,
     },
     procedures::{Procedure, ProcedureError, ProcedureOutput, StrongholdProcedure},
     state::{
         secure::SecureClient,
-        snapshot::{ReadError, WriteError},
+        snapshot::{SnapshotError, UseKey},
     },
     utils::{LoadFromPath, StrongholdFlags, VaultFlags},
     Location,
@@ -313,7 +313,14 @@ impl Stronghold {
         P: Procedure + Into<StrongholdProcedure>,
     {
         let res = self.runtime_exec_chained(vec![procedure.into()]).await?;
-        let mapped = res.map(|mut vec| vec.pop().unwrap().try_into().ok().unwrap());
+        let mapped = res.map(|mut output| {
+            output
+                .pop()
+                .expect("output.len() == procedures.len()")
+                .try_into()
+                .ok()
+                .expect("conversion can never fail.")
+        });
         Ok(mapped)
     }
 
@@ -346,18 +353,42 @@ impl Stronghold {
         Ok(exists)
     }
 
-    /// Reads data from a given snapshot file.  Can only read the data for a single `client_path` at a time. If the new
-    /// actor uses a new `client_path` the former client path may be passed into the function call to read the data into
-    /// that actor. Also requires keydata to unlock the snapshot. A filename and filepath can be specified. The Keydata
-    /// should implement and use Zeroize.
+    /// Reads data from a given snapshot file into memory.
+    ///
+    /// Optionally store the keydata so it can be used again in [`Stronghold::write_snapshot_stored_key`].
     pub async fn read_snapshot<T: Zeroize + AsRef<Vec<u8>>>(
         &mut self,
-        client_path: Vec<u8>,
-        former_client_path: Option<Vec<u8>>,
         keydata: &T,
         filename: Option<String>,
         path: Option<PathBuf>,
-    ) -> StrongholdResult<Result<(), ReadError>> {
+        write_key: Option<Location>,
+    ) -> StrongholdResult<Result<(), SnapshotError>> {
+        let snapshot_actor = self.registry.send(GetSnapshot {}).await?;
+
+        let mut key: [u8; 32] = [0u8; 32];
+        let keydata = keydata.as_ref();
+        key.copy_from_slice(keydata);
+
+        // read the snapshots contents
+        let result = snapshot_actor
+            .send(ReadSnapshot {
+                key,
+                filename,
+                path,
+                key_location: write_key,
+            })
+            .await?;
+        Ok(result)
+    }
+
+    /// Load a client from the state read with [`Stronghold::read_snapshot`].
+    ///  If the new actor uses a new `client_path` the former client path may be passed into the function call to read
+    /// the data into that actor.
+    pub async fn load_client(
+        &mut self,
+        client_path: Vec<u8>,
+        former_client_path: Option<Vec<u8>>,
+    ) -> StrongholdResult<Result<(), SnapshotError>> {
         let client_id = ClientId::load_from_path(&client_path, &client_path);
         let former_client_id = former_client_path.map(|cp| ClientId::load_from_path(&cp, &cp));
 
@@ -370,22 +401,13 @@ impl Stronghold {
             self.target().await?
         };
 
-        let mut key: [u8; 32] = [0u8; 32];
-        let keydata = keydata.as_ref();
-
-        key.copy_from_slice(keydata);
-
         // get address of snapshot actor
         let snapshot_actor = self.registry.send(GetSnapshot {}).await?;
 
         // read the snapshots contents
         let result = snapshot_actor
-            .send(ReadFromSnapshot {
-                key,
-                filename,
-                path,
-                id: client_id,
-                fid: former_client_id,
+            .send(LoadFromSnapshotState {
+                id: former_client_id.unwrap_or(client_id),
             })
             .await?;
         let content = match result {
@@ -406,20 +428,39 @@ impl Stronghold {
     /// Writes the entire state of the [`Stronghold`] into a snapshot.  All Actors and their associated data will be
     /// written into the specified snapshot. Requires keydata to encrypt the snapshot and a filename and path can be
     /// specified. The Keydata should implement and use Zeroize.
-    pub async fn write_all_to_snapshot<T: Zeroize + AsRef<Vec<u8>>>(
+    pub async fn write_snapshot<T: Zeroize + AsRef<Vec<u8>>>(
         &mut self,
         keydata: &T,
         filename: Option<String>,
         path: Option<PathBuf>,
-    ) -> StrongholdResult<Result<(), WriteError>> {
-        // this should be delegated to the secure client actor
-        // wrapping the interior functionality inside it.
-        let clients: Vec<(ClientId, Addr<SecureClient>)> = self.registry.send(GetAllClients).await?;
-
+    ) -> StrongholdResult<Result<(), SnapshotError>> {
         let mut key: [u8; 32] = [0u8; 32];
         let keydata = keydata.as_ref();
         key.copy_from_slice(keydata);
+        let use_key = UseKey::Key(key);
+        self.write_all_to_snapshot(use_key, filename, path).await
+    }
 
+    /// [`Stronghold::write_snapshot`] by using an existing key that is stored in `key_location`.
+    pub async fn write_snapshot_stored_key(
+        &mut self,
+        key_location: Location,
+        filename: Option<String>,
+        path: Option<PathBuf>,
+    ) -> StrongholdResult<Result<(), SnapshotError>> {
+        let use_key = UseKey::Stored(key_location);
+        self.write_all_to_snapshot(use_key, filename, path).await
+    }
+
+    async fn write_all_to_snapshot(
+        &mut self,
+        key: UseKey,
+        filename: Option<String>,
+        path: Option<PathBuf>,
+    ) -> StrongholdResult<Result<(), SnapshotError>> {
+        // this should be delegated to the secure client actor
+        // wrapping the interior functionality inside it.
+        let clients: Vec<(ClientId, Addr<SecureClient>)> = self.registry.send(GetAllClients).await?;
         // get snapshot actor
         let snapshot = self.registry.send(GetSnapshot {}).await?;
 
@@ -428,8 +469,11 @@ impl Stronghold {
             let data = client.send(GetData {}).await?;
 
             // fill into snapshot
-            snapshot.send(FillSnapshot { data, id }).await?;
-        } // end loop
+            match snapshot.send(FillSnapshot { data, id }).await? {
+                Ok(()) => {}
+                Err(e) => return Ok(Err(e)),
+            }
+        }
 
         // write snapshot
         let res = snapshot.send(WriteSnapshot { key, filename, path }).await?;
@@ -821,7 +865,14 @@ impl Stronghold {
         let res = self
             .remote_runtime_exec_chained(peer, client_path, vec![procedure.into()])
             .await?;
-        let mapped = res.map(|mut vec| vec.pop().unwrap().try_into().ok().unwrap());
+        let mapped = res.map(|mut output| {
+            output
+                .pop()
+                .expect("output.len() == procedures.len()")
+                .try_into()
+                .ok()
+                .expect("conversion can never fail.")
+        });
         Ok(mapped)
     }
 

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -39,7 +39,7 @@ mod tests;
 pub use crate::{
     interface::{ActorError, FatalEngineError, Stronghold, StrongholdResult},
     internals::Provider,
-    state::snapshot::{ReadError, WriteError},
+    state::snapshot::SnapshotError,
     utils::{Location, StrongholdFlags, VaultFlags},
 };
 pub use engine::{

--- a/client/src/procedures/primitives.rs
+++ b/client/src/procedures/primitives.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::types::*;
-use crate::{state::secure::SecureClient, Location};
+use crate::{utils::derive_vault_id, Location};
 pub use crypto::keys::slip10::{Chain, ChainCode};
 use crypto::{
     ciphers::{
@@ -199,7 +199,7 @@ impl Procedure for RevokeData {
     fn execute<R: Runner>(self, runner: &mut R) -> Result<Self::Output, ProcedureError> {
         runner.revoke_data(&self.location)?;
         if self.should_gc {
-            runner.garbage_collect(SecureClient::resolve_location(self.location).0);
+            runner.garbage_collect(self.location.resolve().0);
         }
         Ok(())
     }
@@ -215,7 +215,7 @@ impl Procedure for GarbageCollect {
     type Output = ();
 
     fn execute<R: Runner>(self, runner: &mut R) -> Result<Self::Output, ProcedureError> {
-        let vault_id = SecureClient::derive_vault_id(self.vault_path);
+        let vault_id = derive_vault_id(self.vault_path);
         runner.garbage_collect(vault_id);
         Ok(())
     }

--- a/client/src/state/key_store.rs
+++ b/client/src/state/key_store.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use engine::vault::{Key, VaultId};
-
 use std::collections::HashMap;
 
 use crate::Provider;
@@ -17,7 +16,12 @@ impl KeyStore {
         Self { store: HashMap::new() }
     }
 
-    /// Gets the key from the [`KeyStore`] and removes it. Returns an [`Option<Key<Provider>>`]
+    /// Gets the key from the [`KeyStore`] without removing it.
+    pub fn get_key(&self, id: VaultId) -> Option<&Key<Provider>> {
+        self.store.get(&id)
+    }
+
+    /// Gets the key from the [`KeyStore`] and removes it.
     pub fn take_key(&mut self, id: VaultId) -> Option<Key<Provider>> {
         self.store.remove(&id)
     }
@@ -34,7 +38,7 @@ impl KeyStore {
 
     /// Inserts a key into the [`KeyStore`] by [`VaultId`].  If the [`VaultId`] already exists, it just returns the
     /// existing &[`Key<Provider>`]
-    pub fn insert_key(&mut self, id: VaultId, key: Key<Provider>) -> &Key<Provider> {
+    pub fn entry_or_insert_key(&mut self, id: VaultId, key: Key<Provider>) -> &Key<Provider> {
         self.store.entry(id).or_insert(key)
     }
 

--- a/client/src/state/key_store.rs
+++ b/client/src/state/key_store.rs
@@ -16,12 +16,7 @@ impl KeyStore {
         Self { store: HashMap::new() }
     }
 
-    /// Gets the key from the [`KeyStore`] without removing it.
-    pub fn get_key(&self, id: VaultId) -> Option<&Key<Provider>> {
-        self.store.get(&id)
-    }
-
-    /// Gets the key from the [`KeyStore`] and removes it.
+    /// Gets the key from the [`KeyStore`] and removes it. Returns an [`Option<Key<Provider>>`]
     pub fn take_key(&mut self, id: VaultId) -> Option<Key<Provider>> {
         self.store.remove(&id)
     }
@@ -38,7 +33,7 @@ impl KeyStore {
 
     /// Inserts a key into the [`KeyStore`] by [`VaultId`].  If the [`VaultId`] already exists, it just returns the
     /// existing &[`Key<Provider>`]
-    pub fn entry_or_insert_key(&mut self, id: VaultId, key: Key<Provider>) -> &Key<Provider> {
+    pub fn insert_key(&mut self, id: VaultId, key: Key<Provider>) -> &Key<Provider> {
         self.store.entry(id).or_insert(key)
     }
 

--- a/client/src/state/secure.rs
+++ b/client/src/state/secure.rs
@@ -8,13 +8,12 @@ use crate::{
     internals,
     procedures::{FatalProcedureError, Products, Runner},
     state::key_store::KeyStore,
-    utils::LoadFromPath,
     Location,
 };
 use engine::{
     new_runtime::memories::buffer::Buffer,
     store::Cache,
-    vault::{ClientId, DbView, RecordHint, RecordId, VaultId},
+    vault::{ClientId, DbView, RecordHint, VaultId},
 };
 use std::time::Duration;
 
@@ -78,63 +77,9 @@ impl SecureClient {
         self.store = store;
     }
 
-    /// Resolves a location to a `VaultId` and a `RecordId`
-    pub fn resolve_location<L: AsRef<Location>>(l: L) -> (VaultId, RecordId) {
-        match l.as_ref() {
-            Location::Generic {
-                vault_path,
-                record_path,
-            } => {
-                let vid = Self::derive_vault_id(vault_path);
-                let rid = RecordId::load_from_path(vid.as_ref(), record_path);
-                (vid, rid)
-            }
-            Location::Counter { vault_path, counter } => {
-                let vid = Self::derive_vault_id(vault_path);
-                let rid = Self::derive_record_id(vault_path, *counter);
-
-                (vid, rid)
-            }
-        }
-    }
-
-    /// Gets the [`VaultId`] from a specified path.
-    pub fn derive_vault_id<P: AsRef<Vec<u8>>>(path: P) -> VaultId {
-        VaultId::load_from_path(path.as_ref(), path.as_ref())
-    }
-
-    /// Derives the counter [`RecordId`] from the given vault path and the counter value.
-    pub fn derive_record_id<P: AsRef<Vec<u8>>>(vault_path: P, ctr: usize) -> RecordId {
-        let vault_path = vault_path.as_ref();
-
-        let path = if ctr == 0 {
-            format!("{:?}{}", vault_path, "first_record")
-        } else {
-            format!("{:?}{}", vault_path, ctr)
-        };
-
-        RecordId::load_from_path(path.as_bytes(), path.as_bytes())
-    }
-
     /// Gets the client string.
     pub fn get_client_str(&self) -> String {
         self.client_id.into()
-    }
-
-    /// Gets the current index of a record if its a counter.
-    pub fn get_index_from_record_id<P: AsRef<Vec<u8>>>(&self, vault_path: P, record_id: RecordId) -> usize {
-        let mut ctr = 0;
-        let vault_path = vault_path.as_ref();
-
-        while ctr <= 32_000_000 {
-            let rid = Self::derive_record_id(vault_path, ctr);
-            if record_id == rid {
-                break;
-            }
-            ctr += 1;
-        }
-
-        ctr
     }
 }
 
@@ -143,7 +88,7 @@ impl Runner for SecureClient {
     where
         F: FnOnce(Buffer<u8>) -> Result<T, FatalProcedureError>,
     {
-        let (vault_id, record_id) = Self::resolve_location(location);
+        let (vault_id, record_id) = location.resolve();
         let key = self
             .keystore
             .take_key(vault_id)
@@ -155,7 +100,7 @@ impl Runner for SecureClient {
             Ok(())
         };
         let res = self.db.get_guard(&key, vault_id, record_id, execute_procedure);
-        self.keystore.insert_key(vault_id, key);
+        self.keystore.entry_or_insert_key(vault_id, key);
 
         match res {
             Ok(()) => Ok(ret.unwrap()),
@@ -173,8 +118,8 @@ impl Runner for SecureClient {
     where
         F: FnOnce(Buffer<u8>) -> Result<Products<T>, FatalProcedureError>,
     {
-        let (vid0, rid0) = Self::resolve_location(location0);
-        let (vid1, rid1) = Self::resolve_location(location1);
+        let (vid0, rid0) = location0.resolve();
+        let (vid1, rid1) = location1.resolve();
 
         let key0 = self.keystore.take_key(vid0).ok_or(VaultError::VaultNotFound(vid0))?;
 
@@ -199,10 +144,10 @@ impl Runner for SecureClient {
             res = self
                 .db
                 .exec_proc(&key0, vid0, rid0, &key1, vid1, rid1, hint, execute_procedure);
-            self.keystore.insert_key(vid1, key1);
+            self.keystore.entry_or_insert_key(vid1, key1);
         }
 
-        self.keystore.insert_key(vid0, key0);
+        self.keystore.entry_or_insert_key(vid0, key0);
 
         match res {
             Ok(()) => Ok(ret.unwrap()),
@@ -211,22 +156,22 @@ impl Runner for SecureClient {
     }
 
     fn write_to_vault(&mut self, location: &Location, hint: RecordHint, value: Vec<u8>) -> Result<(), RecordError> {
-        let (vault_id, record_id) = Self::resolve_location(location);
+        let (vault_id, record_id) = location.resolve();
         if !self.keystore.vault_exists(vault_id) {
             let key = self.keystore.create_key(vault_id);
             self.db.init_vault(key, vault_id);
         }
         let key = self.keystore.take_key(vault_id).unwrap();
         let res = self.db.write(&key, vault_id, record_id, &value, hint);
-        self.keystore.insert_key(vault_id, key);
+        self.keystore.entry_or_insert_key(vault_id, key);
         res
     }
 
     fn revoke_data(&mut self, location: &Location) -> Result<(), RecordError> {
-        let (vault_id, record_id) = Self::resolve_location(location);
+        let (vault_id, record_id) = location.resolve();
         if let Some(key) = self.keystore.take_key(vault_id) {
             let res = self.db.revoke_record(&key, vault_id, record_id);
-            self.keystore.insert_key(vault_id, key);
+            self.keystore.entry_or_insert_key(vault_id, key);
             res?;
         }
         Ok(())
@@ -238,59 +183,7 @@ impl Runner for SecureClient {
             None => return false,
         };
         self.db.garbage_collect_vault(&key, vault_id);
-        self.keystore.insert_key(vault_id, key);
+        self.keystore.entry_or_insert_key(vault_id, key);
         true
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    use crate::Provider;
-
-    #[test]
-    fn test_rid_internals() {
-        let clientid = ClientId::random::<Provider>().unwrap();
-
-        let vault_path = b"some_vault".to_vec();
-
-        let client: SecureClient = SecureClient::new(clientid);
-        let mut ctr = 0;
-        let mut ctr2 = 0;
-
-        let _rid = SecureClient::derive_record_id(vault_path.clone(), ctr);
-        let _rid2 = SecureClient::derive_record_id(vault_path.clone(), ctr2);
-
-        ctr += 1;
-        ctr2 += 1;
-
-        let _rid = SecureClient::derive_record_id(vault_path.clone(), ctr);
-        let _rid2 = SecureClient::derive_record_id(vault_path.clone(), ctr2);
-
-        ctr += 1;
-
-        let rid = SecureClient::derive_record_id(vault_path.clone(), ctr);
-
-        let test_rid = SecureClient::derive_record_id(vault_path.clone(), 2);
-        let ctr = client.get_index_from_record_id(vault_path, rid);
-
-        assert_eq!(test_rid, rid);
-        assert_eq!(2, ctr);
-    }
-
-    #[test]
-    fn test_location_counter_api() {
-        let vidlochead = Location::counter::<_, usize>("some_vault", 0);
-        let vidlochead2 = Location::counter::<_, usize>("some_vault 2", 0);
-
-        let (_, rid) = SecureClient::resolve_location(&vidlochead);
-        let (_, rid2) = SecureClient::resolve_location(&vidlochead2);
-
-        let (_, rid_head) = SecureClient::resolve_location(&vidlochead);
-        let (_, rid_head_2) = SecureClient::resolve_location(&vidlochead2);
-
-        assert_eq!(rid, rid_head);
-        assert_eq!(rid2, rid_head_2);
     }
 }

--- a/client/src/state/secure.rs
+++ b/client/src/state/secure.rs
@@ -100,7 +100,7 @@ impl Runner for SecureClient {
             Ok(())
         };
         let res = self.db.get_guard(&key, vault_id, record_id, execute_procedure);
-        self.keystore.entry_or_insert_key(vault_id, key);
+        self.keystore.insert_key(vault_id, key);
 
         match res {
             Ok(()) => Ok(ret.unwrap()),
@@ -144,10 +144,10 @@ impl Runner for SecureClient {
             res = self
                 .db
                 .exec_proc(&key0, vid0, rid0, &key1, vid1, rid1, hint, execute_procedure);
-            self.keystore.entry_or_insert_key(vid1, key1);
+            self.keystore.insert_key(vid1, key1);
         }
 
-        self.keystore.entry_or_insert_key(vid0, key0);
+        self.keystore.insert_key(vid0, key0);
 
         match res {
             Ok(()) => Ok(ret.unwrap()),
@@ -163,7 +163,7 @@ impl Runner for SecureClient {
         }
         let key = self.keystore.take_key(vault_id).unwrap();
         let res = self.db.write(&key, vault_id, record_id, &value, hint);
-        self.keystore.entry_or_insert_key(vault_id, key);
+        self.keystore.insert_key(vault_id, key);
         res
     }
 
@@ -171,7 +171,7 @@ impl Runner for SecureClient {
         let (vault_id, record_id) = location.resolve();
         if let Some(key) = self.keystore.take_key(vault_id) {
             let res = self.db.revoke_record(&key, vault_id, record_id);
-            self.keystore.entry_or_insert_key(vault_id, key);
+            self.keystore.insert_key(vault_id, key);
             res?;
         }
         Ok(())
@@ -183,7 +183,7 @@ impl Runner for SecureClient {
             None => return false,
         };
         self.db.garbage_collect_vault(&key, vault_id);
-        self.keystore.entry_or_insert_key(vault_id, key);
+        self.keystore.insert_key(vault_id, key);
         true
     }
 }

--- a/client/src/state/snapshot.rs
+++ b/client/src/state/snapshot.rs
@@ -3,72 +3,161 @@
 
 #![allow(clippy::type_complexity)]
 
-use crate::{state::secure::Store, Provider};
+use crate::{
+    state::{key_store::KeyStore, secure::Store},
+    Location, Provider,
+};
 
 use engine::{
-    snapshot::{self, read_from, write_to, Key, ReadError as EngineReadError, WriteError as EngineWriteError},
-    vault::{ClientId, DbView, Key as PKey, VaultId},
+    snapshot::{
+        self, read, read_from as read_from_file, write, write_to as write_to_file, Key, ReadError as EngineReadError,
+        WriteError as EngineWriteError,
+    },
+    vault::{ClientId, DbView, Key as PKey, RecordHint, RecordId, VaultId},
 };
 
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, io, path::Path};
+use std::{collections::HashMap, convert::Infallible, io, ops::Deref, path::Path};
+use stronghold_utils::random;
 use thiserror::Error as DeriveError;
 
+type EncryptedClientState = (Vec<u8>, Store);
+pub type ClientState = (HashMap<VaultId, PKey<Provider>>, DbView<Provider>, Store);
+
 /// Wrapper for the [`SnapshotState`] data structure.
-#[derive(Default)]
 pub struct Snapshot {
-    pub state: SnapshotState,
+    // Keys for vaults in db and for the encrypted client states.
+    keystore: KeyStore,
+    // Db with snapshot keys.
+    db: DbView<Provider>,
+    // Loaded snapshot states with each client state separately encrypted.
+    states: HashMap<ClientId, EncryptedClientState>,
+}
+
+impl Default for Snapshot {
+    fn default() -> Self {
+        Snapshot {
+            keystore: KeyStore::new(),
+            db: DbView::new(),
+            states: HashMap::new(),
+        }
+    }
+}
+
+pub enum UseKey {
+    Key(snapshot::Key),
+    Stored(Location),
 }
 
 /// Data structure that is written to the snapshot.
 #[derive(Deserialize, Serialize, Default)]
-pub struct SnapshotState(HashMap<ClientId, (HashMap<VaultId, PKey<Provider>>, DbView<Provider>, Store)>);
+pub struct SnapshotState(HashMap<ClientId, ClientState>);
 
 impl Snapshot {
     /// Creates a new [`Snapshot`] from a buffer of [`SnapshotState`] state.
-    pub fn new(state: SnapshotState) -> Self {
-        Self { state }
+    pub fn from_state(
+        state: SnapshotState,
+        snapshot_key: Key,
+        write_key: Option<(VaultId, RecordId)>,
+    ) -> Result<Self, SnapshotError> {
+        let mut snapshot = Snapshot::default();
+        if let Some((vid, rid)) = write_key {
+            let key = snapshot.keystore.create_key(vid);
+            snapshot
+                .db
+                .write(key, vid, rid, &snapshot_key, RecordHint::new("").unwrap())
+                .unwrap();
+        }
+        for (client_id, state) in state.0 {
+            snapshot.add_data(client_id, state)?;
+        }
+        Ok(snapshot)
     }
 
     /// Gets the state component parts as a tuple.
-    pub fn get_state(&mut self, id: ClientId) -> (HashMap<VaultId, PKey<Provider>>, DbView<Provider>, Store) {
-        match self.state.0.remove(&id) {
-            Some(t) => t,
-            None => (HashMap::default(), DbView::default(), Store::default()),
+    pub fn get_snapshot_state(&self) -> Result<SnapshotState, SnapshotError> {
+        let mut state = SnapshotState::default();
+        for client_id in self.states.keys() {
+            let id = *client_id;
+            let client_state = self.get_state(id)?;
+            state.0.insert(id, client_state);
         }
+        Ok(state)
+    }
+
+    /// Gets the state component parts as a tuple.
+    pub fn get_state(&self, id: ClientId) -> Result<ClientState, SnapshotError> {
+        let vid = VaultId(id.0);
+        let ((encrypted, store), key) = match self
+            .states
+            .get(&id)
+            .and_then(|state| self.keystore.get_key(vid).map(|pkey| (state, pkey)))
+            .and_then(|(state, pkey)| {
+                let pkey = &pkey.key;
+                pkey.borrow().deref().try_into().ok().map(|k| (state, k))
+            }) {
+            Some(t) => t,
+            None => return Ok((HashMap::default(), DbView::default(), Store::default())),
+        };
+        let decrypted = read(&mut encrypted.as_slice(), &key, &[])?;
+        let (keys, db) = bincode::deserialize(&decrypted)?;
+        Ok((keys, db, store.clone()))
     }
 
     /// Checks to see if the [`ClientId`] exists in the snapshot hashmap.
     pub fn has_data(&self, cid: ClientId) -> bool {
-        self.state.0.contains_key(&cid)
+        self.states.contains_key(&cid)
     }
 
     /// Reads state from the specified named snapshot or the specified path
     /// TODO: Add associated data.
-    pub fn read_from_snapshot(name: Option<&str>, path: Option<&Path>, key: Key) -> Result<Self, ReadError> {
-        let state = match path {
-            Some(p) => read_from(p, &key, &[])?,
-            None => read_from(&snapshot::files::get_path(name)?, &key, &[])?,
+    pub fn read_from_snapshot(
+        name: Option<&str>,
+        path: Option<&Path>,
+        key: Key,
+        write_key: Option<(VaultId, RecordId)>,
+    ) -> Result<Self, SnapshotError> {
+        let data = match path {
+            Some(p) => read_from_file(p, &key, &[])?,
+            None => read_from_file(&snapshot::files::get_path(name)?, &key, &[])?,
         };
 
-        let data =
-            SnapshotState::deserialize(state).map_err(|_| ReadError::CorruptedContent("Decryption failed.".into()))?;
-
-        Ok(Self::new(data))
+        let state = bincode::deserialize(&data)?;
+        Snapshot::from_state(state, key, write_key)
     }
 
     /// Writes state to the specified named snapshot or the specified path
     /// TODO: Add associated data.
-    pub fn write_to_snapshot(&self, name: Option<&str>, path: Option<&Path>, key: Key) -> Result<(), WriteError> {
-        let data = self
-            .state
-            .serialize()
-            .map_err(|_| WriteError::CorruptedData("Serialization failed.".into()))?;
+    pub fn write_to_snapshot(
+        &mut self,
+        name: Option<&str>,
+        path: Option<&Path>,
+        use_key: UseKey,
+    ) -> Result<(), SnapshotError> {
+        let state = self.get_snapshot_state()?;
+        let data = bincode::serialize(&state)?;
+
+        let key = match use_key {
+            UseKey::Key(k) => k,
+            UseKey::Stored(loc) => {
+                let (vid, rid) = loc.resolve();
+                let pkey = self.keystore.get_key(vid).ok_or(SnapshotError::SnapshotKey(vid, rid))?;
+                let mut data = Vec::new();
+                self.db
+                    .get_guard::<Infallible, _>(pkey, vid, rid, |guarded_data| {
+                        let guarded_data = guarded_data.borrow();
+                        data.extend_from_slice(&*guarded_data);
+                        Ok(())
+                    })
+                    .map_err(|e| SnapshotError::Vault(format!("{}", e)))?;
+                data.try_into().map_err(|_| SnapshotError::SnapshotKey(vid, rid))?
+            }
+        };
 
         // TODO: This is a hack and probably should be removed when we add proper error handling.
         let f = move || match path {
-            Some(p) => write_to(&data, p, &key, &[]),
-            None => write_to(&data, &snapshot::files::get_path(name)?, &key, &[]),
+            Some(p) => write_to_file(&data, p, &key, &[]),
+            None => write_to_file(&data, &snapshot::files::get_path(name)?, &key, &[]),
         };
 
         match f() {
@@ -76,35 +165,47 @@ impl Snapshot {
             Err(_) => f().map_err(|e| e.into()),
         }
     }
-}
 
-impl SnapshotState {
-    /// Creates a new snapshot state.
-    pub fn new(id: ClientId, data: (HashMap<VaultId, PKey<Provider>>, DbView<Provider>, Store)) -> Self {
-        let mut state = HashMap::new();
-        state.insert(id, data);
-
-        Self(state)
+    /// Adds data to the snapshot state hashmap.
+    pub fn add_data(
+        &mut self,
+        id: ClientId,
+        (keys, db, store): (HashMap<VaultId, PKey<Provider>>, DbView<Provider>, Store),
+    ) -> Result<(), SnapshotError> {
+        let bytes = bincode::serialize(&(keys, db))?;
+        let vault_id = VaultId(id.0);
+        let key: snapshot::Key = random::random();
+        let mut buffer = Vec::new();
+        write(&bytes, &mut buffer, &key, &[])?;
+        let pkey = PKey::load(key.into()).expect("Provider::box_key_len == KEY_SIZE == 32");
+        self.keystore.entry_or_insert_key(vault_id, pkey);
+        self.states.insert(id, (buffer, store));
+        Ok(())
     }
 
     /// Adds data to the snapshot state hashmap.
-    pub fn add_data(&mut self, id: ClientId, data: (HashMap<VaultId, PKey<Provider>>, DbView<Provider>, Store)) {
-        self.0.insert(id, data);
-    }
-
-    /// Serializes the snapshot state into bytes.
-    pub fn serialize(&self) -> bincode::Result<Vec<u8>> {
-        bincode::serialize(&self)
-    }
-
-    /// Deserializes the snapshot state from bytes.
-    pub fn deserialize(data: Vec<u8>) -> bincode::Result<Self> {
-        bincode::deserialize(&data)
+    pub fn store_snapshot_key(
+        &mut self,
+        snapshot_key: snapshot::Key,
+        vault_id: VaultId,
+        record_id: RecordId,
+    ) -> Result<(), SnapshotError> {
+        let key = self.keystore.create_key(vault_id);
+        self.db
+            .write(
+                key,
+                vault_id,
+                record_id,
+                &snapshot_key,
+                RecordHint::new("").expect("0 <= 24"),
+            )
+            .map_err(|e| SnapshotError::Vault(format!("{}", e)))?;
+        Ok(())
     }
 }
 
 #[derive(Debug, DeriveError)]
-pub enum ReadError {
+pub enum SnapshotError {
     #[error("I/O error: {0}")]
     Io(#[from] io::Error),
 
@@ -113,15 +214,27 @@ pub enum ReadError {
 
     #[error("invalid file {0}")]
     InvalidFile(String),
+
+    #[error("missing or invalid snapshot key in {0:?} {1:?}")]
+    SnapshotKey(VaultId, RecordId),
+
+    #[error("vault error: {0}")]
+    Vault(String),
 }
 
-impl From<EngineReadError> for ReadError {
+impl From<bincode::Error> for SnapshotError {
+    fn from(e: bincode::Error) -> Self {
+        SnapshotError::CorruptedContent(format!("bincode error: {}", e))
+    }
+}
+
+impl From<EngineReadError> for SnapshotError {
     fn from(e: EngineReadError) -> Self {
         match e {
-            EngineReadError::CorruptedContent(reason) => ReadError::CorruptedContent(reason),
-            EngineReadError::InvalidFile => ReadError::InvalidFile("Not a Snapshot.".into()),
-            EngineReadError::Io(io) => ReadError::Io(io),
-            EngineReadError::UnsupportedVersion { expected, found } => ReadError::InvalidFile(format!(
+            EngineReadError::CorruptedContent(reason) => SnapshotError::CorruptedContent(reason),
+            EngineReadError::InvalidFile => SnapshotError::InvalidFile("Not a Snapshot.".into()),
+            EngineReadError::Io(io) => SnapshotError::Io(io),
+            EngineReadError::UnsupportedVersion { expected, found } => SnapshotError::InvalidFile(format!(
                 "Unsupported version: expected {:?}, found {:?}.",
                 expected, found
             )),
@@ -129,21 +242,12 @@ impl From<EngineReadError> for ReadError {
     }
 }
 
-#[derive(Debug, DeriveError)]
-pub enum WriteError {
-    #[error("I/O error: {0}")]
-    Io(#[from] io::Error),
-
-    #[error("corrupted data: {0}")]
-    CorruptedData(String),
-}
-
-impl From<EngineWriteError> for WriteError {
+impl From<EngineWriteError> for SnapshotError {
     fn from(e: EngineWriteError) -> Self {
         match e {
-            EngineWriteError::Io(io) => WriteError::Io(io),
-            EngineWriteError::CorruptedData(e) => WriteError::CorruptedData(e),
-            EngineWriteError::GenerateRandom(_) => WriteError::Io(io::ErrorKind::Other.into()),
+            EngineWriteError::Io(io) => SnapshotError::Io(io),
+            EngineWriteError::CorruptedData(e) => SnapshotError::CorruptedContent(e),
+            EngineWriteError::GenerateRandom(_) => SnapshotError::Io(io::ErrorKind::Other.into()),
         }
     }
 }

--- a/client/src/state/snapshot.rs
+++ b/client/src/state/snapshot.rs
@@ -62,11 +62,7 @@ impl Snapshot {
     ) -> Result<Self, SnapshotError> {
         let mut snapshot = Snapshot::default();
         if let Some((vid, rid)) = write_key {
-            let key = snapshot.keystore.create_key(vid);
-            snapshot
-                .db
-                .write(key, vid, rid, &snapshot_key, RecordHint::new("").unwrap())
-                .unwrap();
+            snapshot.store_snapshot_key(snapshot_key, vid, rid)?;
         }
         for (client_id, state) in state.0 {
             snapshot.add_data(client_id, state)?;

--- a/client/src/tests/interface_tests.rs
+++ b/client/src/tests/interface_tests.rs
@@ -122,16 +122,21 @@ async fn test_stronghold() {
     stronghold.garbage_collect(vault_path).await.unwrap();
 
     stronghold
-        .write_all_to_snapshot(&key_data, Some("test0".into()), None)
+        .write_snapshot(&key_data, Some("test0".into()), None)
         .await
         .unwrap_or_else(|e| panic!("Actor error: {}", e))
         .unwrap_or_else(|e| panic!("Write snapshot error: {}", e));
 
     stronghold
-        .read_snapshot(client_path.clone(), None, &key_data, Some("test0".into()), None)
+        .read_snapshot(&key_data, Some("test0".into()), None, None)
         .await
         .unwrap_or_else(|e| panic!("Actor error: {}", e))
         .unwrap_or_else(|e| panic!("Read snapshot error: {}", e));
+
+    stronghold
+        .spawn_stronghold_actor(client_path.clone(), vec![])
+        .await
+        .unwrap();
 
     // read head after reading snapshot.
 
@@ -250,7 +255,7 @@ async fn run_stronghold_multi_actors() {
     println!("actor 0: {:?}", ids);
 
     stronghold
-        .write_all_to_snapshot(&key_data.to_vec(), Some("megasnap".into()), None)
+        .write_snapshot(&key_data.to_vec(), Some("megasnap".into()), None)
         .await
         .unwrap_or_else(|e| panic!("Actor error: {}", e))
         .unwrap_or_else(|e| panic!("Write snapshot error: {}", e));
@@ -266,13 +271,13 @@ async fn run_stronghold_multi_actors() {
         .unwrap();
 
     stronghold
-        .read_snapshot(
-            client_path2.clone(),
-            Some(client_path1.clone()),
-            &key_data,
-            Some("megasnap".into()),
-            None,
-        )
+        .read_snapshot(&key_data, Some("megasnap".into()), None, None)
+        .await
+        .unwrap_or_else(|e| panic!("Actor error: {}", e))
+        .unwrap_or_else(|e| panic!("Read snapshot error: {}", e));
+
+    stronghold
+        .load_client(client_path2.clone(), Some(client_path1.clone()))
         .await
         .unwrap_or_else(|e| panic!("Actor error: {}", e))
         .unwrap_or_else(|e| panic!("Read snapshot error: {}", e));
@@ -329,13 +334,7 @@ async fn run_stronghold_multi_actors() {
         .unwrap();
 
     stronghold
-        .read_snapshot(
-            client_path3,
-            Some(client_path0.clone()),
-            &key_data,
-            Some("megasnap".into()),
-            None,
-        )
+        .load_client(client_path3, Some(client_path0.clone()))
         .await
         .unwrap_or_else(|e| panic!("Actor error: {}", e))
         .unwrap_or_else(|e| panic!("Read snapshot error: {}", e));
@@ -382,7 +381,7 @@ async fn test_stronghold_generics() {
     assert_eq!(std::str::from_utf8(&p.unwrap()), Ok("AAAAAA"));
 
     stronghold
-        .write_all_to_snapshot(&key_data.to_vec(), Some("generic".into()), None)
+        .write_snapshot(&key_data.to_vec(), Some("generic".into()), None)
         .await
         .unwrap_or_else(|e| panic!("Actor error: {}", e))
         .unwrap_or_else(|e| panic!("Write snapshot error: {}", e));

--- a/client/src/tests/interface_tests.rs
+++ b/client/src/tests/interface_tests.rs
@@ -403,7 +403,7 @@ async fn test_store_snapshot_key() {
     let loc = Location::counter::<_, usize>("path", 0);
     let data = random::bytestring(1024);
     let snapshot_key_loc = Location::generic(random::string(256), random::string(256));
-    let snapshot = random::string(16);
+    let snapshot = "test_store_snapshot_key".to_string();
 
     let mut stronghold = Stronghold::init_stronghold_system(client_path.clone(), vec![])
         .await

--- a/client/src/tests/procedures_tests.rs
+++ b/client/src/tests/procedures_tests.rs
@@ -18,7 +18,6 @@ use crate::{
         Ed25519Sign, GenerateKey, GenerateSecret, Hkdf, KeyType, MnemonicLanguage, PublicKey, Sha2Hash, Slip10Derive,
         Slip10DeriveInput, Slip10Generate, X25519DiffieHellman,
     },
-    state::secure::SecureClient,
     Location, Stronghold,
 };
 
@@ -92,15 +91,9 @@ async fn usecase_ed25519() -> Result<(), Box<dyn std::error::Error>> {
 
     let list = sh.list_hints_and_ids(vault_path).await?;
     assert_eq!(list.len(), 2);
-    let (_, hint) = list
-        .iter()
-        .find(|(id, _)| *id == SecureClient::resolve_location(seed.clone()).1)
-        .unwrap();
+    let (_, hint) = list.iter().find(|(id, _)| *id == seed.resolve().1).unwrap();
     assert_eq!(*hint, seed_hint);
-    let (_, hint) = list
-        .iter()
-        .find(|(id, _)| *id == SecureClient::resolve_location(key.clone()).1)
-        .unwrap();
+    let (_, hint) = list.iter().find(|(id, _)| *id == key.resolve().1).unwrap();
     assert_eq!(*hint, key_hint);
     Ok(())
 }

--- a/client/src/utils.rs
+++ b/client/src/utils.rs
@@ -6,7 +6,7 @@ mod types;
 
 pub use self::{
     ids::LoadFromPath,
-    types::{Location, StrongholdFlags, VaultFlags},
+    types::{derive_record_id, derive_vault_id, get_index_from_record_id, Location, StrongholdFlags, VaultFlags},
 };
 
 /// Gets the index of a slice.

--- a/client/src/utils/types.rs
+++ b/client/src/utils/types.rs
@@ -1,7 +1,10 @@
 // Copyright 2020-2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use engine::vault::{RecordId, VaultId};
 use serde::{Deserialize, Serialize};
+
+use super::LoadFromPath;
 
 /// A `Location` type used to specify where in the `Stronghold` a piece of data should be stored. A generic location
 /// specifies a non-versioned location while a counter location specifies a versioned location. The Counter location can
@@ -46,6 +49,25 @@ impl Location {
         }
     }
 
+    pub(crate) fn resolve(&self) -> (VaultId, RecordId) {
+        match self {
+            Location::Generic {
+                vault_path,
+                record_path,
+            } => {
+                let vid = derive_vault_id(vault_path);
+                let rid = RecordId::load_from_path(vid.as_ref(), record_path);
+                (vid, rid)
+            }
+            Location::Counter { vault_path, counter } => {
+                let vid = derive_vault_id(vault_path);
+                let rid = derive_record_id(vault_path, *counter);
+
+                (vid, rid)
+            }
+        }
+    }
+
     /// Used to generate a constant generic location.
     pub const fn const_generic(vault_path: Vec<u8>, record_path: Vec<u8>) -> Self {
         Self::Generic {
@@ -66,6 +88,40 @@ impl AsRef<Location> for Location {
     }
 }
 
+/// Gets the [`VaultId`] from a specified path.
+pub fn derive_vault_id<P: AsRef<Vec<u8>>>(path: P) -> VaultId {
+    VaultId::load_from_path(path.as_ref(), path.as_ref())
+}
+
+/// Derives the counter [`RecordId`] from the given vault path and the counter value.
+pub fn derive_record_id<P: AsRef<Vec<u8>>>(vault_path: P, ctr: usize) -> RecordId {
+    let vault_path = vault_path.as_ref();
+
+    let path = if ctr == 0 {
+        format!("{:?}{}", vault_path, "first_record")
+    } else {
+        format!("{:?}{}", vault_path, ctr)
+    };
+
+    RecordId::load_from_path(path.as_bytes(), path.as_bytes())
+}
+
+/// Gets the current index of a record if its a counter.
+pub fn get_index_from_record_id<P: AsRef<Vec<u8>>>(vault_path: P, record_id: RecordId) -> usize {
+    let mut ctr = 0;
+    let vault_path = vault_path.as_ref();
+
+    while ctr <= 32_000_000 {
+        let rid = derive_record_id(vault_path, ctr);
+        if record_id == rid {
+            break;
+        }
+        ctr += 1;
+    }
+
+    ctr
+}
+
 /// Policy options for modifying an entire Stronghold.  Must be specified on creation.
 ///
 /// note:
@@ -78,3 +134,49 @@ pub enum StrongholdFlags {
 /// Policy options for for a specific vault.  Must be specified on creation.
 #[derive(Clone, Debug)]
 pub enum VaultFlags {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_rid_internals() {
+        let vault_path = b"some_vault".to_vec();
+        let mut ctr = 0;
+        let mut ctr2 = 0;
+
+        let _rid = derive_record_id(vault_path.clone(), ctr);
+        let _rid2 = derive_record_id(vault_path.clone(), ctr2);
+
+        ctr += 1;
+        ctr2 += 1;
+
+        let _rid = derive_record_id(vault_path.clone(), ctr);
+        let _rid2 = derive_record_id(vault_path.clone(), ctr2);
+
+        ctr += 1;
+
+        let rid = derive_record_id(vault_path.clone(), ctr);
+
+        let test_rid = derive_record_id(vault_path.clone(), 2);
+        let ctr = get_index_from_record_id(vault_path, rid);
+
+        assert_eq!(test_rid, rid);
+        assert_eq!(2, ctr);
+    }
+
+    #[test]
+    fn test_location_counter_api() {
+        let vidlochead = Location::counter::<_, usize>("some_vault", 0);
+        let vidlochead2 = Location::counter::<_, usize>("some_vault 2", 0);
+
+        let (_, rid) = vidlochead.resolve();
+        let (_, rid2) = vidlochead2.resolve();
+
+        let (_, rid_head) = vidlochead.resolve();
+        let (_, rid_head_2) = vidlochead2.resolve();
+
+        assert_eq!(rid, rid_head);
+        assert_eq!(rid2, rid_head_2);
+    }
+}

--- a/engine/src/vault.rs
+++ b/engine/src/vault.rs
@@ -24,7 +24,8 @@ pub mod view;
 
 pub use crate::vault::{
     base64::{Base64Decodable, Base64Encodable},
-    crypto_box::{BoxProvider, Decrypt, Encrypt, Key},
+    crypto_box::{BoxProvider, Decrypt, DecryptError, Encrypt, Key, NCDecrypt, NCEncrypt, NCKey},
+    key_store::KeyStore,
     types::utils::{ChainId, ClientId, Id, InvalidLength, RecordHint, RecordId, VaultId},
     view::{DbView, RecordError, VaultError},
 };

--- a/engine/src/vault/crypto_box.rs
+++ b/engine/src/vault/crypto_box.rs
@@ -72,7 +72,6 @@ impl<T: BoxProvider> Key<T> {
     /// attempts to load a key from inputted data
     ///
     /// Return `None` if the key length doesn't match [`BoxProvider::box_key_len`].
-    #[allow(dead_code)]
     pub fn load(key: Vec<u8>) -> Option<Self> {
         if key.len() == T::box_key_len() {
             Some(Self {
@@ -137,7 +136,6 @@ pub trait Encrypt<T: From<Vec<u8>>>: AsRef<[u8]> {
 }
 
 #[derive(Debug)]
-#[allow(dead_code)]
 pub enum DecryptError<E: Debug> {
     Invalid,
     Provider(E),
@@ -168,7 +166,6 @@ pub struct NCKey<T: BoxProvider> {
 
 impl<T: BoxProvider> NCKey<T> {
     /// generate a random key using secure random bytes
-    #[allow(dead_code)]
     pub fn random() -> Self {
         Self {
             key: {
@@ -188,7 +185,6 @@ impl<T: BoxProvider> NCKey<T> {
     /// attempts to load a key from inputted data
     ///
     /// Return `None` if the key length doesn't match [`BoxProvider::box_key_len`].
-    #[allow(dead_code)]
     pub fn load(key: Vec<u8>) -> Option<Self> {
         if key.len() == T::box_key_len() {
             Some(Self {
@@ -201,7 +197,6 @@ impl<T: BoxProvider> NCKey<T> {
         }
     }
 
-    #[allow(dead_code)]
     pub fn encrypt_key<AD: AsRef<[u8]>>(&self, data: &Key<T>, ad: AD) -> Result<Vec<u8>, T::Error> {
         let key = Key {
             key: self.key.unlock().expect("Failed to unlock non contiguous memory"),
@@ -210,7 +205,6 @@ impl<T: BoxProvider> NCKey<T> {
         T::box_seal(&key, ad.as_ref(), &*data.key.borrow())
     }
 
-    #[allow(dead_code)]
     pub fn decrypt_key<AD: AsRef<[u8]>>(&self, data: Vec<u8>, ad: AD) -> Result<Key<T>, DecryptError<T::Error>> {
         let key = Key {
             key: self.key.unlock().expect("Failed to unlock non contiguous memory"),
@@ -221,7 +215,6 @@ impl<T: BoxProvider> NCKey<T> {
     }
 
     // /// get the key's bytes from the [`Buffer`]
-    // #[allow(dead_code)]
     // pub fn bytes<'a>(&'a self) -> Ref<'a, u8> {
     //     // hacks the guarded type.  Probably not the best solution.
     //     let buf = self.key.unlock().expect("Failed to unlock non-contiguous memory");

--- a/engine/src/vault/key_store.rs
+++ b/engine/src/vault/key_store.rs
@@ -16,9 +16,13 @@ pub struct KeyStore<P: BoxProvider> {
     master_key: NCKey<P>,
 }
 
-impl<P: BoxProvider> KeyStore<P> {
-    #![allow(dead_code)]
+impl<P: BoxProvider> Default for KeyStore<P> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
+impl<P: BoxProvider> KeyStore<P> {
     /// Creates a new [`KeyStore`].
     pub fn new() -> Self {
         Self {

--- a/engine/src/vault/key_store.rs
+++ b/engine/src/vault/key_store.rs
@@ -33,7 +33,6 @@ impl<P: BoxProvider> KeyStore<P> {
 
     /// Gets the encrypted key from the [`KeyStore`] and removes it.
     /// Decrypt it with the `master_key` and `vault_id` as salt.
-    /// Returns an [`Option<Key<P>>`]
     pub fn take_key(&mut self, id: VaultId) -> Option<Key<P>> {
         let enc_key = self.store.remove(&id)?;
         self.master_key.decrypt_key(enc_key, id).ok()
@@ -47,29 +46,30 @@ impl<P: BoxProvider> KeyStore<P> {
     /// Creates a new key in the [`KeyStore`] if it does not exist yet
     /// Returns None if it fails
     /// Returns None if it fails
-    pub fn create_key(&mut self, id: VaultId) -> Option<Key<P>> {
+    pub fn create_key(&mut self, id: VaultId) -> Result<Key<P>, P::Error> {
         let vault_key = Key::random();
         self.insert_key(id, vault_key)
     }
 
     /// Inserts a key into the [`KeyStore`] by [`VaultId`].
     /// If the [`VaultId`] already exists, it just returns the existing [`Key<P>`]
-    pub fn insert_key(&mut self, id: VaultId, key: Key<P>) -> Option<Key<P>> {
+    pub fn insert_key(&mut self, id: VaultId, key: Key<P>) -> Result<Key<P>, P::Error> {
         let vault_key = if let Some(key) = self.take_key(id) { key } else { key };
-        let enc_key = self.master_key.encrypt_key(&vault_key, id).ok()?;
+        let enc_key = self.master_key.encrypt_key(&vault_key, id)?;
         self.store.insert(id, enc_key);
-        Some(vault_key)
+        Ok(vault_key)
     }
 
     /// Rebuilds the [`KeyStore`] while throwing out any existing [`VaultId`], [`Key<P>`] pairs.  Accepts a
     /// [`Vec<Key<P>>`] and returns then a [`Vec<VaultId>`]; primarily used to repopulate the state from a
     /// snapshot.
-    pub fn rebuild_keystore(&mut self, keys: HashMap<VaultId, Key<P>>) {
+    pub fn rebuild_keystore(&mut self, keys: HashMap<VaultId, Key<P>>) -> Result<(), P::Error> {
         let mut new_ks = KeyStore::new();
         for (id, key) in keys.into_iter() {
-            new_ks.insert_key(id, key);
+            new_ks.insert_key(id, key)?;
         }
         *self = new_ks;
+        Ok(())
     }
 
     /// Gets the state data in a hashmap format for the snapshot.


### PR DESCRIPTION
# Description of change

Implement RFC described in #308:
- secure the snapshot state in memory by encryption each client state separately
- feat: load clients from memory without snapshot-key
- feat: store snapshot key in a vault to use it on `write_snapshot`

## Links to any relevant issues

Fixed #279.

## Type of change

- [x] Enhancement (a non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How the change has been tested

Adjusted existing tests, added `test_store_snapshot_key`.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
