### PR TITLE
 Allow procedures to use multiple secrets 

### DIFF
--- a/client/src/procedures/clientrunner.rs
+++ b/client/src/procedures/clientrunner.rs
@@ -185,7 +185,8 @@ impl Client {
             let key: Key<Provider> = keystore.get_key(vault_id).ok_or(VaultError::VaultNotFound(vault_id))?;
             ids.push((key, vault_id, record_id));
         }
-        let ids: [(Key<Provider>, VaultId, RecordId); N] = ids.try_into().expect("buffers did not have exactly len N");
+        let ids: [(Key<Provider>, VaultId, RecordId); N] =
+            <[_; N]>::try_from(ids).expect("buffers did not have exactly len N");
         Ok(ids)
     }
 

--- a/client/src/procedures/clientrunner.rs
+++ b/client/src/procedures/clientrunner.rs
@@ -20,6 +20,7 @@ use crate::{
 };
 use stronghold_utils::random as rand;
 pub const DEFAULT_RANDOM_HINT_SIZE: usize = 24;
+type ResolvedLocation = (Key<Provider>, VaultId, RecordId);
 
 // ported [`Runner`] impl for [`Client`]
 impl Runner for Client {
@@ -172,7 +173,7 @@ impl Client {
     fn resolve_locations<const N: usize>(
         &self,
         locations: [Location; N],
-    ) -> Result<[(Key<Provider>, VaultId, RecordId); N], VaultError<FatalProcedureError>> {
+    ) -> Result<[ResolvedLocation; N], VaultError<FatalProcedureError>> {
         let mut ids: Vec<(Key<Provider>, VaultId, RecordId)> = Vec::with_capacity(N);
 
         // FIXME: THIS SHOULD RETURN AN ACTUAL ERROR!

--- a/client/src/procedures/clientrunner.rs
+++ b/client/src/procedures/clientrunner.rs
@@ -31,17 +31,7 @@ impl Runner for Client {
     where
         F: FnOnce([Buffer<u8>; N]) -> Result<T, FatalProcedureError>,
     {
-        let mut ids: Vec<(Key<Provider>, VaultId, RecordId)> = Vec::with_capacity(N);
-
-        // FIXME: THIS SHOULD RETURN AN ACTUAL ERROR!
-        let keystore = self.keystore.try_write().map_err(|e| e.to_string()).expect("");
-
-        for location in locations {
-            let (vault_id, record_id) = location.resolve();
-            let key: Key<Provider> = keystore.get_key(vault_id).ok_or(VaultError::VaultNotFound(vault_id))?;
-            ids.push((key, vault_id, record_id));
-        }
-        let ids: [(Key<Provider>, VaultId, RecordId); N] = ids.try_into().expect("buffers did not have exactly len N");
+        let ids: [(Key<Provider>, VaultId, RecordId); N] = self.resolve_locations(locations)?;
 
         let mut ret = None;
         let execute_procedure = |guard: [Buffer<u8>; N]| {
@@ -60,60 +50,52 @@ impl Runner for Client {
         }
     }
 
-    fn exec_proc<F, T>(
+    fn exec_proc<F, T, const N: usize>(
         &self,
-        location0: &Location,
-        location1: &Location,
+        source_locations: [Location; N],
+        target_location: &Location,
         f: F,
     ) -> Result<T, VaultError<FatalProcedureError>>
     where
-        F: FnOnce(Buffer<u8>) -> Result<Products<T>, FatalProcedureError>,
+        F: FnOnce([Buffer<u8>; N]) -> Result<Products<T>, FatalProcedureError>,
     {
-        let (vid0, rid0) = location0.resolve();
-        let (vid1, rid1) = location1.resolve();
-        // FIXME: THIS SHOULD RETURN AN ACTUAL ERROR!
-        let mut keystore = self.keystore.try_write().map_err(|e| e.to_string()).expect("");
-
-        let key0 = keystore.take_key(vid0).ok_or(VaultError::VaultNotFound(vid0))?;
+        let sources: [(Key<Provider>, VaultId, RecordId); N] = self.resolve_locations(source_locations)?;
+        let (target_vid, target_rid) = target_location.resolve();
 
         let mut ret = None;
-        let execute_procedure = |guard: Buffer<u8>| {
-            let Products { output: plain, secret } = f(guard)?;
+        let execute_procedure = |guards: [Buffer<u8>; N]| {
+            let Products { output: plain, secret } = f(guards)?;
             ret = Some(plain);
             Ok(secret)
         };
 
-        let res;
         let random_hint = RecordHint::new(rand::bytestring(DEFAULT_RANDOM_HINT_SIZE)).unwrap();
-        if vid0 == vid1 {
-            // FIXME: THIS SHOULD RETURN AN ACTUAL ERROR!
-            let mut db = self.db.try_write().map_err(|e| e.to_string()).expect("");
 
-            res = db.exec_proc(&key0, vid0, rid0, &key0, vid1, rid1, random_hint, execute_procedure);
-        } else {
-            // FIXME: THIS SHOULD RETURN AN ACTUAL ERROR!
-            let mut db = self.db.try_write().map_err(|e| e.to_string()).expect("");
+        // FIXME: THIS SHOULD RETURN AN ACTUAL ERROR!
+        let mut db = self.db.try_write().map_err(|e| e.to_string()).expect("");
 
-            if !keystore.vault_exists(vid1) {
-                let key1 = keystore
-                    .create_key(vid1)
-                    .map_err(|_| VaultError::Procedure("Failed to generate key from keystore".to_string().into()))?;
-                db.init_vault(&key1, vid1);
-            }
+        // FIXME: THIS SHOULD RETURN AN ACTUAL ERROR!
+        let mut keystore = self.keystore.try_write().map_err(|e| e.to_string()).expect("");
 
-            let key1 = keystore.take_key(vid1).unwrap();
-            res = db.exec_proc(&key0, vid0, rid0, &key1, vid1, rid1, random_hint, execute_procedure);
-
-            // this should return an error
-            keystore
-                .get_or_insert_key(vid1, key1)
-                .expect("Inserting key into vault failed");
+        if !keystore.vault_exists(target_vid) {
+            let key1 = keystore
+                .create_key(target_vid)
+                .map_err(|_| VaultError::Procedure("failed to generate key from keystore".to_string().into()))?;
+            db.init_vault(&key1, target_vid);
         }
 
-        // this should be an errors
-        keystore
-            .get_or_insert_key(vid0, key0)
-            .expect("Inserting key into vault faileds");
+        let target_key = keystore
+            .get_key(target_vid)
+            .ok_or(VaultError::VaultNotFound(target_vid))?;
+
+        let res = db.exec_procedure(
+            sources,
+            &target_key,
+            target_vid,
+            target_rid,
+            random_hint,
+            execute_procedure,
+        );
 
         match res {
             Ok(()) => Ok(ret.unwrap()),
@@ -187,6 +169,24 @@ impl Runner for Client {
 }
 
 impl Client {
+    fn resolve_locations<const N: usize>(
+        &self,
+        locations: [Location; N],
+    ) -> Result<[(Key<Provider>, VaultId, RecordId); N], VaultError<FatalProcedureError>> {
+        let mut ids: Vec<(Key<Provider>, VaultId, RecordId)> = Vec::with_capacity(N);
+
+        // FIXME: THIS SHOULD RETURN AN ACTUAL ERROR!
+        let keystore = self.keystore.try_read().map_err(|e| e.to_string()).expect("");
+
+        for location in locations {
+            let (vault_id, record_id) = location.resolve();
+            let key: Key<Provider> = keystore.get_key(vault_id).ok_or(VaultError::VaultNotFound(vault_id))?;
+            ids.push((key, vault_id, record_id));
+        }
+        let ids: [(Key<Provider>, VaultId, RecordId); N] = ids.try_into().expect("buffers did not have exactly len N");
+        Ok(ids)
+    }
+
     pub fn get_guard<F, T>(&self, location: &Location, f: F) -> Result<T, VaultError<FatalProcedureError>>
     where
         F: FnOnce(Buffer<u8>) -> Result<T, FatalProcedureError>,

--- a/client/src/procedures/clientrunner.rs
+++ b/client/src/procedures/clientrunner.rs
@@ -186,7 +186,7 @@ impl Client {
             ids.push((key, vault_id, record_id));
         }
         let ids: [(Key<Provider>, VaultId, RecordId); N] =
-            <[_; N]>::try_from(ids).expect("buffers did not have exactly len N");
+            <[_; N]>::try_from(ids).expect("ids did not have exactly len N");
         Ok(ids)
     }
 

--- a/client/src/procedures/clientrunner.rs
+++ b/client/src/procedures/clientrunner.rs
@@ -170,6 +170,7 @@ impl Runner for Client {
 }
 
 impl Client {
+    /// Resolve the given locations into their corresponding vault keys and vault and record ids.
     fn resolve_locations<const N: usize>(
         &self,
         locations: [Location; N],
@@ -188,6 +189,7 @@ impl Client {
         Ok(ids)
     }
 
+    /// Applies `f` to the buffer from the given `location`.
     pub fn get_guard<F, T>(&self, location: &Location, f: F) -> Result<T, VaultError<FatalProcedureError>>
     where
         F: FnOnce(Buffer<u8>) -> Result<T, FatalProcedureError>,

--- a/client/src/procedures/primitives.rs
+++ b/client/src/procedures/primitives.rs
@@ -141,7 +141,7 @@ macro_rules! procedures {
             }
         )+
     };
-    { $Trait:ident $($n:literal)? => { $($Proc:ident),+ }} => {
+    { $Trait:ident => { $($Proc:ident),+ }} => {
         $(
             impl Procedure for $Proc {
                 type Output = <$Proc as $Trait>::Output;
@@ -161,7 +161,7 @@ macro_rules! procedures {
 }
 
 #[macro_export]
-macro_rules! procedures2 {
+macro_rules! generic_procedures {
     { $Trait:ident<$n:literal> => { $($Proc:ident),+ }} => {
         $(
             impl Procedure for $Proc {
@@ -174,14 +174,16 @@ macro_rules! procedures2 {
         )+
         procedures!(_ => { $($Proc),+ });
     };
+    { $($Trait:tt<$n:literal> => { $($Proc:ident),+ }),+} => {
+        $(
+            generic_procedures!($Trait<$n> => { $($Proc),+ } );
+        )+
+    };
 }
 
-procedures2! {
+generic_procedures! {
     // Stronghold procedures that implement the `UseSecret` trait.
-    UseSecret<1> => { PublicKey, Ed25519Sign, Hmac, AeadEncrypt, AeadDecrypt }
-}
-
-procedures2! {
+    UseSecret<1> => { PublicKey, Ed25519Sign, Hmac, AeadEncrypt, AeadDecrypt },
     // Stronghold procedures that implement the `DeriveSecret` trait.
     DeriveSecret<1> => { CopyRecord, Slip10Derive, X25519DiffieHellman, Hkdf, ConcatKdf }
 }

--- a/client/src/procedures/primitives.rs
+++ b/client/src/procedures/primitives.rs
@@ -181,11 +181,14 @@ procedures2! {
     UseSecret<1> => { PublicKey, Ed25519Sign, Hmac, AeadEncrypt, AeadDecrypt }
 }
 
+procedures2! {
+    // Stronghold procedures that implement the `DeriveSecret` trait.
+    DeriveSecret<1> => { CopyRecord, Slip10Derive, X25519DiffieHellman, Hkdf, ConcatKdf }
+}
+
 procedures! {
     // Stronghold procedures that implement the `GenerateSecret` trait.
     GenerateSecret => { WriteVault, BIP39Generate, BIP39Recover, Slip10Generate, GenerateKey, Pbkdf2Hmac },
-    // Stronghold procedures that implement the `DeriveSecret` trait.
-    DeriveSecret => { CopyRecord, Slip10Derive, X25519DiffieHellman, Hkdf, ConcatKdf },
     // Stronghold procedures that directly implement the `Procedure` trait.
     _ => { RevokeData, GarbageCollect }
 }
@@ -258,19 +261,19 @@ pub struct CopyRecord {
     pub target: Location,
 }
 
-impl DeriveSecret for CopyRecord {
+impl DeriveSecret<1> for CopyRecord {
     type Output = ();
 
-    fn derive(self, guard: Buffer<u8>) -> Result<Products<()>, FatalProcedureError> {
+    fn derive(self, guards: [Buffer<u8>; 1]) -> Result<Products<()>, FatalProcedureError> {
         let products = Products {
-            secret: (*guard.borrow()).to_vec(),
+            secret: (*guards[0].borrow()).to_vec(),
             output: (),
         };
         Ok(products)
     }
 
-    fn source(&self) -> &Location {
-        &self.source
+    fn source(&self) -> [Location; 1] {
+        [self.source.clone()]
     }
 
     fn target(&self) -> &Location {
@@ -428,16 +431,16 @@ pub struct Slip10Derive {
     pub output: Location,
 }
 
-impl DeriveSecret for Slip10Derive {
+impl DeriveSecret<1> for Slip10Derive {
     type Output = ChainCode;
 
-    fn derive(self, guard: Buffer<u8>) -> Result<Products<ChainCode>, FatalProcedureError> {
+    fn derive(self, guards: [Buffer<u8>; 1]) -> Result<Products<ChainCode>, FatalProcedureError> {
         let dk = match self.input {
             Slip10DeriveInput::Key(_) => {
-                slip10::Key::try_from(&*guard.borrow()).and_then(|parent| parent.derive(&self.chain))
+                slip10::Key::try_from(&*guards[0].borrow()).and_then(|parent| parent.derive(&self.chain))
             }
             Slip10DeriveInput::Seed(_) => {
-                slip10::Seed::from_bytes(&guard.borrow()).derive(slip10::Curve::Ed25519, &self.chain)
+                slip10::Seed::from_bytes(&guards[0].borrow()).derive(slip10::Curve::Ed25519, &self.chain)
             }
         }?;
         Ok(Products {
@@ -446,10 +449,10 @@ impl DeriveSecret for Slip10Derive {
         })
     }
 
-    fn source(&self) -> &Location {
+    fn source(&self) -> [Location; 1] {
         match &self.input {
-            Slip10DeriveInput::Key(loc) => loc,
-            Slip10DeriveInput::Seed(loc) => loc,
+            Slip10DeriveInput::Key(loc) => [loc.clone()],
+            Slip10DeriveInput::Seed(loc) => [loc.clone()],
         }
     }
 
@@ -522,14 +525,14 @@ pub struct PublicKey {
 impl UseSecret<1> for PublicKey {
     type Output = [u8; 32];
 
-    fn use_secret(self, guard: [Buffer<u8>; 1]) -> Result<Self::Output, FatalProcedureError> {
+    fn use_secret(self, guards: [Buffer<u8>; 1]) -> Result<Self::Output, FatalProcedureError> {
         match self.ty {
             KeyType::Ed25519 => {
-                let sk = ed25519_secret_key(guard[0].borrow())?;
+                let sk = ed25519_secret_key(guards[0].borrow())?;
                 Ok(sk.public_key().to_bytes())
             }
             KeyType::X25519 => {
-                let sk = x25519_secret_key(guard[0].borrow())?;
+                let sk = x25519_secret_key(guards[0].borrow())?;
                 Ok(sk.public_key().to_bytes())
             }
         }
@@ -554,8 +557,8 @@ pub struct Ed25519Sign {
 impl UseSecret<1> for Ed25519Sign {
     type Output = [u8; ed25519::SIGNATURE_LENGTH];
 
-    fn use_secret(self, guard: [Buffer<u8>; 1]) -> Result<Self::Output, FatalProcedureError> {
-        let sk = ed25519_secret_key(guard[0].borrow())?;
+    fn use_secret(self, guards: [Buffer<u8>; 1]) -> Result<Self::Output, FatalProcedureError> {
+        let sk = ed25519_secret_key(guards[0].borrow())?;
         let sig = sk.sign(&self.msg);
         Ok(sig.to_bytes())
     }
@@ -574,11 +577,11 @@ pub struct X25519DiffieHellman {
     pub shared_key: Location,
 }
 
-impl DeriveSecret for X25519DiffieHellman {
+impl DeriveSecret<1> for X25519DiffieHellman {
     type Output = ();
 
-    fn derive(self, guard: Buffer<u8>) -> Result<Products<()>, FatalProcedureError> {
-        let sk = x25519_secret_key(guard.borrow())?;
+    fn derive(self, guards: [Buffer<u8>; 1]) -> Result<Products<()>, FatalProcedureError> {
+        let sk = x25519_secret_key(guards[0].borrow())?;
         let public = x25519::PublicKey::from_bytes(self.public_key);
         let shared_key = sk.diffie_hellman(&public);
 
@@ -588,8 +591,8 @@ impl DeriveSecret for X25519DiffieHellman {
         })
     }
 
-    fn source(&self) -> &Location {
-        &self.private_key
+    fn source(&self) -> [Location; 1] {
+        [self.private_key.clone()]
     }
 
     fn target(&self) -> &Location {
@@ -609,21 +612,21 @@ pub struct Hmac {
 impl UseSecret<1> for Hmac {
     type Output = Vec<u8>;
 
-    fn use_secret(self, guard: [Buffer<u8>; 1]) -> Result<Self::Output, FatalProcedureError> {
+    fn use_secret(self, guards: [Buffer<u8>; 1]) -> Result<Self::Output, FatalProcedureError> {
         match self.hash_type {
             Sha2Hash::Sha256 => {
                 let mut mac = [0; SHA256_LEN];
-                HMAC_SHA256(&self.msg, &*guard[0].borrow(), &mut mac);
+                HMAC_SHA256(&self.msg, &*guards[0].borrow(), &mut mac);
                 Ok(mac.to_vec())
             }
             Sha2Hash::Sha384 => {
                 let mut mac = [0; SHA384_LEN];
-                HMAC_SHA384(&self.msg, &*guard[0].borrow(), &mut mac);
+                HMAC_SHA384(&self.msg, &*guards[0].borrow(), &mut mac);
                 Ok(mac.to_vec())
             }
             Sha2Hash::Sha512 => {
                 let mut mac = [0; SHA512_LEN];
-                HMAC_SHA512(&self.msg, &*guard[0].borrow(), &mut mac);
+                HMAC_SHA512(&self.msg, &*guards[0].borrow(), &mut mac);
                 Ok(mac.to_vec())
             }
         }
@@ -643,28 +646,28 @@ pub struct Hkdf {
     pub okm: Location,
 }
 
-impl DeriveSecret for Hkdf {
+impl DeriveSecret<1> for Hkdf {
     type Output = ();
 
-    fn derive(self, guard: Buffer<u8>) -> Result<Products<()>, FatalProcedureError> {
+    fn derive(self, guards: [Buffer<u8>; 1]) -> Result<Products<()>, FatalProcedureError> {
         let secret = match self.hash_type {
             Sha2Hash::Sha256 => {
                 let mut okm = [0; SHA256_LEN];
-                hkdf::Hkdf::<Sha256>::new(Some(&self.salt), &*guard.borrow())
+                hkdf::Hkdf::<Sha256>::new(Some(&self.salt), &*guards[0].borrow())
                     .expand(&self.label, &mut okm)
                     .expect("okm is the correct length");
                 okm.to_vec()
             }
             Sha2Hash::Sha384 => {
                 let mut okm = [0; SHA384_LEN];
-                hkdf::Hkdf::<Sha384>::new(Some(&self.salt), &*guard.borrow())
+                hkdf::Hkdf::<Sha384>::new(Some(&self.salt), &*guards[0].borrow())
                     .expand(&self.label, &mut okm)
                     .expect("okm is the correct length");
                 okm.to_vec()
             }
             Sha2Hash::Sha512 => {
                 let mut okm = [0; SHA512_LEN];
-                hkdf::Hkdf::<Sha512>::new(Some(&self.salt), &*guard.borrow())
+                hkdf::Hkdf::<Sha512>::new(Some(&self.salt), &*guards[0].borrow())
                     .expand(&self.label, &mut okm)
                     .expect("okm is the correct length");
                 okm.to_vec()
@@ -673,8 +676,8 @@ impl DeriveSecret for Hkdf {
         Ok(Products { secret, output: () })
     }
 
-    fn source(&self) -> &Location {
-        &self.ikm
+    fn source(&self) -> [Location; 1] {
+        [self.ikm.clone()]
     }
 
     fn target(&self) -> &Location {
@@ -742,7 +745,7 @@ pub struct AeadEncrypt {
 impl UseSecret<1> for AeadEncrypt {
     type Output = Vec<u8>;
 
-    fn use_secret(self, guard: [Buffer<u8>; 1]) -> Result<Self::Output, FatalProcedureError> {
+    fn use_secret(self, guards: [Buffer<u8>; 1]) -> Result<Self::Output, FatalProcedureError> {
         let mut ctx = vec![0; self.plaintext.len()];
 
         let f = match self.cipher {
@@ -754,7 +757,7 @@ impl UseSecret<1> for AeadEncrypt {
             AeadCipher::XChaCha20Poly1305 => Tag::<XChaCha20Poly1305>::default(),
         };
         f(
-            &*guard[0].borrow(),
+            &*guards[0].borrow(),
             &self.nonce,
             &self.associated_data,
             &self.plaintext,
@@ -790,7 +793,7 @@ pub struct AeadDecrypt {
 impl UseSecret<1> for AeadDecrypt {
     type Output = Vec<u8>;
 
-    fn use_secret(self, guard: [Buffer<u8>; 1]) -> Result<Self::Output, FatalProcedureError> {
+    fn use_secret(self, guards: [Buffer<u8>; 1]) -> Result<Self::Output, FatalProcedureError> {
         let mut ptx = vec![0; self.ciphertext.len()];
 
         let f = match self.cipher {
@@ -798,7 +801,7 @@ impl UseSecret<1> for AeadDecrypt {
             AeadCipher::XChaCha20Poly1305 => XChaCha20Poly1305::try_decrypt,
         };
         f(
-            &*guard[0].borrow(),
+            &*guards[0].borrow(),
             &self.nonce,
             &self.associated_data,
             &mut ptx,
@@ -842,14 +845,14 @@ pub struct ConcatKdf {
     pub output: Location,
 }
 
-impl DeriveSecret for ConcatKdf {
+impl DeriveSecret<1> for ConcatKdf {
     type Output = ();
 
-    fn derive(self, guard: Buffer<u8>) -> Result<Products<()>, FatalProcedureError> {
+    fn derive(self, guards: [Buffer<u8>; 1]) -> Result<Products<()>, FatalProcedureError> {
         let derived_key_material: Vec<u8> = match self.hash {
-            Sha2Hash::Sha256 => self.concat_kdf::<Sha256>(guard.borrow().as_ref()),
-            Sha2Hash::Sha384 => self.concat_kdf::<Sha384>(guard.borrow().as_ref()),
-            Sha2Hash::Sha512 => self.concat_kdf::<Sha512>(guard.borrow().as_ref()),
+            Sha2Hash::Sha256 => self.concat_kdf::<Sha256>(guards[0].borrow().as_ref()),
+            Sha2Hash::Sha384 => self.concat_kdf::<Sha384>(guards[0].borrow().as_ref()),
+            Sha2Hash::Sha512 => self.concat_kdf::<Sha512>(guards[0].borrow().as_ref()),
         }?;
 
         Ok(Products {
@@ -858,8 +861,8 @@ impl DeriveSecret for ConcatKdf {
         })
     }
 
-    fn source(&self) -> &Location {
-        &self.shared_secret
+    fn source(&self) -> [Location; 1] {
+        [self.shared_secret.clone()]
     }
 
     fn target(&self) -> &Location {

--- a/client/src/procedures/types.rs
+++ b/client/src/procedures/types.rs
@@ -12,6 +12,7 @@ use thiserror::Error as DeriveError;
 
 /// Bridge to the engine that is required for using / writing / revoking secrets in the vault.
 pub trait Runner {
+    /// Applies `f` to the buffers from the given `locations`.
     fn get_guards<F, T, const N: usize>(
         &self,
         locations: [Location; N],

--- a/client/src/tests/fresh.rs
+++ b/client/src/tests/fresh.rs
@@ -1,6 +1,7 @@
 // Copyright 2020-2022 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use crypto::keys::slip10::Chain;
 pub use stronghold_utils::{random::*, test_utils};
 
 use crate::Location;
@@ -8,4 +9,16 @@ use crate::Location;
 /// Generates a random [`Location`].
 pub fn location() -> Location {
     Location::generic(bytestring(4096), bytestring(4096))
+}
+
+/// Creates a random hd_path.
+pub fn hd_path() -> (String, Chain) {
+    let mut s = "m".to_string();
+    let mut is = vec![];
+    while coinflip() {
+        let i = random::<u32>() & 0x7fffff;
+        s.push_str(&format!("/{}'", i));
+        is.push(i);
+    }
+    (s, Chain::from_u32_hardened(is))
 }

--- a/client/src/tests/procedure_tests.rs
+++ b/client/src/tests/procedure_tests.rs
@@ -3,12 +3,20 @@
 
 use crate::{
     procedures::{
-        ConcatKdf, DeriveSecret, GenerateKey, GenerateSecret, KeyType, PublicKey, Sha2Hash, StrongholdProcedure,
-        WriteVault, X25519DiffieHellman,
+        AeadCipher, AeadDecrypt, AeadEncrypt, BIP39Generate, BIP39Recover, ConcatKdf, CopyRecord, DeriveSecret,
+        Ed25519Sign, GenerateKey, GenerateSecret, Hkdf, KeyType, MnemonicLanguage, PublicKey, Sha2Hash, Slip10Derive,
+        Slip10DeriveInput, Slip10Generate, StrongholdProcedure, WriteVault, X25519DiffieHellman,
     },
     tests::fresh,
     Client, Location, Stronghold,
 };
+
+use crypto::{
+    ciphers::{aes::Aes256Gcm, chacha::XChaCha20Poly1305},
+    keys::slip10::ChainCode,
+    signatures::ed25519,
+};
+use stronghold_utils::random;
 
 #[tokio::test]
 async fn usecase_diffie_hellman_concat_kdf() {
@@ -27,7 +35,7 @@ async fn usecase_diffie_hellman_concat_kdf() {
     };
 
     let pub_key_1: [u8; 32] = client
-        .execure_procedure_chained(vec![sk1.into(), pk1.into()])
+        .execute_procedure_chained(vec![sk1.into(), pk1.into()])
         .unwrap()
         .pop()
         .unwrap()
@@ -44,7 +52,7 @@ async fn usecase_diffie_hellman_concat_kdf() {
         private_key: sk2.target().clone(),
     };
     let pub_key_2: [u8; 32] = client
-        .execure_procedure_chained(vec![sk2.into(), pk2.into()])
+        .execute_procedure_chained(vec![sk2.into(), pk2.into()])
         .unwrap()
         .pop()
         .unwrap()
@@ -90,7 +98,7 @@ async fn usecase_diffie_hellman_concat_kdf() {
     let procedures: Vec<StrongholdProcedure> =
         vec![dh_1_2.into(), derived_1_2.into(), dh_2_1.into(), derived_2_1.into()];
 
-    client.execure_procedure_chained(procedures).unwrap();
+    client.execute_procedure_chained(procedures).unwrap();
 
     let derived_shared_secret_1_2 = client
         .vault(key_1_2.vault_path())
@@ -136,7 +144,7 @@ async fn concat_kdf_with_jwa() {
     };
 
     client
-        .execure_procedure_chained(vec![write.into(), kdf.into()])
+        .execute_procedure_chained(vec![write.into(), kdf.into()])
         .unwrap();
 
     let derived_key_material = client
@@ -148,4 +156,554 @@ async fn concat_kdf_with_jwa() {
         derived_key_material,
         vec![86, 170, 141, 234, 248, 35, 109, 32, 92, 34, 40, 205, 113, 167, 16, 26]
     );
+}
+
+// --- added tests from `dev`
+
+#[tokio::test]
+async fn usecase_ed25519() -> Result<(), Box<dyn std::error::Error>> {
+    // let (_cp, sh) = setup_stronghold().await?;
+
+    let stronghold: Stronghold = Stronghold::default();
+    let client: Client = stronghold.create_client(b"client_path").unwrap();
+
+    let vault_path = random::bytestring(1024);
+    let seed = Location::generic(vault_path.clone(), random::bytestring(1024));
+
+    if fresh::coinflip() {
+        let size_bytes = if fresh::coinflip() {
+            Some(fresh::usize(1024))
+        } else {
+            None
+        };
+        let slip10_generate = Slip10Generate {
+            size_bytes,
+            output: seed.clone(),
+        };
+
+        assert!(client.execute_procedure(slip10_generate).is_ok());
+    } else {
+        let bip32_gen = BIP39Generate {
+            passphrase: random::passphrase(),
+            output: seed.clone(),
+            language: MnemonicLanguage::English,
+        };
+        assert!(client.execute_procedure(bip32_gen).is_ok());
+    }
+
+    let (_path, chain) = fresh::hd_path();
+    let key = Location::generic(vault_path, random::bytestring(1024));
+
+    let slip10_derive = Slip10Derive {
+        chain,
+        input: Slip10DeriveInput::Seed(seed),
+        output: key.clone(),
+    };
+    assert!(client.execute_procedure(slip10_derive).is_ok());
+
+    let ed25519_pk = PublicKey {
+        private_key: key.clone(),
+        ty: KeyType::Ed25519,
+    };
+    let pk: [u8; ed25519::PUBLIC_KEY_LENGTH] = client.execute_procedure(ed25519_pk).unwrap();
+
+    let msg = fresh::bytestring(4096);
+
+    let ed25519_sign = Ed25519Sign {
+        private_key: key,
+        msg: msg.clone(),
+    };
+    let sig: [u8; ed25519::SIGNATURE_LENGTH] = client.execute_procedure(ed25519_sign).unwrap();
+
+    let pk = ed25519::PublicKey::try_from_bytes(pk).unwrap();
+    let sig = ed25519::Signature::from_bytes(sig);
+    assert!(pk.verify(&sig, &msg));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn usecase_slip10derive_intermediate_keys() -> Result<(), Box<dyn std::error::Error>> {
+    let stronghold: Stronghold = Stronghold::default();
+    let client: Client = stronghold.create_client(b"client_path").unwrap();
+
+    let seed = fresh::location();
+
+    let slip10_generate = Slip10Generate {
+        output: seed.clone(),
+        size_bytes: None,
+    };
+    assert!(client.execute_procedure(slip10_generate).is_ok());
+
+    let (_path, chain0) = fresh::hd_path();
+    let (_path, chain1) = fresh::hd_path();
+
+    let cc0: ChainCode = {
+        let slip10_derive = Slip10Derive {
+            input: Slip10DeriveInput::Seed(seed.clone()),
+            chain: chain0.join(&chain1),
+            output: fresh::location(),
+        };
+
+        client.execute_procedure(slip10_derive).unwrap()
+    };
+
+    let cc1: ChainCode = {
+        let intermediate = fresh::location();
+
+        let slip10_derive_intermediate = Slip10Derive {
+            input: Slip10DeriveInput::Seed(seed),
+            chain: chain0,
+            output: intermediate.clone(),
+        };
+
+        assert!(client.execute_procedure(slip10_derive_intermediate).is_ok());
+
+        let slip10_derive_child = Slip10Derive {
+            input: Slip10DeriveInput::Key(intermediate),
+            chain: chain1,
+            output: fresh::location(),
+        };
+
+        client.execute_procedure(slip10_derive_child).unwrap()
+    };
+
+    assert_eq!(cc0, cc1);
+    Ok(())
+}
+
+#[tokio::test]
+async fn usecase_ed25519_as_complex() -> Result<(), Box<dyn std::error::Error>> {
+    let stronghold: Stronghold = Stronghold::default();
+    let client: Client = stronghold.create_client(b"client_path").unwrap();
+
+    let msg = fresh::bytestring(4096);
+
+    let generate = Slip10Generate {
+        size_bytes: None,
+        output: fresh::location(),
+    };
+    let derive = Slip10Derive {
+        input: Slip10DeriveInput::Seed(generate.target().clone()),
+        output: fresh::location(),
+        chain: fresh::hd_path().1,
+    };
+    let get_pk = PublicKey {
+        ty: KeyType::Ed25519,
+        private_key: derive.target().clone(),
+    };
+    let sign = Ed25519Sign {
+        msg: msg.clone(),
+        private_key: derive.target().clone(),
+    };
+
+    let procedures = vec![generate.into(), derive.into(), get_pk.into(), sign.into()];
+    let output = client.execute_procedure_chained(procedures).unwrap();
+
+    // Skip output from Slip10Generate and Slip10Derive; ?
+    // output.next();
+    // output.next();
+
+    let mut pub_key_vec: [u8; ed25519::PUBLIC_KEY_LENGTH] = [0u8; ed25519::PUBLIC_KEY_LENGTH];
+    let proc_output: Vec<u8> = output[2].clone().into();
+    pub_key_vec.clone_from_slice(proc_output.as_slice());
+
+    let pk = ed25519::PublicKey::try_from_bytes(pub_key_vec).unwrap();
+
+    let mut sig_vec: [u8; ed25519::SIGNATURE_LENGTH] = [0u8; ed25519::SIGNATURE_LENGTH];
+    let sig_output: Vec<u8> = output[3].clone().into();
+    sig_vec.clone_from_slice(sig_output.as_slice());
+
+    let sig = ed25519::Signature::from_bytes(sig_vec);
+    assert!(pk.verify(&sig, &msg));
+    Ok(())
+}
+
+#[tokio::test]
+async fn usecase_collection_of_data() -> Result<(), Box<dyn std::error::Error>> {
+    use crypto::{keys::slip10, utils::rand::fill};
+
+    let stronghold: Stronghold = Stronghold::default();
+    let client: Client = stronghold.create_client(b"client_path").unwrap();
+
+    let key: Vec<u8> = {
+        let size_bytes = fresh::coinflip().then(|| fresh::usize(1024)).unwrap_or(64);
+        let mut seed = vec![0u8; size_bytes];
+
+        assert!(fill(&mut seed).is_ok(), "Failed to fill seed with random data");
+
+        let dk = slip10::Seed::from_bytes(&seed)
+            .derive(slip10::Curve::Ed25519, &fresh::hd_path().1)
+            .unwrap();
+        dk.into()
+    };
+
+    // write seed to vault
+    let key_location = fresh::location();
+    let vault_location = key_location.vault_path();
+
+    let vault = client.vault(vault_location);
+
+    assert!(vault.write_secret(key_location.clone(), key.clone()).is_ok());
+
+    // test sign and hash
+
+    let messages = vec![Vec::from("msg1"), Vec::from("msg2"), Vec::from("msg3")];
+
+    let expected = messages
+        .clone()
+        .into_iter()
+        .map(|msg| {
+            // Sign message
+            let mut raw = key.clone();
+            raw.truncate(32);
+            let mut bs = [0; 32];
+            bs.copy_from_slice(&raw);
+            let sk = ed25519::SecretKey::from_bytes(bs);
+            sk.sign(&msg).to_bytes()
+        })
+        .filter(|bytes| bytes.iter().any(|b| b <= &10u8))
+        .fold(Vec::new(), |mut acc, curr| {
+            acc.extend_from_slice(&curr);
+            acc
+        });
+
+    // test procedure
+    let procedures = messages
+        .into_iter()
+        .map(|msg| {
+            Ed25519Sign {
+                msg,
+                private_key: key_location.clone(),
+            }
+            .into()
+        })
+        .collect();
+    let output = client.execute_procedure_chained(procedures).unwrap();
+    let res = output
+        .into_iter()
+        .map(|v| v.into())
+        .filter(|bytes: &Vec<u8>| bytes.iter().any(|b| b <= &10u8))
+        .fold(Vec::new(), |mut acc, curr| {
+            acc.extend_from_slice(&curr);
+            acc
+        });
+    assert_eq!(res, expected);
+    Ok(())
+}
+
+async fn test_aead(
+    // sh: &mut Stronghold,
+    client: &Client,
+    key_location: Location,
+    key: &[u8],
+    cipher: AeadCipher,
+) -> Result<(), Box<dyn std::error::Error>> {
+    use crypto::ciphers::traits::*;
+
+    let test_plaintext = random::bytestring(4096);
+    let test_associated_data = random::bytestring(4096);
+    let nonce_len = match cipher {
+        AeadCipher::Aes256Gcm => Aes256Gcm::NONCE_LENGTH,
+        AeadCipher::XChaCha20Poly1305 => XChaCha20Poly1305::NONCE_LENGTH,
+    };
+    let mut test_nonce = Vec::with_capacity(nonce_len);
+    for _ in 0..test_nonce.capacity() {
+        test_nonce.push(random::random())
+    }
+
+    // test encryption
+    let aead = AeadEncrypt {
+        cipher,
+        key: key_location.clone(),
+        plaintext: test_plaintext.clone(),
+        associated_data: test_associated_data.clone(),
+        nonce: test_nonce.clone(),
+    };
+
+    let tag_len = match cipher {
+        AeadCipher::Aes256Gcm => Aes256Gcm::TAG_LENGTH,
+        AeadCipher::XChaCha20Poly1305 => XChaCha20Poly1305::TAG_LENGTH,
+    };
+    let mut output = client.execute_procedure(aead).unwrap();
+    let out_tag: Vec<u8> = output.drain(..tag_len).collect();
+    let out_ciphertext = output;
+
+    let mut expected_ctx = vec![0; test_plaintext.len()];
+    let mut expected_tag = vec![0; tag_len];
+
+    let f = match cipher {
+        AeadCipher::Aes256Gcm => Aes256Gcm::try_encrypt,
+        AeadCipher::XChaCha20Poly1305 => XChaCha20Poly1305::try_encrypt,
+    };
+    f(
+        key,
+        &test_nonce,
+        &test_associated_data,
+        &test_plaintext,
+        &mut expected_ctx,
+        &mut expected_tag,
+    )
+    .unwrap_or_else(|e| panic!("Unexpected error: {}", e));
+
+    assert_eq!(expected_ctx, out_ciphertext);
+    assert_eq!(expected_tag, out_tag);
+
+    // test decryption
+    let adad = AeadDecrypt {
+        cipher,
+        key: key_location,
+        ciphertext: out_ciphertext.clone(),
+        associated_data: test_associated_data.clone(),
+        tag: out_tag.clone(),
+        nonce: test_nonce.to_vec(),
+    };
+
+    let out_plaintext = client.execute_procedure(adad);
+
+    let mut expected_ptx = vec![0; out_ciphertext.len()];
+
+    let f = match cipher {
+        AeadCipher::Aes256Gcm => Aes256Gcm::try_decrypt,
+        AeadCipher::XChaCha20Poly1305 => XChaCha20Poly1305::try_decrypt,
+    };
+    f(
+        key,
+        &test_nonce,
+        &test_associated_data,
+        &mut expected_ptx,
+        &out_ciphertext,
+        &out_tag,
+    )
+    .unwrap_or_else(|e| panic!("Unexpected error: {}", e));
+
+    assert_eq!(expected_ptx, out_plaintext.clone().unwrap());
+    assert_eq!(out_plaintext.unwrap(), test_plaintext);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn usecase_aead() -> Result<(), Box<dyn std::error::Error>> {
+    let stronghold: Stronghold = Stronghold::default();
+    let client: Client = stronghold.create_client(b"client_path").unwrap();
+
+    // Init key
+    let key_location = fresh::location();
+    let key = ed25519::SecretKey::generate().unwrap().to_bytes();
+
+    let vault_path = key_location.vault_path();
+
+    let vault = client.vault(vault_path);
+    assert!(vault.write_secret(key_location.clone(), key.to_vec()).is_ok());
+
+    test_aead(&client, key_location.clone(), &key, AeadCipher::Aes256Gcm).await?;
+    test_aead(&client, key_location.clone(), &key, AeadCipher::XChaCha20Poly1305).await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn usecase_diffie_hellman() -> Result<(), Box<dyn std::error::Error>> {
+    let stronghold: Stronghold = Stronghold::default();
+    let client: Client = stronghold.create_client(b"client_path").unwrap();
+
+    let sk1_location = fresh::location();
+    let sk1 = GenerateKey {
+        ty: KeyType::X25519,
+        output: sk1_location.clone(),
+        // hint: fresh::record_hint(),
+    };
+    let pk1 = PublicKey {
+        ty: KeyType::X25519,
+        private_key: sk1.target().clone(),
+    };
+    let pub_key_1: [u8; 32] = client
+        .execute_procedure_chained(vec![sk1.into(), pk1.into()])
+        .unwrap()
+        .pop()
+        .unwrap()
+        .try_into()
+        .unwrap();
+
+    let sk2_location = fresh::location();
+    let sk2 = GenerateKey {
+        ty: KeyType::X25519,
+        output: sk2_location.clone(),
+        // hint: fresh::record_hint(),
+    };
+    let pk2 = PublicKey {
+        ty: KeyType::X25519,
+        private_key: sk2.target().clone(),
+    };
+    let pub_key_2: [u8; 32] = client
+        .execute_procedure_chained(vec![sk2.into(), pk2.into()])
+        .unwrap()
+        .pop()
+        .unwrap()
+        .try_into()
+        .unwrap();
+
+    let mut salt = vec![];
+    salt.extend_from_slice(&pub_key_1);
+    salt.extend_from_slice(&pub_key_2);
+    let label = random::bytestring(1024);
+
+    let key_1_2 = fresh::location();
+    let dh_1_2 = X25519DiffieHellman {
+        private_key: sk1_location,
+        public_key: pub_key_2,
+        shared_key: fresh::location(),
+        // hint: fresh::record_hint(),
+    };
+    let derived_1_2 = Hkdf {
+        hash_type: Sha2Hash::Sha256,
+        salt: salt.clone(),
+        label: label.clone(),
+        ikm: dh_1_2.target().clone(),
+        okm: key_1_2,
+    };
+
+    let key_2_1 = fresh::location();
+    let dh_2_1 = X25519DiffieHellman {
+        private_key: sk2_location,
+        public_key: pub_key_1,
+        shared_key: fresh::location(),
+        // hint: fresh::record_hint(),
+    };
+    let derived_2_1 = Hkdf {
+        hash_type: Sha2Hash::Sha256,
+        salt: salt.clone(),
+        label,
+        ikm: dh_2_1.target().clone(),
+        okm: key_2_1,
+    };
+
+    let procedures = vec![dh_1_2.into(), derived_1_2.into(), dh_2_1.into(), derived_2_1.into()];
+
+    assert!(client.execute_procedure_chained(procedures).is_ok());
+
+    // let hashed_shared_1_2 = client.read_secret(cp.clone(), key_1_2).await?.unwrap();
+    // let hashed_shared_2_1 = client.read_secret(cp, key_2_1).await?.unwrap();
+
+    // assert_eq!(hashed_shared_1_2, hashed_shared_2_1);
+    Ok(())
+}
+
+#[tokio::test]
+async fn usecase_recover_bip39() -> Result<(), Box<dyn std::error::Error>> {
+    let stronghold: Stronghold = Stronghold::default();
+    let client: Client = stronghold.create_client(b"client_path").unwrap();
+
+    let passphrase = random::string(4096);
+    let (_path, chain) = fresh::hd_path();
+    let message = random::bytestring(4095);
+
+    let generate_bip39 = BIP39Generate {
+        language: MnemonicLanguage::English,
+        passphrase: Some(passphrase.clone()),
+        output: fresh::location(),
+    };
+    let derive_from_original = Slip10Derive {
+        input: Slip10DeriveInput::Seed(generate_bip39.target().clone()),
+        chain: chain.clone(),
+        output: fresh::location(),
+    };
+    let sign_from_original = Ed25519Sign {
+        msg: message.clone(),
+        private_key: derive_from_original.target().clone(),
+    };
+
+    let procedures = vec![
+        generate_bip39.into(),
+        derive_from_original.into(),
+        sign_from_original.into(),
+    ];
+    let output = client.execute_procedure_chained(procedures).unwrap();
+
+    let mnemonic = output[0].clone().try_into().unwrap(); // ?
+    let signed_with_original = output[2].clone();
+
+    let recover_bip39 = BIP39Recover {
+        mnemonic,
+        passphrase: Some(passphrase),
+        output: fresh::location(),
+    };
+
+    let derive_from_recovered = Slip10Derive {
+        input: Slip10DeriveInput::Seed(recover_bip39.target().clone()),
+        chain,
+        output: fresh::location(),
+    };
+    let sign_from_recovered = Ed25519Sign {
+        msg: message,
+        private_key: derive_from_recovered.target().clone(),
+    };
+
+    let procedures = vec![
+        recover_bip39.into(),
+        derive_from_recovered.into(),
+        sign_from_recovered.into(),
+    ];
+    let output = client.execute_procedure_chained(procedures).unwrap();
+    let signed_with_recovered = output[2].clone();
+
+    assert_eq!(signed_with_original, signed_with_recovered);
+    Ok(())
+}
+
+#[tokio::test]
+async fn usecase_move_record() -> Result<(), Box<dyn std::error::Error>> {
+    let stronghold: Stronghold = Stronghold::default();
+    let client: Client = stronghold.create_client(b"client_path").unwrap();
+
+    let test_msg = random::bytestring(4096);
+
+    let first_location = fresh::location();
+    let generate_key = GenerateKey {
+        ty: KeyType::Ed25519,
+        output: first_location.clone(),
+    };
+    let pub_key = PublicKey {
+        ty: KeyType::Ed25519,
+        private_key: generate_key.target().clone(),
+    };
+    let sign_message = Ed25519Sign {
+        msg: test_msg.clone(),
+        private_key: generate_key.target().clone(),
+    };
+    let procedures = vec![generate_key.into(), pub_key.into(), sign_message.into()];
+    let output = client.execute_procedure_chained(procedures).unwrap();
+
+    // output.next().unwrap();
+
+    let public_key = output[1].clone();
+    let mut first: Vec<u8> = public_key.into();
+    let second: Vec<u8> = first.drain(first.len() % 2..).collect();
+
+    // signed message used for validation further in the test
+    let signed_with_original: Vec<u8> = output[2].clone().into();
+
+    // pub-key used to derive the new location for the private key
+
+    // Copy record to new location derived from the pub-key
+    let new_location = Location::generic(first, second);
+    let copy_record = CopyRecord {
+        source: first_location.clone(),
+        target: new_location.clone(),
+    };
+    assert!(client.execute_procedure(copy_record).is_ok());
+
+    // Remove record from old location
+    let vault = client.vault(first_location.vault_path());
+    assert!(vault.delete_secret(first_location.record_path()).is_ok());
+
+    // Validate by signing the message from the new location
+    let sign_message = Ed25519Sign {
+        msg: test_msg,
+        private_key: new_location,
+    };
+    let signed_with_moved: Vec<u8> = client.execute_procedure(sign_message).unwrap().into();
+    assert_eq!(signed_with_original, signed_with_moved);
+
+    Ok(())
 }

--- a/client/src/types/client.rs
+++ b/client/src/types/client.rs
@@ -228,7 +228,7 @@ impl Client {
     where
         P: Procedure + Into<StrongholdProcedure>,
     {
-        let res = self.execure_procedure_chained(vec![procedure.into()]);
+        let res = self.execute_procedure_chained(vec![procedure.into()]);
         let mapped = res.map(|mut vec| vec.pop().unwrap().try_into().ok().unwrap())?;
         Ok(mapped)
     }
@@ -236,7 +236,7 @@ impl Client {
     /// Executes a list of cryptographic [`crate::procedures::Procedure`]s sequentially and returns a collected output
     ///
     /// # Example
-    pub fn execure_procedure_chained(
+    pub fn execute_procedure_chained(
         &self,
         procedures: Vec<StrongholdProcedure>,
     ) -> core::result::Result<Vec<ProcedureOutput>, ProcedureError> {

--- a/client/src/types/stronghold.rs
+++ b/client/src/types/stronghold.rs
@@ -412,7 +412,7 @@ impl Stronghold {
             }
 
             network_old::ClientRequest::Procedures { procedures } => {
-                let result = client.execure_procedure_chained(procedures);
+                let result = client.execute_procedure_chained(procedures);
                 assert!(result.is_ok());
                 assert!(tx.send(StrongholdNetworkResult::Proc(result)).is_ok());
 

--- a/client/src/types/vault.rs
+++ b/client/src/types/vault.rs
@@ -94,6 +94,3 @@ impl ClientVault {
         Ok(data)
     }
 }
-
-// #[cfg(feature = "p2p")]
-// impl ClientVault {}

--- a/engine/src/vault/view.rs
+++ b/engine/src/vault/view.rs
@@ -148,7 +148,7 @@ impl<P: BoxProvider> DbView<P> {
             buffers.push(guard);
         }
 
-        let buffers: [Buffer<u8>; N] = buffers.try_into().expect("buffers did not have exactly len N");
+        let buffers: [Buffer<u8>; N] = <[_; N]>::try_from(buffers).expect("buffers did not have exactly len N");
 
         Ok(buffers)
     }

--- a/engine/src/vault/view.rs
+++ b/engine/src/vault/view.rs
@@ -131,6 +131,27 @@ impl<P: BoxProvider> DbView<P> {
         Ok(blob_id)
     }
 
+    fn get_buffers<E, const N: usize>(
+        &self,
+        ids: [(Key<P>, VaultId, RecordId); N],
+    ) -> Result<[Buffer<u8>; N], VaultError<P::Error, E>>
+    where
+        E: Debug,
+    {
+        let mut buffers: Vec<Buffer<u8>> = Vec::with_capacity(N);
+
+        for (key, vid, rid) in ids {
+            let vault = self.vaults.get(&vid).ok_or(VaultError::VaultNotFound(vid))?;
+            let guard = vault.get_guard(&key, rid.0).map_err(VaultError::Record)?;
+
+            buffers.push(guard);
+        }
+
+        let buffers: [Buffer<u8>; N] = buffers.try_into().expect("buffers did not have exactly len N");
+
+        Ok(buffers)
+    }
+
     /// Get access the decrypted [`Buffer`] of the specified [`Record`].
     pub fn get_guard<E, F>(
         &self,
@@ -157,45 +178,32 @@ impl<P: BoxProvider> DbView<P> {
         F: FnOnce([Buffer<u8>; N]) -> Result<(), E>,
         E: Debug,
     {
-        let mut buffers: Vec<Buffer<u8>> = Vec::with_capacity(N);
-
-        for (key, vid, rid) in ids {
-            let vault = self.vaults.get(&vid).ok_or(VaultError::VaultNotFound(vid))?;
-            let guard = vault.get_guard(&key, rid.0).map_err(VaultError::Record)?;
-
-            buffers.push(guard);
-        }
-
-        let buffers: [Buffer<u8>; N] = buffers.try_into().expect("buffers did not have exactly len N");
-
+        let buffers: [Buffer<u8>; N] = self.get_buffers(ids)?;
         f(buffers).map_err(VaultError::Procedure)
     }
 
-    /// Access the decrypted [`Buffer`] of the specified [`Record`] and place the return value into the second
-    /// specified [`Record`]
+    /// Access the decrypted [`Buffer`]s of the specified [`Record`]s and place the return value
+    /// into the target [`Record`].
     #[allow(clippy::too_many_arguments)]
-    pub fn exec_proc<E, F>(
+    pub fn exec_procedure<E, F, const N: usize>(
         &mut self,
-        key0: &Key<P>,
-        vid0: VaultId,
-        rid0: RecordId,
-        key1: &Key<P>,
-        vid1: VaultId,
-        rid1: RecordId,
+        sources: [(Key<P>, VaultId, RecordId); N],
+        target_key: &Key<P>,
+        target_vid: VaultId,
+        target_rid: RecordId,
         hint: RecordHint,
         f: F,
     ) -> Result<(), VaultError<P::Error, E>>
     where
-        F: FnOnce(Buffer<u8>) -> Result<Vec<u8>, E>,
+        F: FnOnce([Buffer<u8>; N]) -> Result<Vec<u8>, E>,
         E: Debug,
     {
-        let vault = self.vaults.get_mut(&vid0).ok_or(VaultError::VaultNotFound(vid0))?;
+        let buffers: [Buffer<u8>; N] = self.get_buffers(sources)?;
 
-        let guard = vault.get_guard(key0, rid0.0).map_err(VaultError::Record)?;
+        let data: Vec<u8> = f(buffers).map_err(VaultError::Procedure)?;
 
-        let data = f(guard).map_err(VaultError::Procedure)?;
-
-        self.write(key1, vid1, rid1, &data, hint).map_err(VaultError::Record)
+        self.write(target_key, target_vid, target_rid, &data, hint)
+            .map_err(VaultError::Record)
     }
 
     /// Add a revocation transaction to the [`Record`]

--- a/engine/src/vault/view.rs
+++ b/engine/src/vault/view.rs
@@ -131,6 +131,7 @@ impl<P: BoxProvider> DbView<P> {
         Ok(blob_id)
     }
 
+    /// Get the buffers for the given records, using the provided key for access.
     fn get_buffers<E, const N: usize>(
         &self,
         ids: [(Key<P>, VaultId, RecordId); N],
@@ -184,7 +185,6 @@ impl<P: BoxProvider> DbView<P> {
 
     /// Access the decrypted [`Buffer`]s of the specified [`Record`]s and place the return value
     /// into the target [`Record`].
-    #[allow(clippy::too_many_arguments)]
     pub fn exec_procedure<E, F, const N: usize>(
         &mut self,
         sources: [(Key<P>, VaultId, RecordId); N],

--- a/engine/tests/vault.rs
+++ b/engine/tests/vault.rs
@@ -106,16 +106,14 @@ fn test_vaults() {
         .unwrap();
 
     // execute a procedure and put the result into a new record
-    view.exec_proc::<Infallible, _>(
-        &key0,
-        vid0,
-        rid0,
+    view.exec_procedure::<Infallible, _, 1>(
+        [(key0.clone(), vid0, rid0)],
         &key1,
         vid1,
         rid1,
         RecordHint::new(b"tester").unwrap(),
-        |guard| {
-            let data = guard.borrow();
+        |guards| {
+            let data = guards[0].borrow();
             let mut ret = Vec::new();
 
             ret.extend(data.iter());

--- a/utils/src/random.rs
+++ b/utils/src/random.rs
@@ -42,3 +42,8 @@ pub fn coinflip() -> bool {
 pub fn usize(upper_bound: usize) -> usize {
     random::<usize>() % upper_bound
 }
+
+/// Returns a random passphrase as String
+pub fn passphrase() -> Option<String> {
+    Some(string(1024))
+}


### PR DESCRIPTION
# Description of change

Allow procedures to use multiple secrets, which is needed for #338 and #339.

A careful review of the synchronization code (when things are locked, and in what manner (write, read)) would be appreciated. 

A downside of using const generics is that one cannot easily convert `[T;N]` into `[X;N]`, because when using iterators, one loses the size information and so we cannot easily `collect` into such a new array. The workaround is to collect into a `Vec<X>` and use [`<[_; N]>::try_from(vec).expect("...")`](https://doc.rust-lang.org/std/primitive.array.html#method.try_from-4) for conversion, which [does not appear to clone buffers unnecessarily](https://doc.rust-lang.org/src/alloc/vec/mod.rs.html#3052).

Open Question: Should we re-add more of the procedure tests that once existed? Currently, the state of procedure testing is very minimal, unless I've missed them somewhere?

## Links to any relevant issues

n/a

## Type of change

Choose a type of change, and delete any options that are not relevant.

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested

#355 uses `UseSecret<2>` and works as intended.

Existing tests for modified procedures pass locally.

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
