### PR TITLE
Expose procedures for AES Key Wrap

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -20,7 +20,7 @@ std                     = []
 thiserror               = { version = "1.0.30" }
 zeroize                 = { version = "1.4.3", features = ["zeroize_derive"] }
 serde                   = { version = "1.0",   features = [ "derive" ] }
-iota-crypto             = { version = "0.8.0", features = [ "aes", "random", "ed25519", "sha", "hmac", "bip39-en", "bip39-jp", "slip10", "chacha", "x25519" ] }
+iota-crypto             = { version = "0.8.0", features = [ "aes", "aes-kw", "random", "ed25519", "sha", "hmac", "bip39-en", "bip39-jp", "slip10", "chacha", "x25519" ] }
 hkdf                    = { version = "0.11" }
 bincode                 = { version = "1.3" }
 pin-project             = { version = "1.0.10", optional = true }

--- a/client/src/procedures.rs
+++ b/client/src/procedures.rs
@@ -8,9 +8,10 @@ mod types;
 pub use clientrunner::*;
 
 pub use primitives::{
-    AeadCipher, AeadDecrypt, AeadEncrypt, BIP39Generate, BIP39Recover, Chain, ChainCode, ConcatKdf, CopyRecord,
-    Ed25519Sign, GarbageCollect, GenerateKey, Hkdf, Hmac, KeyType, MnemonicLanguage, Pbkdf2Hmac, PublicKey, RevokeData,
-    Sha2Hash, Slip10Derive, Slip10DeriveInput, Slip10Generate, StrongholdProcedure, WriteVault, X25519DiffieHellman,
+    AeadCipher, AeadDecrypt, AeadEncrypt, AesKeyWrapCipher, AesKeyWrapEncrypt, BIP39Generate, BIP39Recover, Chain,
+    ChainCode, ConcatKdf, CopyRecord, Ed25519Sign, GarbageCollect, GenerateKey, Hkdf, Hmac, KeyType, MnemonicLanguage,
+    Pbkdf2Hmac, PublicKey, RevokeData, Sha2Hash, Slip10Derive, Slip10DeriveInput, Slip10Generate, StrongholdProcedure,
+    WriteVault, X25519DiffieHellman,
 };
 pub use types::{
     DeriveSecret, FatalProcedureError, GenerateSecret, Procedure, ProcedureError, ProcedureOutput, UseSecret,

--- a/client/src/procedures.rs
+++ b/client/src/procedures.rs
@@ -8,10 +8,10 @@ mod types;
 pub use clientrunner::*;
 
 pub use primitives::{
-    AeadCipher, AeadDecrypt, AeadEncrypt, AesKeyWrapCipher, AesKeyWrapEncrypt, BIP39Generate, BIP39Recover, Chain,
-    ChainCode, ConcatKdf, CopyRecord, Ed25519Sign, GarbageCollect, GenerateKey, Hkdf, Hmac, KeyType, MnemonicLanguage,
-    Pbkdf2Hmac, PublicKey, RevokeData, Sha2Hash, Slip10Derive, Slip10DeriveInput, Slip10Generate, StrongholdProcedure,
-    WriteVault, X25519DiffieHellman,
+    AeadCipher, AeadDecrypt, AeadEncrypt, AesKeyWrapCipher, AesKeyWrapDecrypt, AesKeyWrapEncrypt, BIP39Generate,
+    BIP39Recover, Chain, ChainCode, ConcatKdf, CopyRecord, Ed25519Sign, GarbageCollect, GenerateKey, Hkdf, Hmac,
+    KeyType, MnemonicLanguage, Pbkdf2Hmac, PublicKey, RevokeData, Sha2Hash, Slip10Derive, Slip10DeriveInput,
+    Slip10Generate, StrongholdProcedure, WriteVault, X25519DiffieHellman,
 };
 pub use types::{
     DeriveSecret, FatalProcedureError, GenerateSecret, Procedure, ProcedureError, ProcedureOutput, UseSecret,

--- a/client/src/procedures/primitives.rs
+++ b/client/src/procedures/primitives.rs
@@ -53,6 +53,7 @@ pub enum StrongholdProcedure {
     Hkdf(Hkdf),
     ConcatKdf(ConcatKdf),
     AesKeyWrapEncrypt(AesKeyWrapEncrypt),
+    AesKeyWrapDecrypt(AesKeyWrapDecrypt),
     Pbkdf2Hmac(Pbkdf2Hmac),
     AeadEncrypt(AeadEncrypt),
     AeadDecrypt(AeadDecrypt),
@@ -80,6 +81,7 @@ impl Procedure for StrongholdProcedure {
             Hkdf(proc) => proc.execute(runner).map(|o| o.into()),
             ConcatKdf(proc) => proc.execute(runner).map(|o| o.into()),
             AesKeyWrapEncrypt(proc) => proc.execute(runner).map(|o| o.into()),
+            AesKeyWrapDecrypt(proc) => proc.execute(runner).map(|o| o.into()),
             Pbkdf2Hmac(proc) => proc.execute(runner).map(|o| o.into()),
             AeadEncrypt(proc) => proc.execute(runner).map(|o| o.into()),
             AeadDecrypt(proc) => proc.execute(runner).map(|o| o.into()),
@@ -188,7 +190,7 @@ generic_procedures! {
     UseSecret<1> => { PublicKey, Ed25519Sign, Hmac, AeadEncrypt, AeadDecrypt },
     UseSecret<2> => { AesKeyWrapEncrypt },
     // Stronghold procedures that implement the `DeriveSecret` trait.
-    DeriveSecret<1> => { CopyRecord, Slip10Derive, X25519DiffieHellman, Hkdf, ConcatKdf }
+    DeriveSecret<1> => { CopyRecord, Slip10Derive, X25519DiffieHellman, Hkdf, ConcatKdf, AesKeyWrapDecrypt }
 }
 
 procedures! {
@@ -957,11 +959,59 @@ impl UseSecret<2> for AesKeyWrapEncrypt {
 
 impl AesKeyWrapEncrypt {
     fn wrap_key(&self, encryption_key: &[u8], wrap_key: &[u8]) -> Result<Vec<u8>, FatalProcedureError> {
+        // This uses Aes256Kw unconditionally, since AesKeyWrapCipher has just one variant.
+        // The enum was added for future proofing so support for other variants can be added non-breakingly.
         let mut ciphertext: Vec<u8> = vec![0; wrap_key.len() + Aes256Kw::BLOCK];
 
         let wrap: Aes256Kw = Aes256Kw::new(encryption_key);
         wrap.wrap_key(wrap_key, &mut ciphertext)?;
 
         Ok(ciphertext)
+    }
+}
+
+/// Decrypts a provided wrapped key using a decryption key, and writes the result into an output location.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AesKeyWrapDecrypt {
+    /// The cipher to use for decryption.
+    pub cipher: AesKeyWrapCipher,
+    /// The key to use for decryption of the `wrapped_key`.
+    pub decryption_key: Location,
+    /// The ciphertext of the key to unwrap.
+    pub wrapped_key: Vec<u8>,
+    /// The location into which to write the decrypted key.
+    pub output: Location,
+}
+
+impl DeriveSecret<1> for AesKeyWrapDecrypt {
+    type Output = ();
+
+    fn derive(self, guard: [Buffer<u8>; 1]) -> Result<Products<Self::Output>, FatalProcedureError> {
+        let plaintext: Vec<u8> = self.unwrap_key(guard[0].borrow().as_ref())?;
+        Ok(Products {
+            secret: plaintext,
+            output: (),
+        })
+    }
+
+    fn source(&self) -> [Location; 1] {
+        [self.decryption_key.clone()]
+    }
+
+    fn target(&self) -> &Location {
+        &self.output
+    }
+}
+
+impl AesKeyWrapDecrypt {
+    fn unwrap_key(&self, decryption_key: &[u8]) -> Result<Vec<u8>, FatalProcedureError> {
+        // This uses Aes256Kw unconditionally, since AesKeyWrapCipher has just one variant.
+        // The enum was added for future proofing so support for other variants can be added non-breakingly.
+        let mut plaintext: Vec<u8> = vec![0; self.wrapped_key.len() - Aes256Kw::BLOCK];
+
+        let wrap: Aes256Kw = Aes256Kw::new(decryption_key);
+        wrap.unwrap_key(self.wrapped_key.as_ref(), &mut plaintext)?;
+
+        Ok(plaintext)
     }
 }

--- a/client/src/procedures/primitives.rs
+++ b/client/src/procedures/primitives.rs
@@ -926,6 +926,7 @@ impl ConcatKdf {
     }
 }
 
+/// The available ciphers for AES key wrapping.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub enum AesKeyWrapCipher {
     Aes256,
@@ -956,11 +957,11 @@ impl UseSecret<2> for AesKeyWrapEncrypt {
 
 impl AesKeyWrapEncrypt {
     fn wrap_key(&self, encryption_key: &[u8], wrap_key: &[u8]) -> Result<Vec<u8>, FatalProcedureError> {
-        let mut ctx: Vec<u8> = vec![0; encryption_key.len() + Aes256Kw::BLOCK];
+        let mut ciphertext: Vec<u8> = vec![0; wrap_key.len() + Aes256Kw::BLOCK];
 
         let wrap: Aes256Kw = Aes256Kw::new(encryption_key);
-        wrap.wrap_key(wrap_key, &mut ctx)?;
+        wrap.wrap_key(wrap_key, &mut ciphertext)?;
 
-        Ok(ctx)
+        Ok(ciphertext)
     }
 }

--- a/client/src/procedures/primitives.rs
+++ b/client/src/procedures/primitives.rs
@@ -186,12 +186,9 @@ macro_rules! generic_procedures {
 generic_procedures! {
     // Stronghold procedures that implement the `UseSecret` trait.
     UseSecret<1> => { PublicKey, Ed25519Sign, Hmac, AeadEncrypt, AeadDecrypt },
+    UseSecret<2> => { AesKeyWrapEncrypt },
     // Stronghold procedures that implement the `DeriveSecret` trait.
     DeriveSecret<1> => { CopyRecord, Slip10Derive, X25519DiffieHellman, Hkdf, ConcatKdf }
-}
-
-procedures2! {
-    UseSecret<2> => { AesKeyWrapEncrypt }
 }
 
 procedures! {


### PR DESCRIPTION
# Description of change

Adds `AesKeyWrapEncrypt` and `AesKeyWrapDecrypt` procedures using Aes256, with the option to add Aes128 and Aes192 non-breakingly in the future.

## Encryption

This takes two locations as input, `encryption_key` and `wrap_key`. `encryption_key` will be used to encrypt `wrap_key`, and return the resulting ciphertext bytes to the caller. This looks suspiciously like leaking secrets, but in reality it doesn't. Without the `encryption_key`, no one is able to get the encrypted `wrap_key` secret, except for other parties that can also produce the `encryption_key`, e.g. if this key was created through a Diffie-Hellman operation.

This is exactly the use case we need it for: JSON Web Encryption. We have some secret `verification_method` key material lying in Stronghold, and presumably, so does the peer we want to communicate with. Through DH we can produce a shared secret - this is the `encryption_key` in our case. We also randomly generate another secret key for content encryption, which is our key to be wrapped (the `wrap_key`). Now we wrap the `wrap_key` with `encryption_key` and add it to the message. The receiver can do DH, decrypt the `wrap_key` and decrypt the content. We don't reuse the content encryption key (`wrap_key`).

In general, even if someone leaks a secret in encrypted form, in order for it to be useful someone would still need to somehow gain access to the `encryption_key`, which is not possible through stronghold. All in all, this doesn't seem abusable to me, even by users willing to, but I'd be happy if someone else validates this.

## Decryption

This takes the location of the `encryption_key` and the `wrapped_key` as input, in form of a `Vec<u8>`. The key is unwrapped and written into a location in a vault.

## Links to any relevant issues

closes #338

This feature required procedures to be able to take two secrets as input, which required some refactoring: #354.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested

Added a roundtrip test based on an official test vector which is also used in crypto.rs.

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
