### PR TITLE
feat: add insecure procedure to check values store inside vault

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -16,6 +16,10 @@ default = [ "std" ]
 p2p = [ "std", "futures", "pin-project", "stronghold-p2p" ]
 std = [ ]
 
+# use this feature flag to enable insecure testing functions. This feature flag is disabled by default, and
+# MUST NOT be used in production setups
+insecure = []
+
 [dependencies]
 thiserror = { version = "1.0.30" }
 zeroize = { version = "1.4.3", features = [ "zeroize_derive" ] }

--- a/client/src/procedures.rs
+++ b/client/src/procedures.rs
@@ -7,6 +7,9 @@ mod types;
 
 pub use clientrunner::*;
 
+#[cfg(feature = "insecure")]
+pub use primitives::CheckingProcedure;
+
 pub use primitives::{
     AeadCipher, AeadDecrypt, AeadEncrypt, AesKeyWrapCipher, AesKeyWrapDecrypt, AesKeyWrapEncrypt, BIP39Generate,
     BIP39Recover, Chain, ChainCode, ConcatKdf, CopyRecord, Ed25519Sign, GarbageCollect, GenerateKey, Hkdf, Hmac,

--- a/client/src/procedures.rs
+++ b/client/src/procedures.rs
@@ -8,7 +8,7 @@ mod types;
 pub use clientrunner::*;
 
 #[cfg(feature = "insecure")]
-pub use primitives::CheckingProcedure;
+pub use primitives::CompareSecret;
 
 pub use primitives::{
     AeadCipher, AeadDecrypt, AeadEncrypt, AesKeyWrapCipher, AesKeyWrapDecrypt, AesKeyWrapEncrypt, BIP39Generate,

--- a/client/src/procedures/primitives.rs
+++ b/client/src/procedures/primitives.rs
@@ -59,7 +59,7 @@ pub enum StrongholdProcedure {
     AeadDecrypt(AeadDecrypt),
 
     #[cfg(feature = "insecure")]
-    CheckingProcedure(CheckingProcedure),
+    CompareSecret(CompareSecret),
 }
 
 impl Procedure for StrongholdProcedure {
@@ -90,7 +90,7 @@ impl Procedure for StrongholdProcedure {
             AeadDecrypt(proc) => proc.execute(runner).map(|o| o.into()),
 
             #[cfg(feature = "insecure")]
-            CheckingProcedure(proc) => proc.exec(runner).map(|o| o.into()),
+            CompareSecret(proc) => proc.exec(runner).map(|o| o.into()),
         }
     }
 }
@@ -193,7 +193,7 @@ macro_rules! generic_procedures {
 
 #[cfg(feature = "insecure")]
 generic_procedures! {
-    UseSecret<1> => { CheckingProcedure }
+    UseSecret<1> => { CompareSecret }
 }
 
 generic_procedures! {
@@ -1037,11 +1037,12 @@ impl AesKeyWrapDecrypt {
 }
 
 /// This procedure is to be used to check for values inside the vault.
-/// By it's very nature, this procedure is not secure to use and is by default
+/// By its very nature, this procedure is not secure to use and is by default
 /// inactive. it MUST NOT be used in production setups.
+/// Returns `vec![1]` if `expected` matches the secret at `location`, `vec![0]` otherwise.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg(feature = "insecure")]
-pub struct CheckingProcedure {
+pub struct CompareSecret {
     /// The location to look for the specified value
     pub location: Location,
 
@@ -1050,7 +1051,7 @@ pub struct CheckingProcedure {
 }
 
 #[cfg(feature = "insecure")]
-impl UseSecret<1> for CheckingProcedure {
+impl UseSecret<1> for CompareSecret {
     type Output = Vec<u8>; // this is a hack, since Procedure::Output only allows Vec output types
                            // we assume a value of `1` as `true`, while a `0` is considered `false`
 

--- a/client/src/procedures/primitives.rs
+++ b/client/src/procedures/primitives.rs
@@ -4,7 +4,7 @@
 use std::str::FromStr;
 
 use super::types::*;
-use crate::{derive_record_id, derive_vault_id, Client, ClientError, Location};
+use crate::{derive_record_id, derive_vault_id, Client, ClientError, Location, UseKey};
 pub use crypto::keys::slip10::{Chain, ChainCode};
 use crypto::{
     ciphers::{
@@ -57,6 +57,9 @@ pub enum StrongholdProcedure {
     Pbkdf2Hmac(Pbkdf2Hmac),
     AeadEncrypt(AeadEncrypt),
     AeadDecrypt(AeadDecrypt),
+
+    #[cfg(feature = "insecure")]
+    CheckingProcedure(CheckingProcedure),
 }
 
 impl Procedure for StrongholdProcedure {
@@ -85,6 +88,9 @@ impl Procedure for StrongholdProcedure {
             Pbkdf2Hmac(proc) => proc.execute(runner).map(|o| o.into()),
             AeadEncrypt(proc) => proc.execute(runner).map(|o| o.into()),
             AeadDecrypt(proc) => proc.execute(runner).map(|o| o.into()),
+
+            #[cfg(feature = "insecure")]
+            CheckingProcedure(proc) => proc.exec(runner).map(|o| o.into()),
         }
     }
 }
@@ -183,6 +189,11 @@ macro_rules! generic_procedures {
             generic_procedures!($Trait<$n> => { $($Proc),+ } );
         )+
     };
+}
+
+#[cfg(feature = "insecure")]
+generic_procedures! {
+    UseSecret<1> => { CheckingProcedure }
 }
 
 generic_procedures! {
@@ -1022,5 +1033,35 @@ impl AesKeyWrapDecrypt {
         wrap.unwrap_key(self.wrapped_key.as_ref(), &mut plaintext)?;
 
         Ok(plaintext)
+    }
+}
+
+/// This procedure is to be used to check for values inside the vault.
+/// By it's very nature, this procedure is not secure to use and is by default
+/// inactive. it MUST NOT be used in production setups.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg(feature = "insecure")]
+pub struct CheckingProcedure {
+    /// The location to look for the specified value
+    pub location: Location,
+
+    /// An expected value to check against
+    pub expected: Vec<u8>,
+}
+
+#[cfg(feature = "insecure")]
+impl UseSecret<1> for CheckingProcedure {
+    type Output = Vec<u8>; // this is a hack, since Procedure::Output only allows Vec output types
+                           // we assume a value of `1` as `true`, while a `0` is considered `false`
+
+    fn use_secret(self, guard: [Buffer<u8>; 1]) -> Result<Self::Output, FatalProcedureError> {
+        let inner = guard[0].borrow();
+        let result = self.expected.eq(inner.as_ref());
+
+        Ok(vec![result.into()])
+    }
+
+    fn source(&self) -> [Location; 1] {
+        [self.location.clone()]
     }
 }

--- a/client/src/procedures/types.rs
+++ b/client/src/procedures/types.rs
@@ -115,6 +115,12 @@ pub trait UseSecret<const N: usize>: Sized {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ProcedureOutput(Vec<u8>);
 
+impl From<bool> for ProcedureOutput {
+    fn from(b: bool) -> Self {
+        ProcedureOutput(vec![0]) // don't think thats a good idea
+    }
+}
+
 impl From<()> for ProcedureOutput {
     fn from(_: ()) -> Self {
         ProcedureOutput(Vec::new())

--- a/client/src/procedures/types.rs
+++ b/client/src/procedures/types.rs
@@ -115,12 +115,6 @@ pub trait UseSecret<const N: usize>: Sized {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ProcedureOutput(Vec<u8>);
 
-impl From<bool> for ProcedureOutput {
-    fn from(b: bool) -> Self {
-        ProcedureOutput(vec![0]) // don't think thats a good idea
-    }
-}
-
 impl From<()> for ProcedureOutput {
     fn from(_: ()) -> Self {
         ProcedureOutput(Vec::new())

--- a/client/src/tests/procedure_tests.rs
+++ b/client/src/tests/procedure_tests.rs
@@ -3,6 +3,9 @@
 
 use crypto::ciphers::aes_kw::AesKeyWrap;
 
+#[cfg(feature = "insecure")]
+use crate::procedures::CheckingProcedure;
+
 use crate::{
     procedures::{
         AeadCipher, AeadDecrypt, AeadEncrypt, AesKeyWrapCipher, AesKeyWrapDecrypt, AesKeyWrapEncrypt, BIP39Generate,

--- a/client/src/tests/procedure_tests.rs
+++ b/client/src/tests/procedure_tests.rs
@@ -4,7 +4,7 @@
 use crypto::ciphers::aes_kw::AesKeyWrap;
 
 #[cfg(feature = "insecure")]
-use crate::procedures::CheckingProcedure;
+use crate::procedures::CompareSecret;
 
 use crate::{
     procedures::{

--- a/client/tests/integration.rs
+++ b/client/tests/integration.rs
@@ -1,8 +1,48 @@
 // Copyright 2020-2022 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+#![allow(unused)]
+
 #[cfg(feature = "std")]
-mod stronghold_test_std {}
+mod stronghold_test_std {
+
+    use iota_stronghold::{procedures::WriteVault, Location, Stronghold};
+    use std::error::Error;
+    use stronghold_utils::random::{self, variable_bytestring};
+
+    #[cfg(feature = "insecure")]
+    use iota_stronghold::procedures::CheckingProcedure;
+
+    /// Generates a random [`Location`].
+    pub fn location() -> Location {
+        Location::generic(variable_bytestring(4096), variable_bytestring(4096))
+    }
+
+    #[tokio::test]
+    #[cfg(feature = "insecure")]
+    async fn external_fn_test_access_secrets() -> Result<(), Box<dyn Error>> {
+        let stronghold = Stronghold::default();
+        let client = stronghold.create_client("client_path")?;
+
+        let expected = random::variable_bytestring(4096);
+        let location = location();
+
+        let write_procedure = WriteVault {
+            data: expected.clone(),
+            location: location.clone(),
+        };
+
+        let checking_procedure = CheckingProcedure { location, expected };
+
+        client.execute_procedure(write_procedure)?;
+
+        // The current impl of `Procedure` only allows `Vec<u8>` as return types, hence the ugly conversion
+        // This restriction shall be lifted in the future
+        assert!(matches!(client.execute_procedure(checking_procedure)?, v if v[0] >= 1 ));
+
+        Ok(())
+    }
+}
 
 #[cfg(feature = "p2p")]
 mod stronghold_test_p2p {}

--- a/client/tests/integration.rs
+++ b/client/tests/integration.rs
@@ -11,7 +11,7 @@ mod stronghold_test_std {
     use stronghold_utils::random::{self, variable_bytestring};
 
     #[cfg(feature = "insecure")]
-    use iota_stronghold::procedures::CheckingProcedure;
+    use iota_stronghold::procedures::CompareSecret;
 
     /// Generates a random [`Location`].
     pub fn location() -> Location {
@@ -32,7 +32,7 @@ mod stronghold_test_std {
             location: location.clone(),
         };
 
-        let checking_procedure = CheckingProcedure { location, expected };
+        let checking_procedure = CompareSecret { location, expected };
 
         client.execute_procedure(write_procedure)?;
 


### PR DESCRIPTION
# Description of change

This PR adds an insecure and feature gated [`Procedure`] to compare values stored inside the vault. The purpose of this functionality is to provide the canonical means to access a secret, while requiring explicit opt-in to this feature. DO NOT USE IN PRODUCTION SETTINGS.

## Links to any relevant issues
none

## Type of change
- [x] Enhancement (a non-breaking change which adds functionality)

## How the change has been tested
integration tests have been provided to check for correctness of the feature.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
