### PR TITLE
Fix Snapshot Paths and ClientError improvement

### DIFF
--- a/.changes/improvements.md
+++ b/.changes/improvements.md
@@ -1,0 +1,7 @@
+---
+"iota-stronghold": patch
+---
+
+Loading a snapshot file will now return a new `ClientError` variant `SnapshotFileMissing`, if the snapshot file is not present
+Committing `Client` state into a snapshotfile will now check if all paths to the snapshot file are correct and will create the snapshot file, if it doesn't exist.
+

--- a/client/src/procedures/clientrunner.rs
+++ b/client/src/procedures/clientrunner.rs
@@ -70,7 +70,7 @@ impl Runner for Client {
             Ok(secret)
         };
 
-        let random_hint = RecordHint::new(rand::bytestring(DEFAULT_RANDOM_HINT_SIZE)).unwrap();
+        let random_hint = RecordHint::new(rand::variable_bytestring(DEFAULT_RANDOM_HINT_SIZE)).unwrap();
 
         // FIXME: THIS SHOULD RETURN AN ACTUAL ERROR!
         let mut db = self.db.try_write().map_err(|e| e.to_string()).expect("");
@@ -118,7 +118,7 @@ impl Runner for Client {
             let key = keystore.create_key(vault_id).map_err(|_| RecordError::InvalidKey)?;
             db.init_vault(&key, vault_id);
         }
-        let random_hint = RecordHint::new(rand::bytestring(DEFAULT_RANDOM_HINT_SIZE)).unwrap();
+        let random_hint = RecordHint::new(rand::variable_bytestring(DEFAULT_RANDOM_HINT_SIZE)).unwrap();
         let key = keystore.take_key(vault_id).unwrap();
         let res = db.write(&key, vault_id, record_id, &value, random_hint);
 

