### PR TITLE
Stronghold clear function to reset state

### DIFF
--- a/.changes/unload.md
+++ b/.changes/unload.md
@@ -1,5 +1,5 @@
 ---
-"iota-stronghold:" minor
+"iota-stronghold":  minor
 ---
 
 add clear() function to Stronghold, Client and Snapshot

--- a/.changes/unload.md
+++ b/.changes/unload.md
@@ -1,0 +1,5 @@
+---
+"iota-stronghold:" minor
+---
+
+add clear() function to Stronghold, Client and Snapshot

--- a/client/src/tests/fresh.rs
+++ b/client/src/tests/fresh.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crypto::keys::slip10::Chain;
+use std::fmt::Write;
 pub use stronghold_utils::{random::*, test_utils};
 
 use crate::Location;
@@ -17,7 +18,7 @@ pub fn hd_path() -> (String, Chain) {
     let mut is = vec![];
     while coinflip() {
         let i = random::<u32>() & 0x7fffff;
-        s.push_str(&format!("/{}'", i));
+        write!(&mut s, "/{}'", i).expect("Failed to write path into string");
         is.push(i);
     }
     (s, Chain::from_u32_hardened(is))

--- a/client/src/tests/interface_tests.rs
+++ b/client/src/tests/interface_tests.rs
@@ -430,3 +430,83 @@ fn test_create_snapshot_file_in_custom_directory() {
     let secret = secret.unwrap();
     assert!(secret.eq(&payload));
 }
+
+#[test]
+fn test_clear_stronghold_state() {
+    // pre-requisites
+    let client_path = "my-awesome-client-path";
+    let vault_path = b"vault_path".to_vec();
+    let record_path = b"record_path".to_vec();
+    let payload = b"payload".to_vec();
+    let location = Location::const_generic(vault_path.clone(), record_path);
+
+    let store_key = rand::fixed_bytestring(32);
+    let store_data = rand::fixed_bytestring(1024);
+
+    let mut temp_dir = std::env::temp_dir();
+    temp_dir = temp_dir.join("idkfa.snapshot");
+    let defer = Defer::from((temp_dir, |path: &'_ PathBuf| {
+        println!("Delete temporary snapshot file");
+        let _ = std::fs::remove_file(path);
+    }));
+
+    let snapshot_path = SnapshotPath::from_path(defer.as_path());
+    let password = rand::fixed_bytestring(32);
+    let keyprovider = KeyProvider::try_from(password).expect("KeyProvider failed");
+
+    // init stronghold
+    let stronghold = Stronghold::default();
+
+    let result = stronghold.create_client(client_path);
+    assert!(result.is_ok(), "Could not load client {:?}", result);
+
+    let client = result.unwrap();
+    let client_store = client.store();
+    assert!(client_store.insert(store_key.clone(), store_data, None).is_ok());
+
+    // generate a key
+    assert!(client
+        .execute_procedure(crate::procedures::GenerateKey {
+            output: location.clone(),
+            ty: KeyType::Ed25519
+        })
+        .is_ok());
+
+    // and export its public part
+    let result = client.execute_procedure(crate::procedures::PublicKey {
+        private_key: location,
+        ty: KeyType::Ed25519,
+    });
+
+    // assert the public key export succeeded
+    assert!(result.is_ok());
+
+    // store the state
+    assert!(stronghold.commit(&snapshot_path, &keyprovider).is_ok());
+
+    // --
+    // clear internal state
+    // --
+    assert!(stronghold.clear().is_ok());
+
+    // check that vault does not exist. This is actually an odd case, but the reference
+    // to client is still present, but the inner state is not  since it is managed by stronghold.
+    // it would be safer to drop this reference
+    let result = client.vault_exists(vault_path);
+    assert!(result.is_ok());
+
+    // check for `false`
+    assert!(!result.unwrap());
+
+    let result = client_store.contains_key(&store_key);
+    assert!(result.is_ok());
+
+    // check for `false`
+    assert!(!result.unwrap());
+
+    // check, that loading a non-exisiting client should fail
+    let result = stronghold.load_client(client_path);
+    assert!(result.is_err());
+
+    assert!(matches!(result, Err(ClientError::ClientDataNotPresent)));
+}

