### PR TITLE
Fix `ClientId` not being set when loading clients

### DIFF
--- a/client/src/tests/interface_tests.rs
+++ b/client/src/tests/interface_tests.rs
@@ -5,9 +5,9 @@ use std::{borrow::BorrowMut, error::Error, path::Path};
 
 use crate::{
     procedures::{GenerateKey, KeyType, StrongholdProcedure},
-    Client, ClientError, ClientVault, KeyProvider, LoadFromPath, Location, Snapshot, SnapshotPath, Store, Stronghold,
+    Client, ClientError, ClientVault, KeyProvider, Location, Snapshot, SnapshotPath, Store, Stronghold,
 };
-use engine::vault::{ClientId, RecordHint};
+use engine::vault::RecordHint;
 use stronghold_utils::random as rand;
 use zeroize::Zeroize;
 
@@ -98,13 +98,10 @@ async fn test_full_stronghold_access() -> Result<(), Box<dyn Error>> {
 // Tests that a freshly created client and a loaded client are correctly purged.
 #[test]
 fn test_stronghold_purge_client() {
-    let vault_path = b"vault_path".to_vec();
     let client_path = b"client_path".to_vec();
     let client_path2 = b"client_path2".to_vec();
 
     let stronghold = Stronghold::default();
-
-    let key = b"abcdefghijklmnopqrstuvwxyz123456".to_vec();
 
     let client = stronghold.create_client(&client_path).unwrap();
     let client2 = stronghold.create_client(&client_path2).unwrap();
@@ -119,19 +116,21 @@ fn test_stronghold_purge_client() {
     client.execute_procedure(generate_key_procedure.clone()).unwrap();
     client2.execute_procedure(generate_key_procedure).unwrap();
 
-    // Write client2 into snapshot
+    // Write clients into snapshot
     stronghold.write_client(&client_path).unwrap();
     stronghold.write_client(&client_path2).unwrap();
 
     assert!(client.record_exists(&output_location).unwrap());
     assert!(client2.record_exists(&output_location).unwrap());
 
+    // Reload client2 from the snapshot state.
     std::mem::drop(client2);
     let client2 = stronghold.load_client(&client_path2).unwrap();
 
     stronghold.purge_client(client).unwrap();
     stronghold.purge_client(client2).unwrap();
 
+    // Both clients should no longer be present in the snapshot.
     let err = stronghold.load_client(&client_path).unwrap_err();
     let err2 = stronghold.load_client(&client_path2).unwrap_err();
 

--- a/client/src/tests/interface_tests.rs
+++ b/client/src/tests/interface_tests.rs
@@ -5,9 +5,9 @@ use std::{borrow::BorrowMut, error::Error, path::Path};
 
 use crate::{
     procedures::{GenerateKey, KeyType, StrongholdProcedure},
-    Client, ClientVault, KeyProvider, Location, Snapshot, SnapshotPath, Store, Stronghold,
+    Client, ClientError, ClientVault, KeyProvider, LoadFromPath, Location, Snapshot, SnapshotPath, Store, Stronghold,
 };
-use engine::vault::RecordHint;
+use engine::vault::{ClientId, RecordHint};
 use stronghold_utils::random as rand;
 use zeroize::Zeroize;
 
@@ -93,6 +93,50 @@ async fn test_full_stronghold_access() -> Result<(), Box<dyn Error>> {
     assert!(procedure_result.is_ok());
 
     Ok(())
+}
+
+// Tests that a freshly created client and a loaded client are correctly purged.
+#[test]
+fn test_stronghold_purge_client() {
+    let vault_path = b"vault_path".to_vec();
+    let client_path = b"client_path".to_vec();
+    let client_path2 = b"client_path2".to_vec();
+
+    let stronghold = Stronghold::default();
+
+    let key = b"abcdefghijklmnopqrstuvwxyz123456".to_vec();
+
+    let client = stronghold.create_client(&client_path).unwrap();
+    let client2 = stronghold.create_client(&client_path2).unwrap();
+
+    let output_location = crate::Location::generic(b"vault_path".to_vec(), b"record_path".to_vec());
+
+    let generate_key_procedure = GenerateKey {
+        ty: KeyType::Ed25519,
+        output: output_location.clone(),
+    };
+
+    client.execute_procedure(generate_key_procedure.clone()).unwrap();
+    client2.execute_procedure(generate_key_procedure).unwrap();
+
+    // Write client2 into snapshot
+    stronghold.write_client(&client_path).unwrap();
+    stronghold.write_client(&client_path2).unwrap();
+
+    assert!(client.record_exists(&output_location).unwrap());
+    assert!(client2.record_exists(&output_location).unwrap());
+
+    std::mem::drop(client2);
+    let client2 = stronghold.load_client(&client_path2).unwrap();
+
+    stronghold.purge_client(client).unwrap();
+    stronghold.purge_client(client2).unwrap();
+
+    let err = stronghold.load_client(&client_path).unwrap_err();
+    let err2 = stronghold.load_client(&client_path2).unwrap_err();
+
+    assert!(matches!(err, ClientError::ClientDataNotPresent));
+    assert!(matches!(err2, ClientError::ClientDataNotPresent));
 }
 
 #[tokio::test]

--- a/client/src/types/client.rs
+++ b/client/src/types/client.rs
@@ -192,8 +192,10 @@ impl Client {
     /// Loads the state of [`Self`] from a [`ClientState`]. Replaces all previous data.
     ///
     /// # Example
-    pub(crate) fn restore(&self, state: ClientState, id: ClientId) -> Result<(), ClientError> {
+    pub(crate) fn restore(&mut self, state: ClientState, id: ClientId) -> Result<(), ClientError> {
         let (keys, db, st) = state;
+
+        self.id = id;
 
         // reload keystore
         let mut keystore = self.keystore.try_write()?;

--- a/client/src/types/stronghold.rs
+++ b/client/src/types/stronghold.rs
@@ -107,7 +107,7 @@ impl Stronghold {
     where
         P: AsRef<[u8]>,
     {
-        let client = Client::default();
+        let mut client = Client::default();
         let client_id = ClientId::load_from_path(client_path.as_ref(), client_path.as_ref());
 
         // load the snapshot from disk
@@ -137,8 +137,8 @@ impl Stronghold {
     where
         P: AsRef<[u8]>,
     {
-        let client = Client::default();
         let client_id = ClientId::load_from_path(client_path.as_ref(), client_path.as_ref());
+        let mut client = Client::default();
 
         let snapshot = self.snapshot.try_read()?;
 


### PR DESCRIPTION
# Description of change

Loading a client does not set the `Client`'s `ClientId`, which is required for correct functioning of subsequent `Stronghold::purge_client` calls.

This could have potentially been detected if `#![allow(unused_variables)]` was not allowed, since `Client::restore`'s `ClientId` parameter was unused until now. Strong recommendation to activate those lints.

## Links to any relevant issues

n/a

## Type of change

Choose a type of change, and delete any options that are not relevant.

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested

`Stronghold::purge_client` was tested with both a freshly created client and a loaded client.

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
