### PR TITLE
Return an optional previous value on inserting into the store

### DIFF
--- a/.changes/store.md
+++ b/.changes/store.md
@@ -1,0 +1,5 @@
+---
+"iota-stronghold": minor
+---
+
+Inserting a value into the `Store` will return an optional previous value

--- a/client/src/tests/store_tests.rs
+++ b/client/src/tests/store_tests.rs
@@ -10,7 +10,13 @@ fn test_insert_into_store() {
     let key = b"some key";
     let data = b"some data".to_vec();
 
-    assert!(store.insert(key.to_vec(), data, None).is_ok());
+    assert!(store.insert(key.to_vec(), data.clone(), None).is_ok());
+
+    let new_data = b"some_other_data".to_vec();
+
+    let previous = store.insert(key.to_vec(), new_data, None).unwrap();
+    assert!(previous.is_some());
+    assert_eq!(previous.unwrap(), data);
 }
 
 #[test]

--- a/client/src/types/store.rs
+++ b/client/src/types/store.rs
@@ -51,11 +51,18 @@ impl Store {
     /// let data = b"some data".to_vec();
     /// assert!(store.insert(key.clone(), data, None).is_ok());
     /// ```
-    pub fn insert(&self, key: Vec<u8>, value: Vec<u8>, lifetime: Option<Duration>) -> Result<(), ClientError> {
+    pub fn insert(
+        &self,
+        key: Vec<u8>,
+        value: Vec<u8>,
+        lifetime: Option<Duration>,
+    ) -> Result<Option<Vec<u8>>, ClientError> {
         let mut guard = self.cache.try_write()?;
+
+        let previous = guard.remove(&key);
         guard.insert(key.to_vec(), value, lifetime);
 
-        Ok(())
+        Ok(previous)
     }
 
     /// Tries to get the stored value via `key`

--- a/client/src/types/store.rs
+++ b/client/src/types/store.rs
@@ -58,11 +58,7 @@ impl Store {
         lifetime: Option<Duration>,
     ) -> Result<Option<Vec<u8>>, ClientError> {
         let mut guard = self.cache.try_write()?;
-
-        let previous = guard.remove(&key);
-        guard.insert(key.to_vec(), value, lifetime);
-
-        Ok(previous)
+        Ok(guard.insert(key.to_vec(), value, lifetime))
     }
 
     /// Tries to get the stored value via `key`


### PR DESCRIPTION
# Description of change

This introduces a small breaking change into the API for the insecure `Store`. Inserting a value with the same key again, returns an optional previous value. 

## Links to any relevant issues

#379 

## Type of change

Choose a type of change, and delete any options that are not relevant.
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How the change has been tested

Unit tests have been supplied to verify the correctness of behavior. 

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
