### PR TITLE
Remove `naiveKDF` function; Fix digest for NCTypes

### DIFF
--- a/engine/runtime/Cargo.toml
+++ b/engine/runtime/Cargo.toml
@@ -14,7 +14,7 @@ serde                   = { version = "1.0", features = [ "derive" ] }
 random                  = { version = "0.8.4", package = "rand" }
 dirs                    = { version = "4.0.0" }
 thiserror               = { version = "1.0" }
-iota-crypto             = { version = "0.8.0", features = ["sha"] }
+iota-crypto             = { version = "0.8.0", features = ["blake2b"] }
 
 [dev-dependencies]
 serde_json              = { version = "1.0" }

--- a/engine/runtime/src/memories/noncontiguous_memory.rs
+++ b/engine/runtime/src/memories/noncontiguous_memory.rs
@@ -12,7 +12,8 @@ use core::{
     fmt::{self, Debug, Formatter},
     marker::PhantomData,
 };
-use crypto::hashes::sha;
+// use crypto::hashes::sha;
+use crypto::hashes::{blake2b, Digest};
 use zeroize::Zeroize;
 
 use serde::{
@@ -58,10 +59,10 @@ impl LockedMemory for NonContiguousMemory {
     }
 
     /// Unlocks the memory and returns an unlocked Buffer
-    // To retrieve secret value you xor the hash contained in shard1 with value in shard2
+    /// To retrieve secret value you xor the hash contained in shard1 with value in shard2
     fn unlock(&self) -> Result<Buffer<u8>, MemoryError> {
-        let mut data1 = [0u8; NC_DATA_SIZE];
-        sha::SHA256(&self.get_buffer_from_shard1().borrow(), &mut data1);
+        let data1 = blake2b::Blake2b256::digest(&self.get_buffer_from_shard1().borrow());
+
         let data = match &self.shard2 {
             RamShard(ram2) => {
                 let buf = ram2.unlock()?;
@@ -85,8 +86,7 @@ impl NonContiguousMemory {
             return Err(NCSizeNotAllowed);
         };
         let random = random_vec(NC_DATA_SIZE);
-        let mut digest = [0u8; NC_DATA_SIZE];
-        sha::SHA256(&random, &mut digest);
+        let digest = blake2b::Blake2b256::digest(&random);
         let digest = xor(&digest, payload, NC_DATA_SIZE);
 
         let ram1 = RamMemory::alloc(&random, NC_DATA_SIZE)?;
@@ -128,10 +128,8 @@ impl NonContiguousMemory {
         let new_data1 = xor(data_of_old_shard1, &random, NC_DATA_SIZE);
         let new_shard1 = RamShard(RamMemory::alloc(&new_data1, NC_DATA_SIZE)?);
 
-        let mut hash_of_old_shard1 = [0u8; NC_DATA_SIZE];
-        let mut hash_of_new_shard1 = [0u8; NC_DATA_SIZE];
-        sha::SHA256(data_of_old_shard1, &mut hash_of_old_shard1);
-        sha::SHA256(&new_data1, &mut hash_of_new_shard1);
+        let hash_of_old_shard1 = blake2b::Blake2b256::digest(data_of_old_shard1);
+        let hash_of_new_shard1 = blake2b::Blake2b256::digest(&new_data1);
 
         let new_shard2 = match &self.shard2 {
             RamShard(ram2) => {

--- a/engine/src/snapshot.rs
+++ b/engine/src/snapshot.rs
@@ -25,7 +25,6 @@
 
 mod compression;
 pub mod files;
-pub mod kdf;
 
 mod logic;
 pub use compression::{compress, decompress, Lz4DecodeError};

--- a/engine/src/snapshot/kdf.rs
+++ b/engine/src/snapshot/kdf.rs
@@ -1,8 +1,0 @@
-// Copyright 2020-2021 IOTA Stiftung
-// SPDX-License-Identifier: Apache-2.0
-
-/// a wrapper around the [`HMAC_SHA256`][crypto::macs::hmac::HMAC_SHA256] function used to derive a hash from a given
-/// password.
-pub fn naive_kdf(password: &[u8], salt: &[u8; 32], key: &mut [u8; 32]) {
-    crypto::macs::hmac::HMAC_SHA256(password, salt, key);
-}


### PR DESCRIPTION
# Description of change

sha256 is susceptible for length extension attacks and shall be replaced by `blake2b`. 

## Links to any relevant issues

fixed issues #343 , #341 

## Type of change
- [x] Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

all unit tests pass. 

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
