### PR TITLE
Feat(client_new): State synchronization of Clients and Snapshots

### DIFF
--- a/client_new/src/lib.rs
+++ b/client_new/src/lib.rs
@@ -22,6 +22,9 @@ pub mod security;
 #[cfg(feature = "std")]
 pub mod procedures;
 
+#[cfg(feature = "std")]
+pub mod sync;
+
 // is this std?
 #[cfg(feature = "std")]
 pub mod utils;

--- a/client_new/src/procedures/clientrunner.rs
+++ b/client_new/src/procedures/clientrunner.rs
@@ -38,7 +38,7 @@ impl Runner for Client {
             Ok(())
         };
         // FIXME: THIS SHOULD RETURN AN ACTUAL ERROR!
-        let mut db = self.db.try_write().map_err(|e| e.to_string()).expect("");
+        let db = self.db.try_read().map_err(|e| e.to_string()).expect("");
 
         let res = db.get_guard(&key, vault_id, record_id, execute_procedure);
 

--- a/client_new/src/security/keystore.rs
+++ b/client_new/src/security/keystore.rs
@@ -44,6 +44,12 @@ where
         let enc_key = self.store.remove(&id)?;
         self.master_key.decrypt_key(enc_key, id).ok()
     }
+    /// Gets the encrypted key from the [`KeyStore`].
+    /// Decrypt it with the `master_key` and `vault_id` as salt.
+    pub fn get_key(&self, id: VaultId) -> Option<Key<P>> {
+        let enc_key = self.store.get(&id)?.clone();
+        self.master_key.decrypt_key(enc_key, id).ok()
+    }
 
     /// Checks to see if the vault exists.
     pub fn vault_exists(&self, id: VaultId) -> bool {
@@ -61,7 +67,7 @@ where
     /// Inserts a key into the [`KeyStore`] by [`VaultId`].
     /// If the [`VaultId`] already exists, it just returns the existing [`Key<P>`]
     pub fn get_or_insert_key(&mut self, id: VaultId, key: Key<P>) -> Result<Key<P>, P::Error> {
-        let vault_key = if let Some(key) = self.take_key(id) { key } else { key };
+        let vault_key = if let Some(key) = self.get_key(id) { key } else { key };
         let enc_key = self.master_key.encrypt_key(&vault_key, id)?;
         self.store.insert(id, enc_key);
         Ok(vault_key)

--- a/client_new/src/security/keystore.rs
+++ b/client_new/src/security/keystore.rs
@@ -87,7 +87,7 @@ where
     pub fn rebuild_keystore(&mut self, keys: HashMap<VaultId, Key<P>>) -> Result<(), P::Error> {
         let mut new_ks = KeyStore::default();
         for (id, key) in keys.into_iter() {
-            new_ks.get_or_insert_key(id, key)?;
+            new_ks.insert_key(id, key)?;
         }
         *self = new_ks;
         Ok(())

--- a/client_new/src/sync.rs
+++ b/client_new/src/sync.rs
@@ -415,11 +415,11 @@ mod test {
     }
 
     fn vault_path_to_id(path: &str) -> VaultId {
-        derive_vault_id(path.as_bytes().to_vec())
+        derive_vault_id(path.as_bytes())
     }
 
     fn r_ctr_to_id(vault_path: &str, ctr: usize) -> RecordId {
-        derive_record_id_from_counter(vault_path.as_bytes().to_vec(), ctr)
+        derive_record_id_from_counter(vault_path.as_bytes(), ctr)
     }
 
     #[test]

--- a/client_new/src/sync.rs
+++ b/client_new/src/sync.rs
@@ -21,6 +21,9 @@ pub enum MergePolicy {
 // TODO: Use *_paths instead of `Ids`.
 pub struct SyncClientsConfig {
     /// Optionally only perform a partial sync with specific vaults.
+    ///
+    /// Note: This is referring to the Ids as they are on the source client, not
+    /// to the mapped id.
     pub select_vaults: Option<Vec<VaultId>>,
     /// Perform for a vault only a partial sync so that only the specified records
     /// are copied.
@@ -34,51 +37,14 @@ pub struct SyncClientsConfig {
     pub merge_policy: MergePolicy,
 }
 
-impl SyncClientsConfig {
-    /// Selects the list of vaults that are synched in a partial sync.
-    /// Each [`VaultId`] is mapped to the source's [`VaultId`] according to mapping set in
-    /// [`SyncClientsConfig::map_vaults`].
-    /// Returns `None` in case of a full sync.
-    pub(crate) fn selected_source_vaults(&self) -> Option<Vec<VaultId>> {
-        let mut vaults = self.select_vaults.clone();
-        if self.map_vaults.is_empty() {
-            return vaults;
+impl Default for SyncClientsConfig {
+    fn default() -> Self {
+        SyncClientsConfig {
+            select_vaults: None,
+            select_records: HashMap::new(),
+            map_vaults: HashMap::new(),
+            merge_policy: MergePolicy::Replace,
         }
-        if let Some(vaults) = vaults.as_mut() {
-            vaults.iter_mut().for_each(|vid| {
-                if let Some((&source_vid, _)) = self.map_vaults.iter().find(|(_, local_vid)| local_vid == &vid) {
-                    *vid = source_vid;
-                }
-            })
-        }
-        vaults
-    }
-
-    /// Iterate through the given hierarchy from the source client. Filter out irrelevant entries
-    /// if [`SyncClientsConfig::select_vaults`] or [`SyncClientsConfig::select_records`] was set.
-    /// Map the source's `VaultId` to a local `VaultId`.
-    pub(crate) fn filter_map<T>(
-        &self,
-        hierarchy: HashMap<VaultId, Vec<(RecordId, T)>>,
-    ) -> HashMap<VaultId, Vec<(RecordId, T)>> {
-        if self.select_vaults.is_none() && self.select_records.is_empty() && self.map_vaults.is_empty() {
-            return hierarchy;
-        }
-        hierarchy
-            .into_iter()
-            .filter_map(|(vid, mut records)| {
-                let vid = self.map_vaults.get(&vid).copied().unwrap_or(vid);
-                if let Some(select_vaults) = self.select_vaults.as_ref() {
-                    if !select_vaults.contains(&vid) {
-                        return None;
-                    }
-                }
-                if let Some(select_records) = self.select_records.get(&vid) {
-                    records.retain(|(rid, _)| select_records.contains(rid));
-                }
-                Some((vid, records))
-            })
-            .collect()
     }
 }
 
@@ -112,28 +78,47 @@ where
     pub fn get_diff(
         &self,
         other: HashMap<VaultId, Vec<(RecordId, BlobId)>>,
-        merge_policy: &MergePolicy,
+        config: &SyncClientsConfig,
     ) -> HashMap<VaultId, Vec<RecordId>> {
         other
             .into_iter()
-            .map(|(vid, list)| {
-                let target_key = self.keystore.get_key(vid).unwrap();
+            .filter_map(|(vid, list)| {
+                if let Some(select_vaults) = config.select_vaults.as_ref() {
+                    if !select_vaults.contains(&vid) {
+                        return None;
+                    }
+                }
+                let mapped_vid = config.map_vaults.get(&vid).copied().unwrap_or(vid);
+                let target_key = match self.keystore.get_key(mapped_vid) {
+                    Some(k) => k,
+                    None if !self.db.contains_vault(&mapped_vid) => {
+                        let list = list.into_iter().map(|(rid, _)| rid).collect();
+                        return Some((vid, list));
+                    }
+                    _ => panic!(),
+                };
+                let select_records = config.select_records.get(&vid);
                 let diff = list
                     .into_iter()
                     .filter_map(|(rid, bid)| {
-                        if !self.db.contains_record(vid, rid) {
+                        if let Some(select_records) = select_records {
+                            if !select_records.contains(&rid) {
+                                return None;
+                            }
+                        }
+                        if !self.db.contains_record(mapped_vid, rid) {
                             return Some(rid);
                         }
-                        if matches!(merge_policy, MergePolicy::KeepOld) {
+                        if matches!(config.merge_policy, MergePolicy::KeepOld) {
                             return None;
                         }
-                        if self.db.get_blob_id(&target_key, vid, rid).unwrap() == bid {
+                        if self.db.get_blob_id(&target_key, mapped_vid, rid).unwrap() == bid {
                             return None;
                         }
                         Some(rid)
                     })
                     .collect();
-                (vid, diff)
+                Some((vid, diff))
             })
             .collect()
     }
@@ -146,14 +131,14 @@ where
     }
 }
 
-impl<'a> From<&'a ClientState> for ClientRef<&'a DbView<Provider>, &'a KeyStore<Provider>> {
-    fn from(state: &'a ClientState) -> Self {
-        ClientRef {
-            db: &state.1,
-            keystore: todo!(),
-        }
-    }
-}
+// impl<'a> From<&'a ClientState> for ClientRef<&'a DbView<Provider>, &'a KeyStore<Provider>> {
+//     fn from(state: &'a ClientState) -> Self {
+//         ClientRef {
+//             db: &state.1,
+//             keystore: todo!(),
+//         }
+//     }
+// }
 
 impl<'a> TryFrom<&'a Client>
     for ClientRef<RwLockReadGuard<'a, DbView<Provider>>, RwLockReadGuard<'a, KeyStore<Provider>>>
@@ -172,7 +157,7 @@ impl<'a> TryFrom<&'a Client>
 pub struct ClientRefMut<DB, KS>
 where
     DB: DerefMut<Target = DbView<Provider>>,
-    KS: Deref<Target = KeyStore<Provider>>,
+    KS: DerefMut<Target = KeyStore<Provider>>,
 {
     pub db: DB,
     pub keystore: KS,
@@ -181,7 +166,7 @@ where
 impl<DB, KS> ClientRefMut<DB, KS>
 where
     DB: DerefMut<Target = DbView<Provider>>,
-    KS: Deref<Target = KeyStore<Provider>>,
+    KS: DerefMut<Target = KeyStore<Provider>>,
 {
     pub fn import_own_records(
         &mut self,
@@ -196,397 +181,367 @@ where
         }
     }
 
-    pub fn import_records(
+    pub fn import_records<KS2: Deref<Target = KeyStore<Provider>>>(
         &mut self,
         records: HashMap<VaultId, Vec<(RecordId, Record)>>,
-        old_keystore: &KS,
-        mapping: HashMap<VaultId, VaultId>,
+        old_keystore: &KS2,
+        config: &SyncClientsConfig,
     ) {
-        for (vid, records) in records {
-            let old_vid = mapping.get(&vid).copied().unwrap_or(vid);
-            let old_key = old_keystore.get_key(old_vid).unwrap();
-            let new_key = self.keystore.get_key(vid).unwrap();
-            self.db.import_records(&old_key, &new_key, vid, records).unwrap()
+        for (vid, mut records) in records {
+            if let Some(select_vaults) = config.select_vaults.as_ref() {
+                if !select_vaults.contains(&vid) {
+                    continue;
+                }
+            }
+            if let Some(select_records) = config.select_records.get(&vid) {
+                records.retain(|(rid, _)| select_records.contains(rid));
+            }
+            let mapped_vid = config.map_vaults.get(&vid).copied().unwrap_or(vid);
+            let old_key = old_keystore.get_key(vid).unwrap();
+            let new_key = self.keystore.get_or_insert_key(mapped_vid, Key::random()).unwrap();
+            self.db.import_records(&old_key, &new_key, mapped_vid, records).unwrap()
         }
     }
 }
 
 impl<'a> TryFrom<&'a Client>
-    for ClientRefMut<RwLockWriteGuard<'a, DbView<Provider>>, RwLockReadGuard<'a, KeyStore<Provider>>>
+    for ClientRefMut<RwLockWriteGuard<'a, DbView<Provider>>, RwLockWriteGuard<'a, KeyStore<Provider>>>
 {
     type Error = ClientError;
 
     fn try_from(client: &'a Client) -> Result<Self, Self::Error> {
         let db = client.db.try_write().map_err(|_| ClientError::LockAcquireFailed)?;
-        let keystore = client.keystore.try_read().map_err(|_| ClientError::LockAcquireFailed)?;
+        let keystore = client
+            .keystore
+            .try_write()
+            .map_err(|_| ClientError::LockAcquireFailed)?;
         let state = ClientRefMut { db, keystore };
         Ok(state)
     }
 }
 
-impl<'a> From<&'a mut ClientState> for ClientRefMut<&'a mut DbView<Provider>, &'a KeyStore<Provider>> {
-    fn from(state: &'a mut ClientState) -> Self {
-        ClientRefMut {
-            db: &mut state.1,
-            keystore: todo!(),
-        }
-    }
-}
+// impl<'a> From<&'a mut ClientState> for ClientRefMut<&'a mut DbView<Provider>, &'a mut KeyStore<Provider>> {
+//     fn from(state: &'a mut ClientState) -> Self {
+//         ClientRefMut {
+//             db: &mut state.1,
+//             keystore: todo!(),
+//         }
+//     }
+// }
 
 pub struct SyncSnapshotsConfig {
     pub select_clients: Option<Vec<ClientId>>,
     pub select_vaults: HashMap<ClientId, Vec<VaultId>>,
     pub select_records: HashMap<(ClientId, VaultId), Vec<RecordId>>,
     pub map_clients: HashMap<ClientId, ClientId>,
-    pub map_vaults: HashMap<(ClientId, VaultId), VaultId>,
     pub merge_policy: MergePolicy,
 }
 
-// #[cfg(test)]
-// mod test {
-//     use super::*;
+#[cfg(test)]
+mod test {
+    use std::convert::Infallible;
 
-//     use crate::{procedures::Runner, state::secure::SecureClient, Location};
-//     use engine::vault::RecordHint;
-//     use stronghold_utils::random;
+    use super::*;
 
-//     fn test_hint() -> RecordHint {
-//         random::random::<[u8; 24]>().into()
-//     }
+    use crate::{derive_record_id, derive_vault_id, procedures::Runner, Location};
+    use engine::vault::RecordHint;
+    use stronghold_utils::random;
 
-//     fn test_value() -> Vec<u8> {
-//         random::bytestring(4096)
-//     }
+    fn test_hint() -> RecordHint {
+        random::random::<[u8; 24]>().into()
+    }
 
-//     fn test_location() -> Location {
-//         let v_path = random::bytestring(4096);
-//         let r_path = random::bytestring(4096);
-//         Location::generic(v_path, r_path)
-//     }
+    fn test_value() -> Vec<u8> {
+        random::bytestring(4096)
+    }
 
-//     fn vault_path_to_id(path: &str) -> VaultId {
-//         SecureClient::derive_vault_id(path.as_bytes().to_vec())
-//     }
+    fn test_location() -> Location {
+        let v_path = random::bytestring(4096);
+        let r_path = random::bytestring(4096);
+        Location::generic(v_path, r_path)
+    }
 
-//     fn r_ctr_to_id(vault_path: &str, ctr: usize) -> RecordId {
-//         SecureClient::derive_record_id(vault_path.as_bytes().to_vec(), ctr)
-//     }
+    fn vault_path_to_id(path: &str) -> VaultId {
+        derive_vault_id(path.as_bytes().to_vec())
+    }
 
-//     fn perform_sync(
-//         source: &mut SyncClientState,
-//         target: &mut SyncClientState,
-//         mapper: Option<&Mapper<(VaultId, RecordId)>>,
-//         merge_policy: SelectOrMerge<SelectOne>,
-//     ) -> Result<(), VaultError> {
-//         let hierarchy = source.get_hierarchy()?;
-//         let diff = target.get_diff(hierarchy, mapper, &merge_policy)?;
-//         let exported = source.export_entries(Some(diff))?;
-//         target.import_entries(exported, &merge_policy, mapper, Some(&*source.keystore))?;
-//         Ok(())
-//     }
+    fn r_ctr_to_id(vault_path: &str, ctr: usize) -> RecordId {
+        derive_record_id(vault_path.as_bytes().to_vec(), ctr)
+    }
 
-//     #[test]
-//     fn test_get_hierarchy() -> Result<(), Box<dyn std::error::Error>> {
-//         let cid = ClientId::random::<Provider>()?;
-//         let mut client = SecureClient::new(cid);
-//         let hierarchy = SyncClientState::from(&mut client).get_hierarchy()?;
-//         assert!(hierarchy.is_empty());
+    #[test]
+    fn test_get_hierarchy() -> Result<(), Box<dyn std::error::Error>> {
+        let client = Client::default();
+        let hierarchy = ClientRef::try_from(&client)?.get_hierarchy(None);
+        assert!(hierarchy.is_empty());
 
-//         let location_1 = test_location();
-//         let (vid1, rid1) = SecureClient::resolve_location(location_1.clone());
-//         client.write_to_vault(&location_1, test_hint(), test_value())?;
+        let location_1 = test_location();
+        let (vid1, rid1) = location_1.resolve();
+        client.write_to_vault(&location_1, test_hint(), test_value())?;
 
-//         let v_path_2 = random::bytestring(4096);
-//         let r_path_2 = random::bytestring(4096);
-//         let location_2 = Location::generic(v_path_2.clone(), r_path_2);
-//         let (vid2, rid2) = SecureClient::resolve_location(location_2.clone());
-//         client.write_to_vault(&location_2, test_hint(), test_value())?;
+        let v_path_2 = random::bytestring(4096);
+        let r_path_2 = random::bytestring(4096);
+        let location_2 = Location::generic(v_path_2.clone(), r_path_2);
+        let (vid2, rid2) = location_2.resolve();
+        client.write_to_vault(&location_2, test_hint(), test_value())?;
 
-//         // Same vault as value nr 2.
-//         let r_path_3 = random::bytestring(4096);
-//         let location_3 = Location::generic(v_path_2, r_path_3);
-//         let (vid23, rid3) = SecureClient::resolve_location(location_3.clone());
-//         assert_eq!(vid2, vid23);
-//         client.write_to_vault(&location_3, test_hint(), test_value())?;
+        // Same vault as value nr 2.
+        let r_path_3 = random::bytestring(4096);
+        let location_3 = Location::generic(v_path_2, r_path_3);
+        let (vid23, rid3) = location_3.resolve();
+        assert_eq!(vid2, vid23);
+        client.write_to_vault(&location_3, test_hint(), test_value())?;
 
-//         let hierarchy = SyncClientState::from(&mut client).get_hierarchy()?;
+        let hierarchy = ClientRef::try_from(&client)?.get_hierarchy(None);
 
-//         assert_eq!(hierarchy.len(), 2);
-//         let records_1 = hierarchy
-//             .iter()
-//             .find(|(k, _)| **k == vid1)
-//             .expect("Vault does not exist.")
-//             .1;
-//         assert_eq!(records_1.len(), 1);
-//         assert_eq!(records_1[0].0, rid1);
+        assert_eq!(hierarchy.len(), 2);
+        let records_1 = hierarchy
+            .iter()
+            .find(|(k, _)| **k == vid1)
+            .expect("Vault does not exist.")
+            .1;
+        assert_eq!(records_1.len(), 1);
+        assert_eq!(records_1[0].0, rid1);
 
-//         let records_2 = hierarchy
-//             .iter()
-//             .find(|(k, _)| **k == vid2)
-//             .expect("Vault does not exist.")
-//             .1;
-//         assert_eq!(records_2.len(), 2);
-//         assert!(records_2.iter().any(|(rid, _)| rid == &rid2));
-//         assert!(records_2.iter().any(|(rid, _)| rid == &rid3));
+        let records_2 = hierarchy
+            .iter()
+            .find(|(k, _)| **k == vid2)
+            .expect("Vault does not exist.")
+            .1;
+        assert_eq!(records_2.len(), 2);
+        assert!(records_2.iter().any(|(rid, _)| rid == &rid2));
+        assert!(records_2.iter().any(|(rid, _)| rid == &rid3));
 
-//         Ok(())
-//     }
+        Ok(())
+    }
 
-//     #[test]
-//     fn test_export_with_mapping() -> Result<(), Box<dyn std::error::Error>> {
-//         let mapping = |(vid, rid)| {
-//             if vid == vault_path_to_id("vault_1") {
-//                 if rid == r_ctr_to_id("vault_1", 11) {
-//                     // Map record in same vault to new record id.
-//                     Some((vid, r_ctr_to_id("vault_1", 111)))
-//                 } else if rid == r_ctr_to_id("vault_1", 12) {
-//                     // Map record to a vault that we skipped in the sources hierarchy.
-//                     Some((vault_path_to_id("vault_3"), r_ctr_to_id("vault_3", 121)))
-//                 } else if rid == r_ctr_to_id("vault_1", 13) {
-//                     // Map record to an entirely new vault.
-//                     Some((vault_path_to_id("vault_4"), r_ctr_to_id("vault_4", 13)))
-//                 } else {
-//                     // Keep at same location.
-//                     Some((vid, rid))
-//                 }
-//             } else if vid == vault_path_to_id("vault_2") {
-//                 // Move whole vault.
-//                 Some((vault_path_to_id("vault_5"), rid))
-//             } else {
-//                 // Skip record from any source vault with path != vault_1 || vault_2.
-//                 None
-//             }
-//         };
-//         let mapper = Mapper { f: mapping };
+    #[test]
+    fn test_partial_sync_with_mapping() -> Result<(), Box<dyn std::error::Error>> {
+        let source = Client::default();
 
-//         let cid0 = ClientId::random::<Provider>()?;
-//         let mut source_client = SecureClient::new(cid0);
+        let merge_policy = match random::random() {
+            true => MergePolicy::KeepOld,
+            false => MergePolicy::Replace,
+        };
 
-//         // Fill test vaults.
-//         for i in 1..4usize {
-//             for j in 1..5usize {
-//                 let vault_path = format!("vault_{}", i);
-//                 let location = Location::counter(vault_path, i * 10 + j);
-//                 source_client.write_to_vault(&location, test_hint(), test_value())?;
-//             }
-//         }
+        // Partial sync with only selected vaults.
+        let mut config = SyncClientsConfig {
+            select_vaults: Some(Vec::new()),
+            merge_policy,
+            ..Default::default()
+        };
 
-//         let mut target_client = SecureClient::new(cid0);
+        let v_path_1 = random::bytestring(1024);
+        let vid1 = derive_vault_id(v_path_1.clone());
 
-//         let mut source = SyncClientState::from(&mut source_client);
-//         let mut target = SyncClientState::from(&mut target_client);
-//         let merge_policy = match random::random::<u8>() % 4 {
-//             0 => SelectOrMerge::KeepOld,
-//             1 => SelectOrMerge::Replace,
-//             2 => SelectOrMerge::Merge(SelectOne::KeepOld),
-//             3 => SelectOrMerge::Merge(SelectOne::Replace),
-//             _ => unreachable!("0 <= n % 4 <= 3"),
-//         };
+        let v_path_2 = random::bytestring(1024);
+        let vid2 = derive_vault_id(v_path_2);
 
-//         let source_hierarchy = source.get_hierarchy()?;
-//         let target_hierarchy = target.get_hierarchy()?;
-//         assert!(target_hierarchy.is_empty());
+        // Include vault-1 in the sync.
+        config.select_vaults.as_mut().unwrap().push(vid1);
+        // Map vault-1 to vault-2:
+        config.map_vaults.insert(vid1, vid2);
 
-//         // Do sync.
-//         perform_sync(&mut source, &mut target, Some(&mapper), merge_policy)?;
+        for i in 0..3usize {
+            let location = Location::counter(v_path_1.clone(), 10 + i);
+            source.write_to_vault(&location, test_hint(), test_value())?;
+        }
 
-//         // Check that old state still contains all values
-//         let check_hierarchy = source.get_hierarchy()?;
-//         assert_eq!(source_hierarchy, check_hierarchy);
+        let v_path_3 = random::bytestring(1024);
+        let vid3 = derive_vault_id(v_path_3.clone());
+        // Include vault-3 in the sync, but only selected records.
+        config.select_vaults.as_mut().unwrap().push(vid3);
 
-//         let mut target_hierarchy = target.get_hierarchy()?;
-//         assert_eq!(target_hierarchy.keys().len(), 4);
+        let mut select_records_v3 = Vec::new();
 
-//         // Vault-1 was partly mapped.
-//         let v_1_entries = target_hierarchy
-//             .remove(&vault_path_to_id("vault_1"))
-//             .expect("Vault does not exist.");
-//         assert_eq!(v_1_entries.len(), 2);
-//         // Record-14 was not moved.
-//         assert!(v_1_entries.iter().any(|(rid, _)| rid == &r_ctr_to_id("vault_1", 14)));
-//         // Record-11 was moved to counter 111.
-//         assert!(v_1_entries.iter().any(|(rid, _)| rid == &r_ctr_to_id("vault_1", 111)));
+        for i in 0..3usize {
+            let location = Location::counter(v_path_3.clone(), 30 + i);
+            source.write_to_vault(&location, test_hint(), test_value())?;
+            // Only include record-0 and record-1 in the sync.
+            if i == 0 || i == 1 {
+                select_records_v3.push(location.resolve().1);
+            }
+        }
+        config.select_records.insert(vid3, select_records_v3);
 
-//         // All records from Vault-2 were moved to Vault-5.
-//         assert!(!target_hierarchy.contains_key(&vault_path_to_id("vault_2")));
-//         let v_5_entries = target_hierarchy
-//             .remove(&vault_path_to_id("vault_5"))
-//             .expect("Vault does not exist.");
-//         assert_eq!(v_5_entries.len(), 4);
-//         assert!(v_5_entries.iter().any(|(rid, _)| rid == &r_ctr_to_id("vault_2", 21)));
-//         assert!(v_5_entries.iter().any(|(rid, _)| rid == &r_ctr_to_id("vault_2", 22)));
-//         assert!(v_5_entries.iter().any(|(rid, _)| rid == &r_ctr_to_id("vault_2", 23)));
-//         assert!(v_5_entries.iter().any(|(rid, _)| rid == &r_ctr_to_id("vault_2", 24)));
+        // Vault-4 is not included in the sync.
+        let v_path_4 = random::bytestring(1024);
+        let vid4 = derive_vault_id(v_path_4.clone());
 
-//         // Vault-3 from source was skipped, but Record-12 from Vault-1 was moved to Vault-3 Record-121.
-//         let v_3_entries = target_hierarchy
-//             .remove(&vault_path_to_id("vault_3"))
-//             .expect("Vault does not exist.");
-//         assert_eq!(v_3_entries.len(), 1);
-//         assert!(v_3_entries.iter().any(|(rid, _)| rid == &r_ctr_to_id("vault_3", 121)));
+        let v_path_5 = random::bytestring(1024);
+        let vid5 = derive_vault_id(v_path_5);
+        // Irrelevant mapping of vault-4 to vault-5.
+        config.map_vaults.insert(vid4, vid5);
 
-//         // Record-13 from Vault-1 was moved to new Vault-4.
-//         let v_4_entries = target_hierarchy
-//             .remove(&vault_path_to_id("vault_4"))
-//             .expect("Vault does not exist.");
-//         assert_eq!(v_4_entries.len(), 1);
-//         assert!(v_4_entries.iter().any(|(rid, _)| rid == &r_ctr_to_id("vault_4", 13)));
+        for i in 0..3usize {
+            let location = Location::counter(v_path_4.clone(), 40 + i);
+            source.write_to_vault(&location, test_hint(), test_value())?;
+        }
 
-//         Ok(())
-//     }
+        let target = Client::default();
 
-//     #[test]
-//     fn test_merge_policy() -> Result<(), Box<dyn std::error::Error>> {
-//         let cid0 = ClientId::random::<Provider>()?;
-//         let mut source_client = SecureClient::new(cid0);
+        let source_hierarchy_full = ClientRef::try_from(&source)?.get_hierarchy(None);
+        assert_eq!(source_hierarchy_full.keys().len(), 3);
 
-//         // Fill test vaults.
-//         for i in 1..3usize {
-//             for j in 1..3usize {
-//                 let vault_path = format!("vault_{}", i);
-//                 let location = Location::counter(vault_path, i * 10 + j);
-//                 source_client.write_to_vault(&location, test_hint(), test_value())?;
-//             }
-//         }
+        let source_hierarchy_partial = ClientRef::try_from(&source)?.get_hierarchy(config.select_vaults.clone());
+        assert_eq!(source_hierarchy_partial.keys().len(), 2);
 
-//         let mut source = SyncClientState::from(&mut source_client);
-//         let mut source_vault_2_hierarchy = source
-//             .get_hierarchy()?
-//             .remove(&vault_path_to_id("vault_2"))
-//             .expect("Vault does not exist.");
-//         source_vault_2_hierarchy.sort();
-//         let source_v2_r2_bid = source_vault_2_hierarchy
-//             .iter()
-//             .find(|(rid, _)| rid == &r_ctr_to_id("vault_2", 22))
-//             .map(|(_, bid)| *bid)
-//             .expect("Record does not exist.");
+        let target_hierarchy = ClientRef::try_from(&target)?.get_hierarchy(None);
+        assert!(target_hierarchy.is_empty());
 
-//         let set_up_target = || -> Result<SecureClient, VaultError> {
-//             let mut target_client = SecureClient::new(cid0);
-//             for i in 2..4usize {
-//                 for j in 2..4usize {
-//                     let vault_path = format!("vault_{}", i);
-//                     let location = Location::counter(vault_path, i * 10 + j);
-//                     target_client.write_to_vault(&location, test_hint(), test_value())?;
-//                 }
-//             }
-//             Ok(target_client)
-//         };
+        // Do sync.
+        target.sync_with(&source, config)?;
 
-//         let assert_for_distinct_vaults = |hierarchy: &mut HashMap<VaultId, Vec<(RecordId, BlobId)>>| {
-//             // Imported full vault-1;
-//             assert_eq!(hierarchy.keys().len(), 3);
-//             let v_1_entries = hierarchy
-//                 .remove(&vault_path_to_id("vault_1"))
-//                 .expect("Vault does not exist.");
-//             assert_eq!(v_1_entries.len(), 2);
-//             assert!(v_1_entries.iter().any(|(rid, _)| rid == &r_ctr_to_id("vault_1", 11)));
-//             assert!(v_1_entries.iter().any(|(rid, _)| rid == &r_ctr_to_id("vault_1", 12)));
+        // Check that old state still contains all values
+        let check_hierarchy = ClientRef::try_from(&source)?.get_hierarchy(None);
+        assert_eq!(source_hierarchy_full, check_hierarchy);
 
-//             // Kept old vault-3;
-//             let v_3_entries = hierarchy
-//                 .remove(&vault_path_to_id("vault_3"))
-//                 .expect("Vault does not exist.");
-//             assert_eq!(v_3_entries.len(), 2);
-//             assert!(v_3_entries.iter().any(|(rid, _)| rid == &r_ctr_to_id("vault_3", 32)));
-//             assert!(v_3_entries.iter().any(|(rid, _)| rid == &r_ctr_to_id("vault_3", 33)));
-//         };
+        let mut target_hierarchy = ClientRef::try_from(&target)?.get_hierarchy(None);
+        // Only two vaults (Vault-1 and Vault-3) were imported.
+        assert_eq!(target_hierarchy.keys().len(), 2);
 
-//         // == Test merge policy SelectOrMerge::KeepOld
+        // Vault-1 does not exists.
+        assert!(!target_hierarchy.contains_key(&vid1));
 
-//         let mut target_client_1 = set_up_target()?;
-//         let mut target_1 = SyncClientState::from(&mut target_client_1);
-//         let mut old_vault_2_hierarchy = target_1
-//             .get_hierarchy()?
-//             .remove(&vault_path_to_id("vault_2"))
-//             .expect("Vault does not exist.");
-//         old_vault_2_hierarchy.sort();
-//         let merge_policy = SelectOrMerge::KeepOld;
+        // All records from Vault-1 were imported to Vault-2.
+        let v_2_entries = target_hierarchy.remove(&vid2).expect("Vault does not exist.");
+        assert_eq!(v_2_entries.len(), 3);
+        assert!(v_2_entries
+            .iter()
+            .any(|(rid, _)| *rid == Location::counter(v_path_1.clone(), 10usize).resolve().1));
+        assert!(v_2_entries
+            .iter()
+            .any(|(rid, _)| *rid == Location::counter(v_path_1.clone(), 11usize).resolve().1));
+        assert!(v_2_entries
+            .iter()
+            .any(|(rid, _)| *rid == Location::counter(v_path_1.clone(), 12usize).resolve().1));
 
-//         perform_sync(&mut source, &mut target_1, None, merge_policy)?;
+        // Record-0 and Record-1 were imported from Vault-3
+        let v_3_entries = target_hierarchy.remove(&vid3).expect("Vault does not exist.");
+        assert_eq!(v_3_entries.len(), 2);
+        assert!(v_3_entries
+            .iter()
+            .any(|(rid, _)| *rid == Location::counter(v_path_3.clone(), 30usize).resolve().1));
+        assert!(v_3_entries
+            .iter()
+            .any(|(rid, _)| *rid == Location::counter(v_path_3.clone(), 31usize).resolve().1));
 
-//         let mut hierarchy_1 = target_1.get_hierarchy()?;
+        Ok(())
+    }
 
-//         assert_for_distinct_vaults(&mut hierarchy_1);
+    #[test]
+    fn test_merge_policy() -> Result<(), Box<dyn std::error::Error>> {
+        let source = Client::default();
 
-//         // Kept old vault-2.
-//         let mut v_2_entries = hierarchy_1
-//             .remove(&vault_path_to_id("vault_2"))
-//             .expect("Vault does not exist.");
-//         v_2_entries.sort();
-//         assert_eq!(v_2_entries, old_vault_2_hierarchy);
+        // Fill test vaults.
+        for i in 1..3usize {
+            for j in 1..3usize {
+                let vault_path = format!("vault_{}", i);
+                let location = Location::counter(vault_path, i * 10 + j);
+                source.write_to_vault(&location, test_hint(), test_value())?;
+            }
+        }
 
-//         // == Test merge policy SelectOrMerge::Replace
+        let mut source_vault_2_hierarchy = ClientRef::try_from(&source)?
+            .get_hierarchy(None)
+            .remove(&vault_path_to_id("vault_2"))
+            .expect("Vault does not exist.");
+        source_vault_2_hierarchy.sort();
+        let source_v2_r2_bid = source_vault_2_hierarchy
+            .iter()
+            .find(|(rid, _)| rid == &r_ctr_to_id("vault_2", 22))
+            .map(|(_, bid)| *bid)
+            .expect("Record does not exist.");
 
-//         let mut target_client_2 = set_up_target()?;
-//         let mut target_2 = SyncClientState::from(&mut target_client_2);
-//         let merge_policy = SelectOrMerge::Replace;
-//         perform_sync(&mut source, &mut target_2, None, merge_policy)?;
-//         let mut hierarchy_2 = target_2.get_hierarchy()?;
+        let set_up_target = || -> Result<Client, VaultError<Infallible>> {
+            let target = Client::default();
+            for i in 2..4usize {
+                for j in 2..4usize {
+                    let vault_path = format!("vault_{}", i);
+                    let location = Location::counter(vault_path, i * 10 + j);
+                    target.write_to_vault(&location, test_hint(), test_value())?;
+                }
+            }
+            Ok(target)
+        };
 
-//         assert_for_distinct_vaults(&mut hierarchy_2);
+        let assert_for_distinct_vaults = |hierarchy: &mut HashMap<VaultId, Vec<(RecordId, BlobId)>>| {
+            // Imported full vault-1;
+            assert_eq!(hierarchy.keys().len(), 3);
+            let v_1_entries = hierarchy
+                .remove(&vault_path_to_id("vault_1"))
+                .expect("Vault does not exist.");
+            assert_eq!(v_1_entries.len(), 2);
+            assert!(v_1_entries.iter().any(|(rid, _)| rid == &r_ctr_to_id("vault_1", 11)));
+            assert!(v_1_entries.iter().any(|(rid, _)| rid == &r_ctr_to_id("vault_1", 12)));
 
-//         // Replace vault-2 completely with imported one;
-//         let mut v_2_entries = hierarchy_2
-//             .remove(&vault_path_to_id("vault_2"))
-//             .expect("Vault does not exist.");
-//         v_2_entries.sort();
-//         assert_eq!(v_2_entries, source_vault_2_hierarchy);
+            // Kept old vault-3;
+            let v_3_entries = hierarchy
+                .remove(&vault_path_to_id("vault_3"))
+                .expect("Vault does not exist.");
+            assert_eq!(v_3_entries.len(), 2);
+            assert!(v_3_entries.iter().any(|(rid, _)| rid == &r_ctr_to_id("vault_3", 32)));
+            assert!(v_3_entries.iter().any(|(rid, _)| rid == &r_ctr_to_id("vault_3", 33)));
+        };
 
-//         // == Test merge policy SelectOrMerge::Merge(SelectOne::KeepOld)
+        // == Test merge policy MergePolicy::KeepOld
 
-//         let mut target_client_3 = set_up_target()?;
-//         let mut target_3 = SyncClientState::from(&mut target_client_3);
-//         let old_v2_r2_bid = target_3
-//             .get_hierarchy()?
-//             .remove(&vault_path_to_id("vault_2"))
-//             .and_then(|vec| vec.into_iter().find(|(rid, _)| rid == &r_ctr_to_id("vault_2", 22)))
-//             .map(|(_, bid)| bid)
-//             .expect("Record does not exist.");
-//         let merge_policy = SelectOrMerge::Merge(SelectOne::KeepOld);
-//         perform_sync(&mut source, &mut target_3, None, merge_policy)?;
-//         let mut hierarchy_3 = target_3.get_hierarchy()?;
+        let target_1 = set_up_target()?;
+        let old_v2_r2_bid = ClientRef::try_from(&target_1)?
+            .get_hierarchy(None)
+            .remove(&vault_path_to_id("vault_2"))
+            .and_then(|vec| vec.into_iter().find(|(rid, _)| rid == &r_ctr_to_id("vault_2", 22)))
+            .map(|(_, bid)| bid)
+            .expect("Record does not exist.");
+        let config = SyncClientsConfig {
+            merge_policy: MergePolicy::KeepOld,
+            ..Default::default()
+        };
+        target_1.sync_with(&source, config)?;
+        let mut hierarchy = ClientRef::try_from(&target_1)?.get_hierarchy(None);
 
-//         assert_for_distinct_vaults(&mut hierarchy_3);
+        assert_for_distinct_vaults(&mut hierarchy);
 
-//         // Merge vault-2 with imported one, keep old record on conflict.
-//         let v_2_entries = hierarchy_3
-//             .remove(&vault_path_to_id("vault_2"))
-//             .expect("Vault does not exist.");
-//         assert_eq!(v_2_entries.len(), 3);
-//         assert!(v_2_entries.iter().any(|(rid, _)| rid == &r_ctr_to_id("vault_2", 21)));
-//         assert!(v_2_entries.iter().any(|(rid, _)| rid == &r_ctr_to_id("vault_2", 23)));
-//         let v2_r2_bid = v_2_entries
-//             .into_iter()
-//             .find(|(rid, _)| rid == &r_ctr_to_id("vault_2", 22))
-//             .map(|(_, bid)| bid)
-//             .expect("Record does not exist.");
-//         assert_eq!(v2_r2_bid, old_v2_r2_bid);
+        // Merge vault-2 with imported one, keep old record on conflict.
+        let v_2_entries = hierarchy
+            .remove(&vault_path_to_id("vault_2"))
+            .expect("Vault does not exist.");
+        assert_eq!(v_2_entries.len(), 3);
+        assert!(v_2_entries.iter().any(|(rid, _)| rid == &r_ctr_to_id("vault_2", 21)));
+        assert!(v_2_entries.iter().any(|(rid, _)| rid == &r_ctr_to_id("vault_2", 23)));
+        let v2_r2_bid = v_2_entries
+            .into_iter()
+            .find(|(rid, _)| rid == &r_ctr_to_id("vault_2", 22))
+            .map(|(_, bid)| bid)
+            .expect("Record does not exist.");
+        assert_eq!(v2_r2_bid, old_v2_r2_bid);
 
-//         // == Test merge policy SelectOrMerge::Merge(SelectOne::Replace)
+        // == Test merge policy MergePolicy::Replace
 
-//         let mut target_client_4 = set_up_target()?;
-//         let mut target_4 = SyncClientState::from(&mut target_client_4);
-//         let merge_policy = SelectOrMerge::Merge(SelectOne::Replace);
-//         perform_sync(&mut source, &mut target_4, None, merge_policy)?;
-//         let mut hierarchy_4 = target_4.get_hierarchy()?;
+        let target_2 = set_up_target()?;
+        let config = SyncClientsConfig {
+            merge_policy: MergePolicy::Replace,
+            ..Default::default()
+        };
+        target_2.sync_with(&source, config)?;
+        let mut hierarchy = ClientRef::try_from(&target_2)?.get_hierarchy(None);
 
-//         assert_for_distinct_vaults(&mut hierarchy_4);
+        assert_for_distinct_vaults(&mut hierarchy);
 
-//         // Merge vault-2 with imported one, keep old record on conflict.
-//         let v_2_entries = hierarchy_4
-//             .remove(&vault_path_to_id("vault_2"))
-//             .expect("Vault does not exist.");
-//         assert_eq!(v_2_entries.len(), 3);
-//         assert!(v_2_entries.iter().any(|(rid, _)| rid == &r_ctr_to_id("vault_2", 21)));
-//         assert!(v_2_entries.iter().any(|(rid, _)| rid == &r_ctr_to_id("vault_2", 23)));
-//         let v2_r2_bid = v_2_entries
-//             .into_iter()
-//             .find(|(rid, _)| rid == &r_ctr_to_id("vault_2", 22))
-//             .map(|(_, bid)| bid)
-//             .expect("Record does not exist.");
-//         assert_eq!(v2_r2_bid, source_v2_r2_bid);
+        // Merge vault-2 with imported one, keep old record on conflict.
+        let v_2_entries = hierarchy
+            .remove(&vault_path_to_id("vault_2"))
+            .expect("Vault does not exist.");
+        assert_eq!(v_2_entries.len(), 3);
+        assert!(v_2_entries.iter().any(|(rid, _)| rid == &r_ctr_to_id("vault_2", 21)));
+        assert!(v_2_entries.iter().any(|(rid, _)| rid == &r_ctr_to_id("vault_2", 23)));
+        let v2_r2_bid = v_2_entries
+            .into_iter()
+            .find(|(rid, _)| rid == &r_ctr_to_id("vault_2", 22))
+            .map(|(_, bid)| bid)
+            .expect("Record does not exist.");
+        assert_eq!(v2_r2_bid, source_v2_r2_bid);
 
-//         Ok(())
-//     }
-// }
+        Ok(())
+    }
+}

--- a/client_new/src/sync.rs
+++ b/client_new/src/sync.rs
@@ -1,0 +1,592 @@
+// Copyright 2020-2022 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use engine::vault::{view::Record, BlobId, ClientId, DbView, Key, RecordId, VaultId};
+use std::{
+    collections::HashMap,
+    ops::{Deref, DerefMut},
+    sync::{RwLockReadGuard, RwLockWriteGuard},
+};
+
+use crate::{Client, ClientError, ClientState, KeyStore, Provider, RecordError, VaultError};
+
+/// Policy for conflicts when merging two vaults.
+pub enum MergePolicy {
+    /// Do not copy the record, instead keep the existing one.
+    KeepOld,
+    /// Replace the existing record.
+    Replace,
+}
+
+// TODO: Use *_paths instead of `Ids`.
+pub struct SyncClientsConfig {
+    /// Optionally only perform a partial sync with specific vaults.
+    pub select_vaults: Option<Vec<VaultId>>,
+    /// Perform for a vault only a partial sync so that only the specified records
+    /// are copied.
+    pub select_records: HashMap<VaultId, Vec<RecordId>>,
+    /// Map the `VaultId` from the source to a local `VaultId`.
+    /// If no mapping is set for a vault it assumes that the `VaultId` is the same
+    /// on source and target.
+    pub map_vaults: HashMap<VaultId, VaultId>,
+    /// Policy if a record exists both, at source and the target, with different
+    /// content.
+    pub merge_policy: MergePolicy,
+}
+
+impl SyncClientsConfig {
+    /// Selects the list of vaults that are synched in a partial sync.
+    /// Each [`VaultId`] is mapped to the source's [`VaultId`] according to mapping set in
+    /// [`SyncClientsConfig::map_vaults`].
+    /// Returns `None` in case of a full sync.
+    pub(crate) fn selected_source_vaults(&self) -> Option<Vec<VaultId>> {
+        let mut vaults = self.select_vaults.clone();
+        if self.map_vaults.is_empty() {
+            return vaults;
+        }
+        if let Some(vaults) = vaults.as_mut() {
+            vaults.iter_mut().for_each(|vid| {
+                if let Some((&source_vid, _)) = self.map_vaults.iter().find(|(_, local_vid)| local_vid == &vid) {
+                    *vid = source_vid;
+                }
+            })
+        }
+        vaults
+    }
+
+    /// Iterate through the given hierarchy from the source client. Filter out irrelevant entries
+    /// if [`SyncClientsConfig::select_vaults`] or [`SyncClientsConfig::select_records`] was set.
+    /// Map the source's `VaultId` to a local `VaultId`.
+    pub(crate) fn filter_map<T>(
+        &self,
+        hierarchy: HashMap<VaultId, Vec<(RecordId, T)>>,
+    ) -> HashMap<VaultId, Vec<(RecordId, T)>> {
+        if self.select_vaults.is_none() && self.select_records.is_empty() && self.map_vaults.is_empty() {
+            return hierarchy;
+        }
+        hierarchy
+            .into_iter()
+            .filter_map(|(vid, mut records)| {
+                let vid = self.map_vaults.get(&vid).copied().unwrap_or(vid);
+                if let Some(select_vaults) = self.select_vaults.as_ref() {
+                    if !select_vaults.contains(&vid) {
+                        return None;
+                    }
+                }
+                if let Some(select_records) = self.select_records.get(&vid) {
+                    records.retain(|(rid, _)| select_records.contains(rid));
+                }
+                Some((vid, records))
+            })
+            .collect()
+    }
+}
+
+/// Immutable access to a client's [`DbView`] and [`KeyStore`].
+pub struct ClientRef<DB, KS>
+where
+    DB: Deref<Target = DbView<Provider>>,
+    KS: Deref<Target = KeyStore<Provider>>,
+{
+    pub db: DB,
+    pub keystore: KS,
+}
+
+impl<DB, KS> ClientRef<DB, KS>
+where
+    DB: Deref<Target = DbView<Provider>>,
+    KS: Deref<Target = KeyStore<Provider>>,
+{
+    pub fn get_hierarchy(&self, vaults: Option<Vec<VaultId>>) -> HashMap<VaultId, Vec<(RecordId, BlobId)>> {
+        let vaults = vaults.unwrap_or_else(|| self.db.list_vaults());
+        vaults
+            .into_iter()
+            .map(|vid| {
+                let key = self.keystore.get_key(vid).unwrap();
+                let list = self.db.list_records_with_blob_id(&key, vid).unwrap();
+                (vid, list)
+            })
+            .collect()
+    }
+
+    pub fn get_diff(
+        &self,
+        other: HashMap<VaultId, Vec<(RecordId, BlobId)>>,
+        merge_policy: &MergePolicy,
+    ) -> HashMap<VaultId, Vec<RecordId>> {
+        other
+            .into_iter()
+            .map(|(vid, list)| {
+                let target_key = self.keystore.get_key(vid).unwrap();
+                let diff = list
+                    .into_iter()
+                    .filter_map(|(rid, bid)| {
+                        if !self.db.contains_record(vid, rid) {
+                            return Some(rid);
+                        }
+                        if matches!(merge_policy, MergePolicy::KeepOld) {
+                            return None;
+                        }
+                        if self.db.get_blob_id(&target_key, vid, rid).unwrap() == bid {
+                            return None;
+                        }
+                        Some(rid)
+                    })
+                    .collect();
+                (vid, diff)
+            })
+            .collect()
+    }
+
+    pub fn export_entries(&self, select: HashMap<VaultId, Vec<RecordId>>) -> HashMap<VaultId, Vec<(RecordId, Record)>> {
+        select
+            .into_iter()
+            .map(|(vid, select)| (vid, self.db.export_records(vid, select).unwrap()))
+            .collect()
+    }
+}
+
+impl<'a> From<&'a ClientState> for ClientRef<&'a DbView<Provider>, &'a KeyStore<Provider>> {
+    fn from(state: &'a ClientState) -> Self {
+        ClientRef {
+            db: &state.1,
+            keystore: todo!(),
+        }
+    }
+}
+
+impl<'a> TryFrom<&'a Client>
+    for ClientRef<RwLockReadGuard<'a, DbView<Provider>>, RwLockReadGuard<'a, KeyStore<Provider>>>
+{
+    type Error = ClientError;
+
+    fn try_from(client: &'a Client) -> Result<Self, Self::Error> {
+        let db = client.db.try_read().map_err(|_| ClientError::LockAcquireFailed)?;
+        let keystore = client.keystore.try_read().map_err(|_| ClientError::LockAcquireFailed)?;
+        let state = ClientRef { db, keystore };
+        Ok(state)
+    }
+}
+
+/// Mutable access to a client's [`DbView`] and [`KeyStore`].
+pub struct ClientRefMut<DB, KS>
+where
+    DB: DerefMut<Target = DbView<Provider>>,
+    KS: Deref<Target = KeyStore<Provider>>,
+{
+    pub db: DB,
+    pub keystore: KS,
+}
+
+impl<DB, KS> ClientRefMut<DB, KS>
+where
+    DB: DerefMut<Target = DbView<Provider>>,
+    KS: Deref<Target = KeyStore<Provider>>,
+{
+    pub fn import_own_records(
+        &mut self,
+        records: HashMap<VaultId, Vec<(RecordId, Record)>>,
+        mapping: HashMap<VaultId, VaultId>,
+    ) {
+        for (vid, records) in records {
+            let old_vid = mapping.get(&vid).copied().unwrap_or(vid);
+            let old_key = self.keystore.get_key(old_vid).unwrap();
+            let new_key = self.keystore.get_key(vid).unwrap();
+            self.db.import_records(&old_key, &new_key, vid, records).unwrap()
+        }
+    }
+
+    pub fn import_records(
+        &mut self,
+        records: HashMap<VaultId, Vec<(RecordId, Record)>>,
+        old_keystore: &KS,
+        mapping: HashMap<VaultId, VaultId>,
+    ) {
+        for (vid, records) in records {
+            let old_vid = mapping.get(&vid).copied().unwrap_or(vid);
+            let old_key = old_keystore.get_key(old_vid).unwrap();
+            let new_key = self.keystore.get_key(vid).unwrap();
+            self.db.import_records(&old_key, &new_key, vid, records).unwrap()
+        }
+    }
+}
+
+impl<'a> TryFrom<&'a Client>
+    for ClientRefMut<RwLockWriteGuard<'a, DbView<Provider>>, RwLockReadGuard<'a, KeyStore<Provider>>>
+{
+    type Error = ClientError;
+
+    fn try_from(client: &'a Client) -> Result<Self, Self::Error> {
+        let db = client.db.try_write().map_err(|_| ClientError::LockAcquireFailed)?;
+        let keystore = client.keystore.try_read().map_err(|_| ClientError::LockAcquireFailed)?;
+        let state = ClientRefMut { db, keystore };
+        Ok(state)
+    }
+}
+
+impl<'a> From<&'a mut ClientState> for ClientRefMut<&'a mut DbView<Provider>, &'a KeyStore<Provider>> {
+    fn from(state: &'a mut ClientState) -> Self {
+        ClientRefMut {
+            db: &mut state.1,
+            keystore: todo!(),
+        }
+    }
+}
+
+pub struct SyncSnapshotsConfig {
+    pub select_clients: Option<Vec<ClientId>>,
+    pub select_vaults: HashMap<ClientId, Vec<VaultId>>,
+    pub select_records: HashMap<(ClientId, VaultId), Vec<RecordId>>,
+    pub map_clients: HashMap<ClientId, ClientId>,
+    pub map_vaults: HashMap<(ClientId, VaultId), VaultId>,
+    pub merge_policy: MergePolicy,
+}
+
+// #[cfg(test)]
+// mod test {
+//     use super::*;
+
+//     use crate::{procedures::Runner, state::secure::SecureClient, Location};
+//     use engine::vault::RecordHint;
+//     use stronghold_utils::random;
+
+//     fn test_hint() -> RecordHint {
+//         random::random::<[u8; 24]>().into()
+//     }
+
+//     fn test_value() -> Vec<u8> {
+//         random::bytestring(4096)
+//     }
+
+//     fn test_location() -> Location {
+//         let v_path = random::bytestring(4096);
+//         let r_path = random::bytestring(4096);
+//         Location::generic(v_path, r_path)
+//     }
+
+//     fn vault_path_to_id(path: &str) -> VaultId {
+//         SecureClient::derive_vault_id(path.as_bytes().to_vec())
+//     }
+
+//     fn r_ctr_to_id(vault_path: &str, ctr: usize) -> RecordId {
+//         SecureClient::derive_record_id(vault_path.as_bytes().to_vec(), ctr)
+//     }
+
+//     fn perform_sync(
+//         source: &mut SyncClientState,
+//         target: &mut SyncClientState,
+//         mapper: Option<&Mapper<(VaultId, RecordId)>>,
+//         merge_policy: SelectOrMerge<SelectOne>,
+//     ) -> Result<(), VaultError> {
+//         let hierarchy = source.get_hierarchy()?;
+//         let diff = target.get_diff(hierarchy, mapper, &merge_policy)?;
+//         let exported = source.export_entries(Some(diff))?;
+//         target.import_entries(exported, &merge_policy, mapper, Some(&*source.keystore))?;
+//         Ok(())
+//     }
+
+//     #[test]
+//     fn test_get_hierarchy() -> Result<(), Box<dyn std::error::Error>> {
+//         let cid = ClientId::random::<Provider>()?;
+//         let mut client = SecureClient::new(cid);
+//         let hierarchy = SyncClientState::from(&mut client).get_hierarchy()?;
+//         assert!(hierarchy.is_empty());
+
+//         let location_1 = test_location();
+//         let (vid1, rid1) = SecureClient::resolve_location(location_1.clone());
+//         client.write_to_vault(&location_1, test_hint(), test_value())?;
+
+//         let v_path_2 = random::bytestring(4096);
+//         let r_path_2 = random::bytestring(4096);
+//         let location_2 = Location::generic(v_path_2.clone(), r_path_2);
+//         let (vid2, rid2) = SecureClient::resolve_location(location_2.clone());
+//         client.write_to_vault(&location_2, test_hint(), test_value())?;
+
+//         // Same vault as value nr 2.
+//         let r_path_3 = random::bytestring(4096);
+//         let location_3 = Location::generic(v_path_2, r_path_3);
+//         let (vid23, rid3) = SecureClient::resolve_location(location_3.clone());
+//         assert_eq!(vid2, vid23);
+//         client.write_to_vault(&location_3, test_hint(), test_value())?;
+
+//         let hierarchy = SyncClientState::from(&mut client).get_hierarchy()?;
+
+//         assert_eq!(hierarchy.len(), 2);
+//         let records_1 = hierarchy
+//             .iter()
+//             .find(|(k, _)| **k == vid1)
+//             .expect("Vault does not exist.")
+//             .1;
+//         assert_eq!(records_1.len(), 1);
+//         assert_eq!(records_1[0].0, rid1);
+
+//         let records_2 = hierarchy
+//             .iter()
+//             .find(|(k, _)| **k == vid2)
+//             .expect("Vault does not exist.")
+//             .1;
+//         assert_eq!(records_2.len(), 2);
+//         assert!(records_2.iter().any(|(rid, _)| rid == &rid2));
+//         assert!(records_2.iter().any(|(rid, _)| rid == &rid3));
+
+//         Ok(())
+//     }
+
+//     #[test]
+//     fn test_export_with_mapping() -> Result<(), Box<dyn std::error::Error>> {
+//         let mapping = |(vid, rid)| {
+//             if vid == vault_path_to_id("vault_1") {
+//                 if rid == r_ctr_to_id("vault_1", 11) {
+//                     // Map record in same vault to new record id.
+//                     Some((vid, r_ctr_to_id("vault_1", 111)))
+//                 } else if rid == r_ctr_to_id("vault_1", 12) {
+//                     // Map record to a vault that we skipped in the sources hierarchy.
+//                     Some((vault_path_to_id("vault_3"), r_ctr_to_id("vault_3", 121)))
+//                 } else if rid == r_ctr_to_id("vault_1", 13) {
+//                     // Map record to an entirely new vault.
+//                     Some((vault_path_to_id("vault_4"), r_ctr_to_id("vault_4", 13)))
+//                 } else {
+//                     // Keep at same location.
+//                     Some((vid, rid))
+//                 }
+//             } else if vid == vault_path_to_id("vault_2") {
+//                 // Move whole vault.
+//                 Some((vault_path_to_id("vault_5"), rid))
+//             } else {
+//                 // Skip record from any source vault with path != vault_1 || vault_2.
+//                 None
+//             }
+//         };
+//         let mapper = Mapper { f: mapping };
+
+//         let cid0 = ClientId::random::<Provider>()?;
+//         let mut source_client = SecureClient::new(cid0);
+
+//         // Fill test vaults.
+//         for i in 1..4usize {
+//             for j in 1..5usize {
+//                 let vault_path = format!("vault_{}", i);
+//                 let location = Location::counter(vault_path, i * 10 + j);
+//                 source_client.write_to_vault(&location, test_hint(), test_value())?;
+//             }
+//         }
+
+//         let mut target_client = SecureClient::new(cid0);
+
+//         let mut source = SyncClientState::from(&mut source_client);
+//         let mut target = SyncClientState::from(&mut target_client);
+//         let merge_policy = match random::random::<u8>() % 4 {
+//             0 => SelectOrMerge::KeepOld,
+//             1 => SelectOrMerge::Replace,
+//             2 => SelectOrMerge::Merge(SelectOne::KeepOld),
+//             3 => SelectOrMerge::Merge(SelectOne::Replace),
+//             _ => unreachable!("0 <= n % 4 <= 3"),
+//         };
+
+//         let source_hierarchy = source.get_hierarchy()?;
+//         let target_hierarchy = target.get_hierarchy()?;
+//         assert!(target_hierarchy.is_empty());
+
+//         // Do sync.
+//         perform_sync(&mut source, &mut target, Some(&mapper), merge_policy)?;
+
+//         // Check that old state still contains all values
+//         let check_hierarchy = source.get_hierarchy()?;
+//         assert_eq!(source_hierarchy, check_hierarchy);
+
+//         let mut target_hierarchy = target.get_hierarchy()?;
+//         assert_eq!(target_hierarchy.keys().len(), 4);
+
+//         // Vault-1 was partly mapped.
+//         let v_1_entries = target_hierarchy
+//             .remove(&vault_path_to_id("vault_1"))
+//             .expect("Vault does not exist.");
+//         assert_eq!(v_1_entries.len(), 2);
+//         // Record-14 was not moved.
+//         assert!(v_1_entries.iter().any(|(rid, _)| rid == &r_ctr_to_id("vault_1", 14)));
+//         // Record-11 was moved to counter 111.
+//         assert!(v_1_entries.iter().any(|(rid, _)| rid == &r_ctr_to_id("vault_1", 111)));
+
+//         // All records from Vault-2 were moved to Vault-5.
+//         assert!(!target_hierarchy.contains_key(&vault_path_to_id("vault_2")));
+//         let v_5_entries = target_hierarchy
+//             .remove(&vault_path_to_id("vault_5"))
+//             .expect("Vault does not exist.");
+//         assert_eq!(v_5_entries.len(), 4);
+//         assert!(v_5_entries.iter().any(|(rid, _)| rid == &r_ctr_to_id("vault_2", 21)));
+//         assert!(v_5_entries.iter().any(|(rid, _)| rid == &r_ctr_to_id("vault_2", 22)));
+//         assert!(v_5_entries.iter().any(|(rid, _)| rid == &r_ctr_to_id("vault_2", 23)));
+//         assert!(v_5_entries.iter().any(|(rid, _)| rid == &r_ctr_to_id("vault_2", 24)));
+
+//         // Vault-3 from source was skipped, but Record-12 from Vault-1 was moved to Vault-3 Record-121.
+//         let v_3_entries = target_hierarchy
+//             .remove(&vault_path_to_id("vault_3"))
+//             .expect("Vault does not exist.");
+//         assert_eq!(v_3_entries.len(), 1);
+//         assert!(v_3_entries.iter().any(|(rid, _)| rid == &r_ctr_to_id("vault_3", 121)));
+
+//         // Record-13 from Vault-1 was moved to new Vault-4.
+//         let v_4_entries = target_hierarchy
+//             .remove(&vault_path_to_id("vault_4"))
+//             .expect("Vault does not exist.");
+//         assert_eq!(v_4_entries.len(), 1);
+//         assert!(v_4_entries.iter().any(|(rid, _)| rid == &r_ctr_to_id("vault_4", 13)));
+
+//         Ok(())
+//     }
+
+//     #[test]
+//     fn test_merge_policy() -> Result<(), Box<dyn std::error::Error>> {
+//         let cid0 = ClientId::random::<Provider>()?;
+//         let mut source_client = SecureClient::new(cid0);
+
+//         // Fill test vaults.
+//         for i in 1..3usize {
+//             for j in 1..3usize {
+//                 let vault_path = format!("vault_{}", i);
+//                 let location = Location::counter(vault_path, i * 10 + j);
+//                 source_client.write_to_vault(&location, test_hint(), test_value())?;
+//             }
+//         }
+
+//         let mut source = SyncClientState::from(&mut source_client);
+//         let mut source_vault_2_hierarchy = source
+//             .get_hierarchy()?
+//             .remove(&vault_path_to_id("vault_2"))
+//             .expect("Vault does not exist.");
+//         source_vault_2_hierarchy.sort();
+//         let source_v2_r2_bid = source_vault_2_hierarchy
+//             .iter()
+//             .find(|(rid, _)| rid == &r_ctr_to_id("vault_2", 22))
+//             .map(|(_, bid)| *bid)
+//             .expect("Record does not exist.");
+
+//         let set_up_target = || -> Result<SecureClient, VaultError> {
+//             let mut target_client = SecureClient::new(cid0);
+//             for i in 2..4usize {
+//                 for j in 2..4usize {
+//                     let vault_path = format!("vault_{}", i);
+//                     let location = Location::counter(vault_path, i * 10 + j);
+//                     target_client.write_to_vault(&location, test_hint(), test_value())?;
+//                 }
+//             }
+//             Ok(target_client)
+//         };
+
+//         let assert_for_distinct_vaults = |hierarchy: &mut HashMap<VaultId, Vec<(RecordId, BlobId)>>| {
+//             // Imported full vault-1;
+//             assert_eq!(hierarchy.keys().len(), 3);
+//             let v_1_entries = hierarchy
+//                 .remove(&vault_path_to_id("vault_1"))
+//                 .expect("Vault does not exist.");
+//             assert_eq!(v_1_entries.len(), 2);
+//             assert!(v_1_entries.iter().any(|(rid, _)| rid == &r_ctr_to_id("vault_1", 11)));
+//             assert!(v_1_entries.iter().any(|(rid, _)| rid == &r_ctr_to_id("vault_1", 12)));
+
+//             // Kept old vault-3;
+//             let v_3_entries = hierarchy
+//                 .remove(&vault_path_to_id("vault_3"))
+//                 .expect("Vault does not exist.");
+//             assert_eq!(v_3_entries.len(), 2);
+//             assert!(v_3_entries.iter().any(|(rid, _)| rid == &r_ctr_to_id("vault_3", 32)));
+//             assert!(v_3_entries.iter().any(|(rid, _)| rid == &r_ctr_to_id("vault_3", 33)));
+//         };
+
+//         // == Test merge policy SelectOrMerge::KeepOld
+
+//         let mut target_client_1 = set_up_target()?;
+//         let mut target_1 = SyncClientState::from(&mut target_client_1);
+//         let mut old_vault_2_hierarchy = target_1
+//             .get_hierarchy()?
+//             .remove(&vault_path_to_id("vault_2"))
+//             .expect("Vault does not exist.");
+//         old_vault_2_hierarchy.sort();
+//         let merge_policy = SelectOrMerge::KeepOld;
+
+//         perform_sync(&mut source, &mut target_1, None, merge_policy)?;
+
+//         let mut hierarchy_1 = target_1.get_hierarchy()?;
+
+//         assert_for_distinct_vaults(&mut hierarchy_1);
+
+//         // Kept old vault-2.
+//         let mut v_2_entries = hierarchy_1
+//             .remove(&vault_path_to_id("vault_2"))
+//             .expect("Vault does not exist.");
+//         v_2_entries.sort();
+//         assert_eq!(v_2_entries, old_vault_2_hierarchy);
+
+//         // == Test merge policy SelectOrMerge::Replace
+
+//         let mut target_client_2 = set_up_target()?;
+//         let mut target_2 = SyncClientState::from(&mut target_client_2);
+//         let merge_policy = SelectOrMerge::Replace;
+//         perform_sync(&mut source, &mut target_2, None, merge_policy)?;
+//         let mut hierarchy_2 = target_2.get_hierarchy()?;
+
+//         assert_for_distinct_vaults(&mut hierarchy_2);
+
+//         // Replace vault-2 completely with imported one;
+//         let mut v_2_entries = hierarchy_2
+//             .remove(&vault_path_to_id("vault_2"))
+//             .expect("Vault does not exist.");
+//         v_2_entries.sort();
+//         assert_eq!(v_2_entries, source_vault_2_hierarchy);
+
+//         // == Test merge policy SelectOrMerge::Merge(SelectOne::KeepOld)
+
+//         let mut target_client_3 = set_up_target()?;
+//         let mut target_3 = SyncClientState::from(&mut target_client_3);
+//         let old_v2_r2_bid = target_3
+//             .get_hierarchy()?
+//             .remove(&vault_path_to_id("vault_2"))
+//             .and_then(|vec| vec.into_iter().find(|(rid, _)| rid == &r_ctr_to_id("vault_2", 22)))
+//             .map(|(_, bid)| bid)
+//             .expect("Record does not exist.");
+//         let merge_policy = SelectOrMerge::Merge(SelectOne::KeepOld);
+//         perform_sync(&mut source, &mut target_3, None, merge_policy)?;
+//         let mut hierarchy_3 = target_3.get_hierarchy()?;
+
+//         assert_for_distinct_vaults(&mut hierarchy_3);
+
+//         // Merge vault-2 with imported one, keep old record on conflict.
+//         let v_2_entries = hierarchy_3
+//             .remove(&vault_path_to_id("vault_2"))
+//             .expect("Vault does not exist.");
+//         assert_eq!(v_2_entries.len(), 3);
+//         assert!(v_2_entries.iter().any(|(rid, _)| rid == &r_ctr_to_id("vault_2", 21)));
+//         assert!(v_2_entries.iter().any(|(rid, _)| rid == &r_ctr_to_id("vault_2", 23)));
+//         let v2_r2_bid = v_2_entries
+//             .into_iter()
+//             .find(|(rid, _)| rid == &r_ctr_to_id("vault_2", 22))
+//             .map(|(_, bid)| bid)
+//             .expect("Record does not exist.");
+//         assert_eq!(v2_r2_bid, old_v2_r2_bid);
+
+//         // == Test merge policy SelectOrMerge::Merge(SelectOne::Replace)
+
+//         let mut target_client_4 = set_up_target()?;
+//         let mut target_4 = SyncClientState::from(&mut target_client_4);
+//         let merge_policy = SelectOrMerge::Merge(SelectOne::Replace);
+//         perform_sync(&mut source, &mut target_4, None, merge_policy)?;
+//         let mut hierarchy_4 = target_4.get_hierarchy()?;
+
+//         assert_for_distinct_vaults(&mut hierarchy_4);
+
+//         // Merge vault-2 with imported one, keep old record on conflict.
+//         let v_2_entries = hierarchy_4
+//             .remove(&vault_path_to_id("vault_2"))
+//             .expect("Vault does not exist.");
+//         assert_eq!(v_2_entries.len(), 3);
+//         assert!(v_2_entries.iter().any(|(rid, _)| rid == &r_ctr_to_id("vault_2", 21)));
+//         assert!(v_2_entries.iter().any(|(rid, _)| rid == &r_ctr_to_id("vault_2", 23)));
+//         let v2_r2_bid = v_2_entries
+//             .into_iter()
+//             .find(|(rid, _)| rid == &r_ctr_to_id("vault_2", 22))
+//             .map(|(_, bid)| bid)
+//             .expect("Record does not exist.");
+//         assert_eq!(v2_r2_bid, source_v2_r2_bid);
+
+//         Ok(())
+//     }
+// }

--- a/client_new/src/tests/interface_tests.rs
+++ b/client_new/src/tests/interface_tests.rs
@@ -47,7 +47,7 @@ async fn test_full_stronghold_access() -> Result<(), Box<dyn Error>> {
 
     assert!(procedure_result.is_ok());
 
-    let vault_exists = client.vault_exists(b"vault_path".to_vec()).await;
+    let vault_exists = client.vault_exists(b"vault_path").await;
     assert!(vault_exists.is_ok());
     assert!(vault_exists.unwrap());
 

--- a/client_new/src/types/client.rs
+++ b/client_new/src/types/client.rs
@@ -125,11 +125,13 @@ impl Client {
     /// ```
     pub fn sync_vaults(
         &self,
-        source: VaultId,
-        target: VaultId,
+        source_path: Vec<u8>,
+        target_path: Vec<u8>,
         select_records: Option<Vec<RecordId>>,
         merge_policy: MergePolicy,
     ) -> Result<(), ClientError> {
+        let source = derive_vault_id(source_path);
+        let target = derive_vault_id(target_path);
         let select_vaults = vec![source];
         let map_vaults = [(source, target)].into();
         let select_records = select_records.map(|vec| [(source, vec)].into()).unwrap_or_default();

--- a/client_new/src/types/client.rs
+++ b/client_new/src/types/client.rs
@@ -96,7 +96,7 @@ impl Client {
     /// ```
     pub async fn vault_exists<P>(&self, vault_path: P) -> Result<bool, ClientError>
     where
-        P: AsRef<Vec<u8>>,
+        P: AsRef<[u8]>,
     {
         let vault_id = derive_vault_id(vault_path);
         let keystore = self.keystore.try_read()?;

--- a/client_new/src/types/client.rs
+++ b/client_new/src/types/client.rs
@@ -140,15 +140,13 @@ impl Client {
         };
         let state = ClientRef::try_from(self)?;
 
-        let hierarchy = state.get_hierarchy(config.selected_source_vaults());
-        let mapped_hierarchy = config.filter_map(hierarchy);
-        let diff = state.get_diff(mapped_hierarchy, &config.merge_policy);
+        let hierarchy = state.get_hierarchy(config.select_vaults.clone());
+        let diff = state.get_diff(hierarchy, &config);
         let exported = state.export_entries(diff);
-        let mapped_exported = config.filter_map(exported);
 
         drop(state);
         let mut state_mut = ClientRefMut::try_from(self)?;
-        state_mut.import_own_records(mapped_exported, config.map_vaults);
+        state_mut.import_own_records(exported, config.map_vaults);
         Ok(())
     }
 
@@ -161,15 +159,13 @@ impl Client {
         let self_state = ClientRef::try_from(self)?;
         let other_state = ClientRef::try_from(other)?;
 
-        let hierarchy = other_state.get_hierarchy(config.selected_source_vaults());
-        let mapped_hierarchy = config.filter_map(hierarchy);
-        let diff = self_state.get_diff(mapped_hierarchy, &config.merge_policy);
+        let hierarchy = other_state.get_hierarchy(config.select_vaults.clone());
+        let diff = self_state.get_diff(hierarchy, &config);
         let exported = other_state.export_entries(diff);
-        let mapped_exported = config.filter_map(exported);
 
         drop(self_state);
         let mut self_state_mut = ClientRefMut::try_from(self)?;
-        self_state_mut.import_records(mapped_exported, &other_state.keystore, config.map_vaults);
+        self_state_mut.import_records(exported, &other_state.keystore, &config);
         Ok(())
     }
 

--- a/client_new/src/types/error.rs
+++ b/client_new/src/types/error.rs
@@ -1,9 +1,12 @@
 // Copyright 2020-2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::TryLockError;
+use std::{convert::Infallible, fmt::Debug, sync::TryLockError};
 
-use engine::vault::{BoxProvider, RecordError as EngineRecordError, RecordId, VaultError as EngineVaultError, VaultId};
+use engine::{
+    snapshot::{ReadError as EngineReadError, WriteError as EngineWriteError},
+    vault::{BoxProvider, RecordError as EngineRecordError, RecordId, VaultError as EngineVaultError, VaultId},
+};
 use serde::{de::Error, Deserialize, Serialize};
 use thiserror::Error as DeriveError;
 
@@ -27,6 +30,12 @@ pub enum ClientError {
     #[error("Inner error occured({0})")]
     Inner(String),
 
+    #[error("Engine error occured({0})")]
+    Engine(String),
+
+    #[error("BoxProvider error: {0}")]
+    Provider(String),
+
     #[error("Error loading client data. No data present")]
     ClientDataNotPresent,
 }
@@ -37,6 +46,24 @@ impl<T> From<TryLockError<T>> for ClientError {
     }
 }
 
+impl<E: Debug> From<VaultError<E>> for ClientError {
+    fn from(e: VaultError<E>) -> Self {
+        ClientError::Engine(format!("{:?}", e))
+    }
+}
+
+impl From<RecordError> for ClientError {
+    fn from(e: RecordError) -> Self {
+        VaultError::<Infallible>::Record(e).into()
+    }
+}
+
+impl From<<Provider as BoxProvider>::Error> for ClientError {
+    fn from(e: <Provider as BoxProvider>::Error) -> Self {
+        ClientError::Provider(format!("{:?}", e))
+    }
+}
+
 pub type VaultError<E> = EngineVaultError<<Provider as BoxProvider>::Error, E>;
 
 pub type RecordError = EngineRecordError<<Provider as BoxProvider>::Error>;
@@ -44,6 +71,18 @@ pub type RecordError = EngineRecordError<<Provider as BoxProvider>::Error>;
 #[derive(DeriveError, Debug, Clone, Serialize, Deserialize)]
 #[error("fatal engine error: {0}")]
 pub struct FatalEngineError(String);
+
+impl From<RecordError> for FatalEngineError {
+    fn from(e: RecordError) -> Self {
+        FatalEngineError(e.to_string())
+    }
+}
+
+impl From<String> for FatalEngineError {
+    fn from(e: String) -> Self {
+        FatalEngineError(e)
+    }
+}
 
 #[derive(Debug, DeriveError)]
 pub enum SnapshotError {
@@ -60,7 +99,7 @@ pub enum SnapshotError {
     SnapshotKey(VaultId, RecordId),
 
     #[error("vault error: {0}")]
-    Vault(String),
+    Engine(String),
 
     #[error("BoxProvider error: {0}")]
     Provider(String),
@@ -69,14 +108,56 @@ pub enum SnapshotError {
     Inner(String),
 }
 
-impl From<RecordError> for FatalEngineError {
-    fn from(e: RecordError) -> Self {
-        FatalEngineError(e.to_string())
+impl From<ClientError> for SnapshotError {
+    fn from(e: ClientError) -> Self {
+        SnapshotError::Inner(format!("{}", e))
     }
 }
 
-impl From<String> for FatalEngineError {
-    fn from(e: String) -> Self {
-        FatalEngineError(e)
+impl From<bincode::Error> for SnapshotError {
+    fn from(e: bincode::Error) -> Self {
+        SnapshotError::CorruptedContent(format!("bincode error: {}", e))
+    }
+}
+
+impl From<<Provider as BoxProvider>::Error> for SnapshotError {
+    fn from(e: <Provider as BoxProvider>::Error) -> Self {
+        SnapshotError::Provider(format!("{:?}", e))
+    }
+}
+
+impl<E: Debug> From<VaultError<E>> for SnapshotError {
+    fn from(e: VaultError<E>) -> Self {
+        SnapshotError::Engine(format!("{:?}", e))
+    }
+}
+
+impl From<RecordError> for SnapshotError {
+    fn from(e: RecordError) -> Self {
+        VaultError::<Infallible>::Record(e).into()
+    }
+}
+
+impl From<EngineReadError> for SnapshotError {
+    fn from(e: EngineReadError) -> Self {
+        match e {
+            EngineReadError::CorruptedContent(reason) => SnapshotError::CorruptedContent(reason),
+            EngineReadError::InvalidFile => SnapshotError::InvalidFile("Not a Snapshot.".into()),
+            EngineReadError::Io(io) => SnapshotError::Io(io),
+            EngineReadError::UnsupportedVersion { expected, found } => SnapshotError::InvalidFile(format!(
+                "Unsupported version: expected {:?}, found {:?}.",
+                expected, found
+            )),
+        }
+    }
+}
+
+impl From<EngineWriteError> for SnapshotError {
+    fn from(e: EngineWriteError) -> Self {
+        match e {
+            EngineWriteError::Io(io) => SnapshotError::Io(io),
+            EngineWriteError::CorruptedData(e) => SnapshotError::CorruptedContent(e),
+            EngineWriteError::GenerateRandom(_) => SnapshotError::Io(std::io::ErrorKind::Other.into()),
+        }
     }
 }

--- a/client_new/src/types/error.rs
+++ b/client_new/src/types/error.rs
@@ -1,6 +1,8 @@
 // Copyright 2020-2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use std::sync::TryLockError;
+
 use engine::vault::{BoxProvider, RecordError as EngineRecordError, RecordId, VaultError as EngineVaultError, VaultId};
 use serde::{de::Error, Deserialize, Serialize};
 use thiserror::Error as DeriveError;
@@ -27,6 +29,12 @@ pub enum ClientError {
 
     #[error("Error loading client data. No data present")]
     ClientDataNotPresent,
+}
+
+impl<T> From<TryLockError<T>> for ClientError {
+    fn from(_: TryLockError<T>) -> Self {
+        ClientError::LockAcquireFailed
+    }
 }
 
 pub type VaultError<E> = EngineVaultError<<Provider as BoxProvider>::Error, E>;

--- a/client_new/src/types/location.rs
+++ b/client_new/src/types/location.rs
@@ -70,12 +70,12 @@ impl Location {
                 record_path,
             } => {
                 let vid = derive_vault_id(vault_path);
-                let rid = RecordId::load_from_path(vid.as_ref(), record_path);
+                let rid = derive_record_id(vault_path, record_path);
                 (vid, rid)
             }
             Location::Counter { vault_path, counter } => {
                 let vid = derive_vault_id(vault_path);
-                let rid = derive_record_id(vault_path, *counter);
+                let rid = derive_record_id_from_counter(vault_path, *counter);
 
                 (vid, rid)
             }
@@ -97,7 +97,17 @@ where
 }
 
 // Derives the counter [`RecordId`] from the given vault path and the counter value.
-pub fn derive_record_id<P>(vault_path: P, counter: usize) -> RecordId
+pub fn derive_record_id<V, R>(vault_path: V, record_path: R) -> RecordId
+where
+    V: AsRef<Vec<u8>>,
+    R: AsRef<Vec<u8>>,
+{
+    let vid = derive_vault_id(vault_path);
+    RecordId::load_from_path(vid.as_ref(), record_path.as_ref())
+}
+
+// Derives the counter [`RecordId`] from the given vault path and the counter value.
+pub fn derive_record_id_from_counter<P>(vault_path: P, counter: usize) -> RecordId
 where
     P: AsRef<Vec<u8>>,
 {

--- a/client_new/src/types/location.rs
+++ b/client_new/src/types/location.rs
@@ -91,7 +91,7 @@ impl AsRef<Location> for Location {
 
 pub fn derive_vault_id<P>(path: P) -> VaultId
 where
-    P: AsRef<Vec<u8>>,
+    P: AsRef<[u8]>,
 {
     VaultId::load_from_path(path.as_ref(), path.as_ref())
 }
@@ -99,8 +99,8 @@ where
 // Derives the counter [`RecordId`] from the given vault path and the counter value.
 pub fn derive_record_id<V, R>(vault_path: V, record_path: R) -> RecordId
 where
-    V: AsRef<Vec<u8>>,
-    R: AsRef<Vec<u8>>,
+    V: AsRef<[u8]>,
+    R: AsRef<[u8]>,
 {
     let vid = derive_vault_id(vault_path);
     RecordId::load_from_path(vid.as_ref(), record_path.as_ref())
@@ -109,7 +109,7 @@ where
 // Derives the counter [`RecordId`] from the given vault path and the counter value.
 pub fn derive_record_id_from_counter<P>(vault_path: P, counter: usize) -> RecordId
 where
-    P: AsRef<Vec<u8>>,
+    P: AsRef<[u8]>,
 {
     let vault_path = vault_path.as_ref();
 

--- a/client_new/src/types/snapshot.rs
+++ b/client_new/src/types/snapshot.rs
@@ -118,7 +118,7 @@ pub enum UseKey {
 
 /// Data structure that is written to the snapshot.
 #[derive(Deserialize, Serialize, Default)]
-pub struct SnapshotState(HashMap<ClientId, ClientState>);
+pub struct SnapshotState(pub(crate) HashMap<ClientId, ClientState>);
 
 impl Snapshot {
     /// Creates a new [`Snapshot`] from a buffer of [`SnapshotState`] state.

--- a/client_new/src/types/store.rs
+++ b/client_new/src/types/store.rs
@@ -68,7 +68,7 @@ impl Store {
     /// assert!(store.insert(key.clone(), data, None).is_ok());
     /// ```
     pub fn insert(&self, key: Vec<u8>, value: Vec<u8>, lifetime: Option<Duration>) -> Result<(), ClientError> {
-        let mut guard = self.cache.try_write().map_err(|_| ClientError::LockAcquireFailed)?;
+        let mut guard = self.cache.try_write()?;
         guard.insert(key, value, lifetime);
 
         Ok(())
@@ -88,7 +88,7 @@ impl Store {
     /// assert!(store.get(key).unwrap().deref().is_some());
     /// ```
     pub fn get(&self, key: Vec<u8>) -> Result<StoreGuard<'_>, ClientError> {
-        let guard = self.cache.try_read().map_err(|_| ClientError::LockAcquireFailed)?;
+        let guard = self.cache.try_read()?;
 
         // Problem: The returned rwread guard is local to this function, hence we can't return a borrowed ref
         // to the inner value. we could return the guard itself, but would rely on the user to deref the rwguard
@@ -111,7 +111,7 @@ impl Store {
     /// assert!(store.get(key).unwrap().deref().is_none());
     /// ```
     pub fn delete(&self, key: Vec<u8>) -> Result<Option<Vec<u8>>, ClientError> {
-        let mut guard = self.cache.try_write().map_err(|_| ClientError::LockAcquireFailed)?;
+        let mut guard = self.cache.try_write()?;
         Ok(guard.remove(&key))
     }
 
@@ -127,7 +127,7 @@ impl Store {
     /// assert!(store.contains_key(key).unwrap());
     /// ```
     pub fn contains_key(&self, key: Vec<u8>) -> Result<bool, ClientError> {
-        let guard = self.cache.try_read().map_err(|_| ClientError::LockAcquireFailed)?;
+        let guard = self.cache.try_read()?;
         Ok(guard.get(&key).is_some())
     }
 
@@ -150,7 +150,7 @@ impl Store {
     /// store.reload(cache);
     /// ```
     pub fn reload(&self, cache: Cache<Vec<u8>, Vec<u8>>) -> Result<(), ClientError> {
-        let mut inner = self.cache.try_write().map_err(|_| ClientError::LockAcquireFailed)?;
+        let mut inner = self.cache.try_write()?;
         *inner = cache;
         Ok(())
     }

--- a/client_new/src/types/stronghold/base.rs
+++ b/client_new/src/types/stronghold/base.rs
@@ -30,7 +30,7 @@ impl Stronghold {
         snapshot_path: &SnapshotPath,
     ) -> Result<Client, ClientError>
     where
-        P: AsRef<Vec<u8>>,
+        P: AsRef<[u8]>,
     {
         let client = Client::default();
         let client_id = ClientId::load_from_path(client_path.as_ref(), client_path.as_ref());
@@ -67,7 +67,7 @@ impl Stronghold {
     /// Loads a client from [`Snapshot`] data
     pub async fn load_client<P>(&self, client_path: P) -> Result<Client, ClientError>
     where
-        P: AsRef<Vec<u8>>,
+        P: AsRef<[u8]>,
     {
         let client = Client::default();
         let client_id = ClientId::load_from_path(client_path.as_ref(), client_path.as_ref());
@@ -98,7 +98,7 @@ impl Stronghold {
     /// # Example
     pub async fn create_client<P>(&self, client_path: P) -> Result<Client, ClientError>
     where
-        P: AsRef<Vec<u8>>,
+        P: AsRef<[u8]>,
     {
         let client = Client::default();
         let client_id = ClientId::load_from_path(client_path.as_ref(), client_path.as_ref());
@@ -144,7 +144,7 @@ impl Stronghold {
     /// # Example
     pub async fn write_client<P>(&self, client_path: P) -> Result<(), ClientError>
     where
-        P: AsRef<Vec<u8>>,
+        P: AsRef<[u8]>,
     {
         let client_id = ClientId::load_from_path(client_path.as_ref(), client_path.as_ref());
         self.write(client_id).await

--- a/client_new/src/types/stronghold/base.rs
+++ b/client_new/src/types/stronghold/base.rs
@@ -15,7 +15,10 @@ impl Stronghold {
         Self::default()
     }
 
-    /// Loads a [`Client`] from `client_path` from a [`Snapshot`] with given `snapshot_path` as [`SnapshotPath`]
+    /// Load the state of a [`Snapshot`] at given `snapshot_path`.
+    /// The [`Snapshot`] is secured in memory and may be used to load further
+    /// clients with [`Stronghold::load_client`].
+    /// Load a [`Client`] at `client_path` from the snapshot.
     ///
     /// # Example
     /// ```no_run

--- a/client_new/src/types/stronghold/base.rs
+++ b/client_new/src/types/stronghold/base.rs
@@ -69,7 +69,7 @@ impl Stronghold {
         let client = Client::default();
         let client_id = ClientId::load_from_path(client_path.as_ref(), client_path.as_ref());
 
-        let mut snapshot = self.snapshot.try_write().map_err(|_| ClientError::LockAcquireFailed)?;
+        let snapshot = self.snapshot.try_read().map_err(|_| ClientError::LockAcquireFailed)?;
 
         if !snapshot.has_data(client_id) {
             return Err(ClientError::ClientDataNotPresent);
@@ -120,7 +120,7 @@ impl Stronghold {
             self.write(client_id).await?;
         }
 
-        let mut snapshot = self.snapshot.try_write().map_err(|_| ClientError::LockAcquireFailed)?;
+        let snapshot = self.snapshot.try_read().map_err(|_| ClientError::LockAcquireFailed)?;
 
         // CRITICAL SECTION
         let buffer = keyprovider

--- a/client_new/src/types/vault.rs
+++ b/client_new/src/types/vault.rs
@@ -30,13 +30,12 @@ impl ClientVault {
     /// ```
     /// ```
     pub fn write_secret(&self, location: Location, payload: Vec<u8>) -> Result<(), ClientError> {
-        self.client
-            .write_to_vault(
-                &location,
-                RecordHint::new(rand::bytestring(DEFAULT_RANDOM_HINT_SIZE)).unwrap(),
-                payload,
-            )
-            .map_err(|e| ClientError::Inner(e.to_string()))
+        self.client.write_to_vault(
+            &location,
+            RecordHint::new(rand::bytestring(DEFAULT_RANDOM_HINT_SIZE)).unwrap(),
+            payload,
+        )?;
+        Ok(())
     }
 
     /// Deletes a secret from the vault
@@ -55,9 +54,8 @@ impl ClientVault {
     /// ```
     /// ```
     pub fn revoke_secret(&self, location: Location) -> Result<(), ClientError> {
-        self.client
-            .revoke_data(&location)
-            .map_err(|e| ClientError::Inner(e.to_string()))
+        self.client.revoke_data(&location)?;
+        Ok(())
     }
 
     /// Collects revoked records and deletes them

--- a/engine/src/vault/view.rs
+++ b/engine/src/vault/view.rs
@@ -133,7 +133,7 @@ impl<P: BoxProvider> DbView<P> {
 
     /// Get access the decrypted [`Buffer`] of the specified [`Record`].
     pub fn get_guard<E, F>(
-        &mut self,
+        &self,
         key: &Key<P>,
         vid: VaultId,
         rid: RecordId,
@@ -143,7 +143,7 @@ impl<P: BoxProvider> DbView<P> {
         F: FnOnce(Buffer<u8>) -> Result<(), E>,
         E: Debug,
     {
-        let vault = self.vaults.get_mut(&vid).ok_or(VaultError::VaultNotFound(vid))?;
+        let vault = self.vaults.get(&vid).ok_or(VaultError::VaultNotFound(vid))?;
         let guard = vault.get_guard(key, rid.0).map_err(VaultError::Record)?;
         f(guard).map_err(VaultError::Procedure)
     }


### PR DESCRIPTION
# Description of change

Add the synchronization feature to the new client.
This is a refactor of #317, ported to the new client. 

Further improvements included in this PR outside of the sync feature:
- remove unnecessary `mut` requirement from method signatures
- favor `KeyStore::get_key` over `KeyStore::take_key` where possible

Remaining TODOs for this PR:
- [x] handle errors
- [x] add docs

Remaining TODOs outside of this PR:
- Add remote sync
- Test (remote) snapshot sync

// CC @PhilippGackstatter: Can you confirm that your use-case in identity is solved with [`Client::sync_with`](https://github.com/iotaledger/stronghold.rs/blob/d427893d73ed3a96dff1d271bada1edba7fc8a4b/client_new/src/types/client.rs#L159-L164)?


## Links to any relevant issues

Fixes issue #278.

## Type of change

- [x] Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Added test for client-sync.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
