### PR TITLE
security fix: reduce visibility of client runners *get_guard* function

### DIFF
--- a/.changes/security.md
+++ b/.changes/security.md
@@ -1,0 +1,5 @@
+---
+"iota-stronghold": patch
+---
+
+reduce visibility of Client runners `get_guard` function

--- a/client/src/procedures/clientrunner.rs
+++ b/client/src/procedures/clientrunner.rs
@@ -191,7 +191,7 @@ impl Client {
     }
 
     /// Applies `f` to the buffer from the given `location`.
-    pub fn get_guard<F, T>(&self, location: &Location, f: F) -> Result<T, VaultError<FatalProcedureError>>
+    pub(crate) fn get_guard<F, T>(&self, location: &Location, f: F) -> Result<T, VaultError<FatalProcedureError>>
     where
         F: FnOnce(Buffer<u8>) -> Result<T, FatalProcedureError>,
     {


### PR DESCRIPTION
# Description of change
Reduced the visibility of [`Client`] runners function `get_guard`.
## Links to any relevant issues
none
## Type of change
- [x] Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested
none
## Change checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
