### PR TITLE
Security/clear mnemonic from bip39 procedure

### DIFF
--- a/.changes/bip39clear.md
+++ b/.changes/bip39clear.md
@@ -1,0 +1,5 @@
+---
+"iota-stronghold" : fix
+---
+
+Bip39 mnemonic will now be cleared before the procedure will be dropped

--- a/.changes/bip39clear.md
+++ b/.changes/bip39clear.md
@@ -1,5 +1,5 @@
 ---
-"iota-stronghold" : fix
+"iota-stronghold" : patch
 ---
 
 Bip39 mnemonic will now be cleared before the procedure will be dropped

--- a/client/src/procedures/primitives.rs
+++ b/client/src/procedures/primitives.rs
@@ -30,6 +30,7 @@ use crypto::{
 use engine::runtime::memories::buffer::{Buffer, Ref};
 use serde::{Deserialize, Serialize};
 use stronghold_utils::GuardDebug;
+use zeroize::Zeroize;
 
 /// Enum that wraps all cryptographic procedures that are supported by Stronghold.
 ///
@@ -388,8 +389,12 @@ impl GenerateSecret for BIP39Recover {
 
     fn generate(self) -> Result<Products<Self::Output>, FatalProcedureError> {
         let mut seed = [0u8; 64];
-        let passphrase = self.passphrase.unwrap_or_else(|| "".into());
+        let mut passphrase = self.passphrase.clone().unwrap_or_else(|| "".into());
         bip39::mnemonic_to_seed(&self.mnemonic, &passphrase, &mut seed);
+
+        // explicitly clear passphrase
+        passphrase.zeroize();
+
         Ok(Products {
             secret: seed.to_vec(),
             output: (),
@@ -398,6 +403,15 @@ impl GenerateSecret for BIP39Recover {
 
     fn target(&self) -> &Location {
         &self.output
+    }
+}
+
+impl Drop for BIP39Recover {
+    fn drop(&mut self) {
+        self.mnemonic.zeroize();
+        if let Some(ref mut p) = &mut self.passphrase {
+            p.zeroize();
+        }
     }
 }
 

--- a/client/src/procedures/primitives.rs
+++ b/client/src/procedures/primitives.rs
@@ -361,8 +361,10 @@ impl GenerateSecret for BIP39Generate {
         let mnemonic = bip39::wordlist::encode(&entropy, &wordlist).unwrap();
 
         let mut seed = [0u8; 64];
-        let passphrase = self.passphrase.unwrap_or_else(|| "".into());
+        let mut passphrase = self.passphrase.clone().unwrap_or_else(|| "".into());
         bip39::mnemonic_to_seed(&mnemonic, &passphrase, &mut seed);
+
+        passphrase.zeroize();
 
         Ok(Products {
             secret: seed.to_vec(),
@@ -372,6 +374,12 @@ impl GenerateSecret for BIP39Generate {
 
     fn target(&self) -> &Location {
         &self.output
+    }
+}
+
+impl Drop for BIP39Generate {
+    fn drop(&mut self) {
+        self.passphrase.zeroize();
     }
 }
 
@@ -756,6 +764,13 @@ impl GenerateSecret for Pbkdf2Hmac {
 
     fn target(&self) -> &Location {
         &self.output
+    }
+}
+
+impl Drop for Pbkdf2Hmac {
+    fn drop(&mut self) {
+        self.password.zeroize();
+        self.salt.zeroize();
     }
 }
 

--- a/client/src/tests/procedure_tests.rs
+++ b/client/src/tests/procedure_tests.rs
@@ -769,3 +769,36 @@ async fn usecase_move_record() -> Result<(), Box<dyn std::error::Error>> {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn test_bip39_recover_zeroize() -> Result<(), Box<dyn std::error::Error>> {
+    let client_path = "client-path";
+    let vault_path = b"vault-path";
+    let record_path = b"record_path";
+    let location_a = Location::const_generic(vault_path.to_vec(), record_path.to_vec());
+    let location_b = Location::const_generic(vault_path.to_vec(), record_path.to_vec());
+    let passphrase = "passphrase".to_string();
+
+    let stronghold = Stronghold::default();
+
+    let client = stronghold.create_client(client_path)?;
+
+    let bip39_generate = BIP39Generate {
+        language: MnemonicLanguage::English,
+        output: location_a,
+        passphrase: Some(passphrase.clone()),
+    };
+
+    let mnemonic = client.execute_procedure(bip39_generate)?;
+
+    let bip39_recover = BIP39Recover {
+        passphrase: Some(passphrase),
+        mnemonic,
+        output: location_b,
+    };
+
+    let result = client.execute_procedure(bip39_recover);
+    assert!(result.is_ok());
+
+    Ok(())
+}

--- a/client/src/tests/procedure_tests.rs
+++ b/client/src/tests/procedure_tests.rs
@@ -777,7 +777,7 @@ async fn test_bip39_recover_zeroize() -> Result<(), Box<dyn std::error::Error>> 
     let record_path = b"record_path";
     let location_a = Location::const_generic(vault_path.to_vec(), record_path.to_vec());
     let location_b = Location::const_generic(vault_path.to_vec(), record_path.to_vec());
-    let passphrase = "passphrase".to_string();
+    let passphrase = "PASSPHRASEPASSHRASE".to_string();
 
     let stronghold = Stronghold::default();
 
@@ -796,6 +796,8 @@ async fn test_bip39_recover_zeroize() -> Result<(), Box<dyn std::error::Error>> 
         mnemonic,
         output: location_b,
     };
+
+    let pid = std::process::id();
 
     let result = client.execute_procedure(bip39_recover);
     assert!(result.is_ok());


### PR DESCRIPTION
# Description of change

This PR adds `zeroize` to clear the mnemonic when dropping the `BIP39Recover` procedure.

## Links to any relevant issues

none.

## Type of change

- [x] Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

This bug fix has a unit test provided, but would require memory assertion, that the mnemonic has been actually cleared.
## Change checklist


- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