--- a/client/src/procedures/types.rs
+++ b/client/src/procedures/types.rs
@@ -218,7 +218,7 @@ mod test {
 
     #[test]
     fn proc_io_vec() {
-        let vec = random::bytestring(2048);
+        let vec = random::variable_bytestring(2048);
         let proc_io: ProcedureOutput = vec.clone().into();
         let converted = Vec::try_from(proc_io).unwrap();
         assert_eq!(vec.len(), converted.len());

--- a/client/src/sync.rs
+++ b/client/src/sync.rs
@@ -409,12 +409,12 @@ mod test {
     }
 
     fn test_value() -> Vec<u8> {
-        random::bytestring(4096)
+        random::variable_bytestring(4096)
     }
 
     fn test_location() -> Location {
-        let v_path = random::bytestring(4096);
-        let r_path = random::bytestring(4096);
+        let v_path = random::variable_bytestring(4096);
+        let r_path = random::variable_bytestring(4096);
         Location::generic(v_path, r_path)
     }
 
@@ -436,14 +436,14 @@ mod test {
         let (vid1, rid1) = location_1.resolve();
         client.write_to_vault(&location_1, test_value())?;
 
-        let v_path_2 = random::bytestring(4096);
-        let r_path_2 = random::bytestring(4096);
+        let v_path_2 = random::variable_bytestring(4096);
+        let r_path_2 = random::variable_bytestring(4096);
         let location_2 = Location::generic(v_path_2.clone(), r_path_2);
         let (vid2, rid2) = location_2.resolve();
         client.write_to_vault(&location_2, test_value())?;
 
         // Same vault as value nr 2.
-        let r_path_3 = random::bytestring(4096);
+        let r_path_3 = random::variable_bytestring(4096);
         let location_3 = Location::generic(v_path_2, r_path_3);
         let (vid23, rid3) = location_3.resolve();
         assert_eq!(vid2, vid23);
@@ -488,10 +488,10 @@ mod test {
             ..Default::default()
         };
 
-        let v_path_1 = random::bytestring(1024);
+        let v_path_1 = random::variable_bytestring(1024);
         let vid1 = derive_vault_id(v_path_1.clone());
 
-        let v_path_2 = random::bytestring(1024);
+        let v_path_2 = random::variable_bytestring(1024);
         let vid2 = derive_vault_id(v_path_2);
 
         // Include vault-1 in the sync.
@@ -504,7 +504,7 @@ mod test {
             source.write_to_vault(&location, test_value())?;
         }
 
-        let v_path_3 = random::bytestring(1024);
+        let v_path_3 = random::variable_bytestring(1024);
         let vid3 = derive_vault_id(v_path_3.clone());
         // Include vault-3 in the sync, but only selected records.
         config.select_vaults.as_mut().unwrap().push(vid3);
@@ -522,10 +522,10 @@ mod test {
         config.select_records.insert(vid3, select_records_v3);
 
         // Vault-4 is not included in the sync.
-        let v_path_4 = random::bytestring(1024);
+        let v_path_4 = random::variable_bytestring(1024);
         let vid4 = derive_vault_id(v_path_4.clone());
 
-        let v_path_5 = random::bytestring(1024);
+        let v_path_5 = random::variable_bytestring(1024);
         let vid5 = derive_vault_id(v_path_5);
         // Irrelevant mapping of vault-4 to vault-5.
         config.map_vaults.insert(vid4, vid5);

--- a/client/src/tests/fresh.rs
+++ b/client/src/tests/fresh.rs
@@ -8,7 +8,7 @@ use crate::Location;
 
 /// Generates a random [`Location`].
 pub fn location() -> Location {
-    Location::generic(bytestring(4096), bytestring(4096))
+    Location::generic(variable_bytestring(4096), variable_bytestring(4096))
 }
 
 /// Creates a random hd_path.

--- a/client/src/tests/interface_tests.rs
+++ b/client/src/tests/interface_tests.rs
@@ -392,3 +392,17 @@ fn test_load_client_from_non_existing_snapshot() {
 
     assert!(result)
 }
+
+#[test]
+fn test_create_snapshot_file_in_custom_directory() {
+    let client_path = "my-awesome-client-path";
+    let stronghold = Stronghold::default();
+    let mut temp_dir = std::env::temp_dir();
+    temp_dir = temp_dir.join("idkfa.snapshot");
+
+    let snapshot_path = SnapshotPath::from_path(format!("{:?}", temp_dir.as_path()));
+    let password = rand::fixed_bytestring(32);
+    let keyprovider = KeyProvider::try_from(password).expect("KeyProvider failed");
+
+    assert!(stronghold.commit(&snapshot_path, &keyprovider).is_ok());
+}

--- a/client/src/tests/interface_tests.rs
+++ b/client/src/tests/interface_tests.rs
@@ -373,3 +373,22 @@ fn test_load_multiple_clients_from_snapshot() {
         assert!(result.is_ok(), "Failed to load client from snapshot path {:?}", result);
     });
 }
+
+#[test]
+fn test_load_client_from_non_existing_snapshot() {
+    let client_path = "my-awesome-client-path";
+    let stronghold = Stronghold::default();
+    let snapshot_path = SnapshotPath::named("idkfa.snapshot");
+    let password = rand::fixed_bytestring(32);
+    let keyprovider = KeyProvider::try_from(password).expect("KeyProvider failed");
+
+    let result = match stronghold.load_client_from_snapshot(client_path, &keyprovider, &snapshot_path) {
+        Err(client_error) => {
+            std::mem::discriminant(&client_error)
+                == std::mem::discriminant(&ClientError::SnapshotfileMissing("obo".to_string()))
+        }
+        Ok(_) => false,
+    };
+
+    assert!(result)
+}

--- a/client/src/tests/interface_tests.rs
+++ b/client/src/tests/interface_tests.rs
@@ -385,7 +385,7 @@ fn test_load_client_from_non_existing_snapshot() {
     let result = match stronghold.load_client_from_snapshot(client_path, &keyprovider, &snapshot_path) {
         Err(client_error) => {
             std::mem::discriminant(&client_error)
-                == std::mem::discriminant(&ClientError::SnapshotfileMissing("obo".to_string()))
+                == std::mem::discriminant(&ClientError::SnapshotFileMissing("obo".to_string()))
         }
         Ok(_) => false,
     };

--- a/client/src/tests/network_tests.rs
+++ b/client/src/tests/network_tests.rs
@@ -32,7 +32,7 @@ use crate::{
 
 /// Generates a random [`Location`].
 pub fn location() -> Location {
-    Location::generic(rand::bytestring(4096), rand::bytestring(4096))
+    Location::generic(rand::variable_bytestring(4096), rand::variable_bytestring(4096))
 }
 
 /// generates a random string based on a coinflip.
@@ -506,7 +506,7 @@ async fn test_p2p_firewall_old() {
 async fn test_p2p_cycle() {
     // -- setup
     let key_pair = Keypair::generate_ed25519();
-    let remote_client_path = rand::bytestring(1024);
+    let remote_client_path = rand::variable_bytestring(1024);
     let remote = Stronghold::default();
     let config = NetworkConfig::new(Permissions::allow_all()).with_mdns_enabled(false);
 
@@ -549,7 +549,7 @@ async fn test_p2p_write_read_delete_remote_store() {
     let remote_key_pair = Keypair::generate_ed25519();
     let remote_public_key = remote_key_pair.public();
     let remote_key_path = Location::generic(b"remote-key-path".to_vec(), b"remote-key-path".to_vec());
-    let remote_client_path = rand::bytestring(1024);
+    let remote_client_path = rand::variable_bytestring(1024);
     let remote = Stronghold::default();
     let config = NetworkConfig::new(Permissions::allow_all()).with_mdns_enabled(true);
 
@@ -582,7 +582,7 @@ async fn test_p2p_write_read_delete_remote_store() {
     let server = tokio::spawn(async move { remote_stronghold_server.serve(receiver_terminate_signal).await });
     // tests come here
     {
-        let local_client_path = rand::bytestring(1024);
+        let local_client_path = rand::variable_bytestring(1024);
         let local_key_pair = Keypair::generate_ed25519();
         let local_public_key = local_key_pair.public();
         let local_key_path = Location::generic(b"keypair-path".to_vec(), b"keypair-path".to_vec());
@@ -615,8 +615,8 @@ async fn test_p2p_write_read_delete_remote_store() {
 
         //  run this test a couple of times
         for _ in 0..10 {
-            let key = rand::bytestring(1024);
-            let data = rand::bytestring(1024);
+            let key = rand::variable_bytestring(1024);
+            let data = rand::variable_bytestring(1024);
 
             let result = peer.remote_write_store(key.clone(), data.clone(), None).await;
             assert!(result.is_ok(), "Assertion Failed= {:?}", result);
@@ -653,7 +653,7 @@ async fn test_p2p_write_read_to_remote_store() {
     let remote_key_pair = Keypair::generate_ed25519();
     let remote_public_key = remote_key_pair.public();
     let remote_key_path = Location::generic(b"remote-key-path".to_vec(), b"remote-key-path".to_vec());
-    let remote_client_path = rand::bytestring(1024);
+    let remote_client_path = rand::variable_bytestring(1024);
     let remote = Stronghold::default();
     let config = NetworkConfig::new(Permissions::allow_all()).with_mdns_enabled(true);
 
@@ -687,7 +687,7 @@ async fn test_p2p_write_read_to_remote_store() {
 
     // tests come here
     {
-        let local_client_path = rand::bytestring(1024);
+        let local_client_path = rand::variable_bytestring(1024);
         let local_key_pair = Keypair::generate_ed25519();
         let local_public_key = local_key_pair.public();
         let local_key_path = Location::generic(b"keypair-path".to_vec(), b"keypair-path".to_vec());
@@ -720,8 +720,8 @@ async fn test_p2p_write_read_to_remote_store() {
 
         //  run this test a couple of times
         for _ in 0..10 {
-            let key = rand::bytestring(1024);
-            let data = rand::bytestring(1024);
+            let key = rand::variable_bytestring(1024);
+            let data = rand::variable_bytestring(1024);
 
             let result = peer.remote_write_store(key.clone(), data.clone(), None).await;
             assert!(result.is_ok(), "Assertion Failed= {:?}", result);
@@ -756,7 +756,7 @@ async fn test_write_remote_secret_export_public_key() {
     let remote_key_pair = Keypair::generate_ed25519();
     let remote_public_key = remote_key_pair.public();
     let remote_key_path = Location::generic(b"remote-key-path".to_vec(), b"remote-key-path".to_vec());
-    let remote_client_path = rand::bytestring(1024);
+    let remote_client_path = rand::variable_bytestring(1024);
     let remote = Stronghold::default();
     let config = NetworkConfig::new(Permissions::allow_all()).with_mdns_enabled(true);
 
@@ -790,7 +790,7 @@ async fn test_write_remote_secret_export_public_key() {
 
     // tests come here
     {
-        let local_client_path = rand::bytestring(1024);
+        let local_client_path = rand::variable_bytestring(1024);
         let local_key_pair = Keypair::generate_ed25519();
         let local_public_key = local_key_pair.public();
         let local_key_path = Location::generic(b"keypair-path".to_vec(), b"keypair-path".to_vec());
@@ -822,8 +822,8 @@ async fn test_write_remote_secret_export_public_key() {
         assert!(result.is_ok(), "Assertion Failed= {:?}", result);
 
         // prepare procedure to generate key on remote side
-        let remote_vault_path = rand::bytestring(1024);
-        let remote_record_path = rand::bytestring(1024);
+        let remote_vault_path = rand::variable_bytestring(1024);
+        let remote_record_path = rand::variable_bytestring(1024);
         let output = Location::const_generic(remote_vault_path, remote_record_path);
 
         let proc = GenerateKey {
@@ -891,7 +891,7 @@ async fn test_synchronize_snapshots() {
     let remote_key_pair = Keypair::generate_ed25519();
     let remote_public_key = remote_key_pair.public();
     let remote_key_path = Location::generic(b"remote-key-path".to_vec(), b"remote-key-path".to_vec());
-    let remote_client_path = rand::bytestring(1024);
+    let remote_client_path = rand::variable_bytestring(1024);
     let remote = Stronghold::default();
     let config = NetworkConfig::new(Permissions::allow_all()).with_mdns_enabled(false);
 
@@ -935,7 +935,7 @@ async fn test_synchronize_snapshots() {
 
     // tests come here
     {
-        let local_client_path = rand::bytestring(1024);
+        let local_client_path = rand::variable_bytestring(1024);
         let local_key_pair = Keypair::generate_ed25519();
         let local_public_key = local_key_pair.public();
         let local_key_path = Location::generic(b"keypair-path".to_vec(), b"keypair-path".to_vec());

--- a/client/src/tests/procedure_tests.rs
+++ b/client/src/tests/procedure_tests.rs
@@ -229,8 +229,8 @@ async fn usecase_ed25519() -> Result<(), Box<dyn std::error::Error>> {
     let stronghold: Stronghold = Stronghold::default();
     let client: Client = stronghold.create_client(b"client_path").unwrap();
 
-    let vault_path = random::bytestring(1024);
-    let seed = Location::generic(vault_path.clone(), random::bytestring(1024));
+    let vault_path = random::variable_bytestring(1024);
+    let seed = Location::generic(vault_path.clone(), random::variable_bytestring(1024));
 
     if fresh::coinflip() {
         let size_bytes = if fresh::coinflip() {
@@ -254,7 +254,7 @@ async fn usecase_ed25519() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     let (_path, chain) = fresh::hd_path();
-    let key = Location::generic(vault_path, random::bytestring(1024));
+    let key = Location::generic(vault_path, random::variable_bytestring(1024));
 
     let slip10_derive = Slip10Derive {
         chain,
@@ -269,7 +269,7 @@ async fn usecase_ed25519() -> Result<(), Box<dyn std::error::Error>> {
     };
     let pk: [u8; ed25519::PUBLIC_KEY_LENGTH] = client.execute_procedure(ed25519_pk).unwrap();
 
-    let msg = fresh::bytestring(4096);
+    let msg = fresh::variable_bytestring(4096);
 
     let ed25519_sign = Ed25519Sign {
         private_key: key,
@@ -339,7 +339,7 @@ async fn usecase_ed25519_as_complex() -> Result<(), Box<dyn std::error::Error>> 
     let stronghold: Stronghold = Stronghold::default();
     let client: Client = stronghold.create_client(b"client_path").unwrap();
 
-    let msg = fresh::bytestring(4096);
+    let msg = fresh::variable_bytestring(4096);
 
     let generate = Slip10Generate {
         size_bytes: None,
@@ -458,8 +458,8 @@ async fn test_aead(
 ) -> Result<(), Box<dyn std::error::Error>> {
     use crypto::ciphers::traits::*;
 
-    let test_plaintext = random::bytestring(4096);
-    let test_associated_data = random::bytestring(4096);
+    let test_plaintext = random::variable_bytestring(4096);
+    let test_associated_data = random::variable_bytestring(4096);
     let nonce_len = match cipher {
         AeadCipher::Aes256Gcm => Aes256Gcm::NONCE_LENGTH,
         AeadCipher::XChaCha20Poly1305 => XChaCha20Poly1305::NONCE_LENGTH,
@@ -601,7 +601,7 @@ async fn usecase_diffie_hellman() -> Result<(), Box<dyn std::error::Error>> {
     let mut salt = vec![];
     salt.extend_from_slice(&pub_key_1);
     salt.extend_from_slice(&pub_key_2);
-    let label = random::bytestring(1024);
+    let label = random::variable_bytestring(1024);
 
     let key_1_2 = fresh::location();
     let dh_1_2 = X25519DiffieHellman {
@@ -655,7 +655,7 @@ async fn usecase_recover_bip39() -> Result<(), Box<dyn std::error::Error>> {
 
     let passphrase = random::string(4096);
     let (_path, chain) = fresh::hd_path();
-    let message = random::bytestring(4095);
+    let message = random::variable_bytestring(4095);
 
     let generate_bip39 = BIP39Generate {
         language: MnemonicLanguage::English,
@@ -715,7 +715,7 @@ async fn usecase_move_record() -> Result<(), Box<dyn std::error::Error>> {
     let stronghold: Stronghold = Stronghold::default();
     let client: Client = stronghold.create_client(b"client_path").unwrap();
 
-    let test_msg = random::bytestring(4096);
+    let test_msg = random::variable_bytestring(4096);
 
     let first_location = fresh::location();
     let generate_key = GenerateKey {

--- a/client/src/tests/store_tests.rs
+++ b/client/src/tests/store_tests.rs
@@ -61,7 +61,7 @@ fn test_keys() {
     let store = Store::default();
     let max_entries = 10;
     let generate = || -> Vec<Vec<u8>> {
-        std::iter::repeat_with(|| rand::bytestring(256))
+        std::iter::repeat_with(|| rand::variable_bytestring(256))
             .take(max_entries)
             .collect()
     };

--- a/client/src/types/error.rs
+++ b/client/src/types/error.rs
@@ -44,7 +44,7 @@ pub enum ClientError {
     ConnectionFailure(String),
 
     #[error("Snapshot file is missing ({0})")]
-    SnapshotfileMissing(String),
+    SnapshotFileMissing(String),
 }
 
 #[cfg(feature = "p2p")]
@@ -102,7 +102,7 @@ impl From<Box<dyn Any>> for ClientError {
 impl From<SnapshotError> for ClientError {
     fn from(se: SnapshotError) -> Self {
         match se {
-            SnapshotError::MissingFile(path) => ClientError::SnapshotfileMissing(path),
+            SnapshotError::MissingFile(path) => ClientError::SnapshotFileMissing(path),
             SnapshotError::Io(inner) => ClientError::Inner(inner.to_string()),
             SnapshotError::CorruptedContent(inner) => ClientError::Inner(inner),
             SnapshotError::InvalidFile(inner) => ClientError::Inner(inner),

--- a/client/src/types/error.rs
+++ b/client/src/types/error.rs
@@ -107,7 +107,7 @@ impl From<SnapshotError> for ClientError {
             SnapshotError::CorruptedContent(inner) => ClientError::Inner(inner),
             SnapshotError::InvalidFile(inner) => ClientError::Inner(inner),
             SnapshotError::SnapshotKey(vault_id, record_id) => ClientError::Inner(format!(
-                "Missing or invalid snapshot key vaultid: {:?},  recordid{:?}",
+                "Missing or invalid snapshot key vaultid: {:?}, recordid: {:?}",
                 vault_id, record_id
             )),
             SnapshotError::Engine(inner) => ClientError::Inner(inner),

--- a/client/src/types/error.rs
+++ b/client/src/types/error.rs
@@ -42,6 +42,9 @@ pub enum ClientError {
 
     #[error("Connection failure ({0})")]
     ConnectionFailure(String),
+
+    #[error("Snapshot file is missing ({0})")]
+    SnapshotfileMissing(String),
 }
 
 #[cfg(feature = "p2p")]
@@ -96,6 +99,24 @@ impl From<Box<dyn Any>> for ClientError {
     }
 }
 
+impl From<SnapshotError> for ClientError {
+    fn from(se: SnapshotError) -> Self {
+        match se {
+            SnapshotError::MissingFile(path) => ClientError::SnapshotfileMissing(path),
+            SnapshotError::Io(inner) => ClientError::Inner(inner.to_string()),
+            SnapshotError::CorruptedContent(inner) => ClientError::Inner(inner),
+            SnapshotError::InvalidFile(inner) => ClientError::Inner(inner),
+            SnapshotError::SnapshotKey(vault_id, record_id) => ClientError::Inner(format!(
+                "Missing or invalid snapshot key vaultid: {:?},  recordid{:?}",
+                vault_id, record_id
+            )),
+            SnapshotError::Engine(inner) => ClientError::Inner(inner),
+            SnapshotError::Provider(inner) => ClientError::Inner(inner),
+            SnapshotError::Inner(inner) => ClientError::Inner(inner),
+        }
+    }
+}
+
 pub type VaultError<E> = EngineVaultError<<Provider as BoxProvider>::Error, E>;
 pub type RecordError = EngineRecordError<<Provider as BoxProvider>::Error>;
 
@@ -134,6 +155,9 @@ pub enum SnapshotError {
 
     #[error("BoxProvider error: {0}")]
     Provider(String),
+
+    #[error("Snapshot file is missing ({0})")]
+    MissingFile(String),
 
     #[error("Inner error: ({0})")]
     Inner(String),

--- a/client/src/types/snapshot.rs
+++ b/client/src/types/snapshot.rs
@@ -114,6 +114,12 @@ impl SnapshotPath {
     pub fn as_path(&self) -> &Path {
         &self.path
     }
+
+    /// Returns `true`, if the provided path to the snapshot file exists,
+    /// `false` otherwise
+    pub fn exists(&self) -> bool {
+        self.as_path().exists()
+    }
 }
 
 impl Display for SnapshotPath {

--- a/client/src/types/snapshot.rs
+++ b/client/src/types/snapshot.rs
@@ -90,8 +90,8 @@ impl SnapshotPath {
     where
         P: AsRef<Path>,
     {
-        assert!(name.as_ref().is_relative());
-        assert!(engine::snapshot::files::home_dir().is_ok());
+        // assert!(name.as_ref().is_relative());
+        // assert!(engine::snapshot::files::home_dir().is_ok());
 
         let path = engine::snapshot::files::home_dir().unwrap();
 

--- a/client/src/types/snapshot.rs
+++ b/client/src/types/snapshot.rs
@@ -90,9 +90,6 @@ impl SnapshotPath {
     where
         P: AsRef<Path>,
     {
-        // assert!(name.as_ref().is_relative());
-        // assert!(engine::snapshot::files::home_dir().is_ok());
-
         let path = engine::snapshot::files::home_dir().unwrap();
 
         Self { path: path.join(name) }

--- a/client/src/types/stronghold.rs
+++ b/client/src/types/stronghold.rs
@@ -199,9 +199,12 @@ impl Stronghold {
         let mut snapshot = self.snapshot.try_write()?;
 
         if !snapshot_path.exists() {
-            return Err(ClientError::SnapshotfileMissing(
-                snapshot_path.as_path().to_str().unwrap().to_string(),
-            ));
+            let path = snapshot_path
+                .as_path()
+                .to_str()
+                .ok_or_else(|| ClientError::Inner("Cannot display path as string".to_string()))?;
+
+            return Err(ClientError::SnapshotfileMissing(path.to_string()));
         }
 
         // CRITICAL SECTION

--- a/client/src/types/stronghold.rs
+++ b/client/src/types/stronghold.rs
@@ -198,6 +198,12 @@ impl Stronghold {
     pub fn load_snapshot(&self, keyprovider: &KeyProvider, snapshot_path: &SnapshotPath) -> Result<(), ClientError> {
         let mut snapshot = self.snapshot.try_write()?;
 
+        if std::fs::File::open(snapshot_path.as_path()).is_err() {
+            return Err(ClientError::SnapshotfileMissing(
+                snapshot_path.as_path().to_str().unwrap().to_string(),
+            ));
+        }
+
         // CRITICAL SECTION
         let buffer = keyprovider
             .try_unlock()

--- a/client/src/types/stronghold.rs
+++ b/client/src/types/stronghold.rs
@@ -254,7 +254,9 @@ impl Stronghold {
         let clients = self.clients.try_read()?;
 
         if !snapshot_path.exists() {
-            let path = snapshot_path.as_path().parent().unwrap();
+            let path = snapshot_path.as_path().parent().ok_or_else(|| {
+                ClientError::SnapshotfileMissing("Parent directory of snapshot file does not exist".to_string())
+            })?;
             if let Err(io_error) = std::fs::create_dir_all(path) {
                 return Err(ClientError::SnapshotfileMissing(
                     "Could not create snapshot file".to_string(),

--- a/client/src/types/stronghold.rs
+++ b/client/src/types/stronghold.rs
@@ -204,7 +204,7 @@ impl Stronghold {
                 .to_str()
                 .ok_or_else(|| ClientError::Inner("Cannot display path as string".to_string()))?;
 
-            return Err(ClientError::SnapshotfileMissing(path.to_string()));
+            return Err(ClientError::SnapshotFileMissing(path.to_string()));
         }
 
         // CRITICAL SECTION
@@ -258,10 +258,10 @@ impl Stronghold {
 
         if !snapshot_path.exists() {
             let path = snapshot_path.as_path().parent().ok_or_else(|| {
-                ClientError::SnapshotfileMissing("Parent directory of snapshot file does not exist".to_string())
+                ClientError::SnapshotFileMissing("Parent directory of snapshot file does not exist".to_string())
             })?;
             if let Err(io_error) = std::fs::create_dir_all(path) {
-                return Err(ClientError::SnapshotfileMissing(
+                return Err(ClientError::SnapshotFileMissing(
                     "Could not create snapshot file".to_string(),
                 ));
             }

--- a/engine/src/snapshot/logic.rs
+++ b/engine/src/snapshot/logic.rs
@@ -246,7 +246,7 @@ mod test {
     };
 
     fn random_bytestring() -> Vec<u8> {
-        random::bytestring(4096)
+        random::variable_bytestring(4096)
     }
 
     fn random_key() -> Key {

--- a/p2p/src/interface/event_channel.rs
+++ b/p2p/src/interface/event_channel.rs
@@ -194,7 +194,7 @@ mod test {
     fn test_vec() -> Vec<Vec<u8>> {
         let mut data = Vec::with_capacity(TEST_DATA_COUNT);
         for _ in 0..data.capacity() {
-            let v = random::bytestring(32);
+            let v = random::variable_bytestring(32);
             data.push(v)
         }
         data

--- a/utils/src/random.rs
+++ b/utils/src/random.rs
@@ -15,13 +15,19 @@ where
 }
 
 // Random Bytestring with random length in range 1..max_len.
-pub fn bytestring(max_len: usize) -> Vec<u8> {
+pub fn variable_bytestring(max_len: usize) -> Vec<u8> {
     let s = (random::<usize>() % (max_len - 1)) + 1;
     let mut bs = Vec::with_capacity(s);
     for _ in 0..s {
         bs.push(random());
     }
     bs
+}
+
+/// Returns a fixed sized byte string
+pub fn fixed_bytestring(len: usize) -> Vec<u8> {
+    let mut rmut = rand::thread_rng();
+    std::iter::repeat_with(|| rmut.gen()).take(len).collect()
 }
 
 // Random string with random length in range 1..max_len.


### PR DESCRIPTION
# Description of change
This PR adds a new error variant to `ClientError` to indicate, that loading a non-existing snapshot failed. Committing all client state into a `Snapshot` file now creates all paths to the snapshot file. 
## Links to any relevant issues
none
## Type of change
- [x] Enhancement (a non-breaking change which adds functionality)
## How the change has been tested
Unit tests have been supplied.
## Change checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