--- a/client/src/tests/network_tests.rs
+++ b/client/src/tests/network_tests.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{future, ptr::addr_of, sync::Arc, time::Duration};
+use std::{fmt::Write, future, ptr::addr_of, sync::Arc, time::Duration};
 
 use stronghold_p2p::{
     identity::{Keypair, PublicKey},
@@ -50,7 +50,7 @@ pub fn hd_path() -> (String, Chain) {
     let mut is = vec![];
     while rand::coinflip() {
         let i = rand::random::<u32>() & 0x7fffff;
-        s.push_str(&format!("/{}'", i));
+        write!(&mut s, "/{}'", i).expect("Failed to write path into string");
         is.push(i);
     }
     (s, Chain::from_u32_hardened(is))

--- a/client/src/types/client.rs
+++ b/client/src/types/client.rs
@@ -225,6 +225,21 @@ impl Client {
         Ok(())
     }
 
+    /// Clears the inner [`Client`] state. This functions should not be called directly
+    /// but by calling the function of same name on [`Stronghold`]
+    pub(crate) fn clear(&self) -> Result<(), ClientError> {
+        let mut view = self.db.try_write()?;
+        view.clear();
+
+        let mut store = self.store.cache.try_write()?;
+        store.clear();
+
+        let mut ks = self.keystore.try_write()?;
+        ks.clear_keys();
+
+        Ok(())
+    }
+
     /// Executes a cryptographic [`Procedure`] and returns its output.
     /// A cryptographic [`Procedure`] is the main operation on secrets.
     ///

--- a/client/src/types/snapshot.rs
+++ b/client/src/types/snapshot.rs
@@ -385,6 +385,16 @@ impl Snapshot {
         engine::snapshot::write(&compressed_plain, &mut buffer, shared_key.as_bytes(), &[])?;
         Ok((pk, buffer))
     }
+
+    /// Clears the state from the [`Snapshot`]. This function shouldn't be called directly,
+    /// but from [`crate::Stronghold::clear()`]
+    pub(crate) fn clear(&mut self) -> Result<(), SnapshotError> {
+        self.keystore.clear_keys();
+        self.db.clear();
+        self.states.clear();
+
+        Ok(())
+    }
 }
 
 impl SyncSnapshots for Snapshot {

--- a/client/src/types/store.rs
+++ b/client/src/types/store.rs
@@ -156,6 +156,12 @@ impl Store {
         let inner = self.cache.try_read()?;
         Ok(inner.keys())
     }
+
+    /// Clear the [`Store`]
+    pub fn clear(&self) -> Result<(), ClientError> {
+        self.cache.try_write()?.clear();
+        Ok(())
+    }
 }
 
 // compatibility implementation

--- a/engine/fuzz/src/snapshot_fuzz.rs
+++ b/engine/fuzz/src/snapshot_fuzz.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 #![no_main]
 
 use engine::snapshot::{compress, decompress};

--- a/engine/fuzz/src/vault_fuzz.rs
+++ b/engine/fuzz/src/vault_fuzz.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 #![no_main]
 
 use engine::vault::{DbView, Key, RecordHint, RecordId, VaultId};

--- a/engine/rustfmt.toml
+++ b/engine/rustfmt.toml
@@ -1,6 +1,5 @@
 comment_width = 120
 format_code_in_doc_comments = true
-license_template_path = ".license_template"
 max_width = 120
 imports_granularity = "Crate"
 normalize_comments = true

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,7 +1,6 @@
 comment_width = 120
 format_code_in_doc_comments = true
 max_width = 120
-license_template_path = ".license_template"
 imports_granularity = "Crate"
 normalize_comments = true
 normalize_doc_attributes = true


### PR DESCRIPTION
# Description of change

This provides a `clear` function for `Stronghold` to reset the inner state of all `Clients` and the in-memory `Snapshot`. References to `Client` are still functional, but will have their state cleared. 

## Links to any relevant issues

#394 

## Type of change
- [x] Enhancement (a non-breaking change which adds functionality)
## How the change has been tested
unit tests have been provided.
## Change checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
