### PR TITLE
Extend KeyProvider to accept arbitrary length pass-phrases

### DIFF
--- a/.changes/keyprovider.md
+++ b/.changes/keyprovider.md
@@ -1,0 +1,5 @@
+---
+"iota-stronghold" : minor
+---
+
+Extend `KeyProvider` to create from truncated, or hashed passphrase

--- a/.github/workflows/about.toml
+++ b/.github/workflows/about.toml
@@ -7,6 +7,7 @@ accepted = [
     "MIT",
     "MPL-2.0",
     "OpenSSL",
+    "Unicode-DFS-2016",
 ]
 workarounds = [
     "ring"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -21,8 +21,9 @@ insecure = [ ]
 thiserror = { version = "1.0.30" }
 zeroize = { version = "1.4.3", features = [ "zeroize_derive" ] }
 serde = { version = "1.0", features = [ "derive" ] }
-iota-crypto = { version = "0.12.1", features = [
+iota-crypto = { version = "=0.13.0", features = [
   "aes-gcm",
+  "blake2b",
   "aes-kw",
   "random",
   "ed25519",
@@ -43,6 +44,7 @@ rlu = { package = "stronghold-rlu", path = "../rlu/", version = "0.4.0" }
 engine = { package = "stronghold_engine", path = "../engine", version = "0.5.3" }
 stronghold_utils = { package = "stronghold-utils", path = "../utils/", version = "0.4.1" }
 stronghold_derive = { package = "stronghold-derive", path = "../derive", version = "0.3.1" }
+rust-argon2 = { version = "=1.0.0" }
 
 [dev-dependencies]
 tokio = { version = "1.15.0", features = [ "full" ] }

--- a/client/src/security/keyprovider.rs
+++ b/client/src/security/keyprovider.rs
@@ -153,7 +153,7 @@ impl KeyProvider {
         let key = digest.finalize().to_vec();
 
         if key.len() != KEY_SIZE_HASHED {
-            // This restriction referes to the current implementation of the non-contiguous types
+            // This restriction refers to the current implementation of the non-contiguous types
             // and may be lifted in the future. This error will only be thrown, if digests will return
             // another size than 32 bytes.
             return Err(ClientError::IllegalKeySize(32));

--- a/client/src/security/keyprovider.rs
+++ b/client/src/security/keyprovider.rs
@@ -1,8 +1,7 @@
 // Copyright 2020-2022 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::ops::Deref;
-
+use crypto::hashes::Digest;
 use engine::{
     runtime::{
         locked_memory::LockedMemory,
@@ -11,10 +10,14 @@ use engine::{
     },
     vault::NCKey,
 };
+use std::ops::Deref;
 use stronghold_utils::GuardDebug;
 use zeroize::Zeroize;
 
-use crate::internal::Provider;
+use crate::{internal::Provider, ClientError};
+
+/// This constant will be used to truncate a supplied passphrase
+const KEY_SIZE_TRUNCATED: usize = 32;
 
 /// The [`KeyProvider`] keeps secrets in [`NCKey`] at rest,
 /// such that no key can be directly read out from memory. The memory fragments
@@ -32,6 +35,237 @@ impl TryFrom<Vec<u8>> for KeyProvider {
             Some(inner) => Ok(Self { inner }),
             None => Err(MemoryError::NCSizeNotAllowed),
         }
+    }
+}
+
+/// Constructor functions for KeyProvider
+impl KeyProvider {
+    /// Creates a new [`KeyProvider`] with a `passphrase` of arbitrary length.
+    ///
+    /// The `passphrase` will be truncated to 32 bytes of length internally. This function
+    /// is being provided to support legacy passphrase unlock of the snapshot-file.
+    ///
+    /// # Example
+    /// ```
+    /// use iota_stronghold::KeyProvider;
+    /// use std::ops::Deref;
+    ///
+    /// let passphrase = b"superlongpassphraseextrasecure";
+    /// let mut expected: [u8; 32] = [0u8; 32];
+    /// passphrase
+    ///     .as_ref()
+    ///     .iter()
+    ///     .enumerate()
+    ///     .take(32)
+    ///     .for_each(|(i, value)| {
+    ///         expected[i] = *value;
+    ///     });
+    ///
+    /// let result = KeyProvider::with_passphrase_truncated(passphrase.clone());
+    /// assert!(result.is_ok());
+    ///
+    /// // it is safe to unwrap keyprovider
+    /// let keyprovider = result.unwrap();
+    ///
+    /// let buffer = keyprovider.try_unlock();
+    /// assert!(buffer.is_ok(), "Unlocking the keyprovider failed");
+    ///
+    /// // it is safe to unwrap buffer
+    /// let buffer = buffer.unwrap();
+    /// let buffer_ref = buffer.borrow();
+    /// let key = buffer_ref.deref();
+    ///
+    /// assert_eq!(key, expected, "Key does not match expected {:?}", key);
+    /// ```
+    pub fn with_passphrase_truncated<P>(mut passphrase: P) -> Result<Self, ClientError>
+    where
+        P: AsRef<[u8]> + Zeroize,
+    {
+        let mut key: [u8; KEY_SIZE_TRUNCATED] = [0u8; KEY_SIZE_TRUNCATED];
+        passphrase
+            .as_ref()
+            .iter()
+            .enumerate()
+            .take(KEY_SIZE_TRUNCATED)
+            .for_each(|(i, value)| {
+                key[i] = *value;
+            });
+
+        let result = Self::try_from(key.to_vec()).map_err(|e| ClientError::Inner(e.to_string()));
+        key.zeroize();
+        passphrase.zeroize();
+
+        result
+    }
+
+    /// Creates a new [`KeyProvider`] from a passphrase, that will be hashed by a custom supplied hashing
+    /// function that implements [`Digest`].
+    ///
+    /// # Example
+    /// ```
+    /// use crypto::hashes::Digest;
+    /// use iota_stronghold::KeyProvider;
+    /// use std::ops::Deref;
+    ///
+    /// // some password and some associated salt.
+    /// let mut passphrase = b"passphrase".to_vec();
+    ///
+    /// // some expected value for the test
+    /// let mut blake2b = crypto::hashes::blake2b::Blake2b256::new();
+    /// blake2b.update(&passphrase);
+    /// let expected = blake2b.finalize();
+    ///
+    /// // create the keyprovider
+    /// let result =
+    ///     KeyProvider::with_passphrase_hashed(passphrase, crypto::hashes::blake2b::Blake2b256::new());
+    ///
+    /// assert!(result.is_ok(), "Failed: {:?}", result);
+    ///
+    /// // unwrapping the keyprovider is safe here
+    /// let keyprovider = result.unwrap();
+    ///
+    /// // unlock the keyprovider
+    /// let buffer = keyprovider.try_unlock();
+    ///
+    /// assert!(
+    ///     buffer.is_ok(),
+    ///     "unlocking the inner buffer failed {:?}",
+    ///     buffer
+    /// );
+    ///
+    /// // unwrappeing the buffer is safe here
+    /// let buffer = buffer.unwrap();
+    ///
+    /// // borrow the inner key
+    /// let buffer_ref = buffer.borrow();
+    ///
+    /// // deref the key
+    /// let key = buffer_ref.deref();
+    ///
+    /// assert_eq!(key, &expected.to_vec());
+    /// ```
+    pub fn with_passphrase_hashed<P, D>(mut passphrase: P, mut digest: D) -> Result<Self, ClientError>
+    where
+        P: AsRef<[u8]> + Zeroize,
+        D: Digest,
+    {
+        digest.update(passphrase.as_ref());
+        let key = digest.finalize();
+
+        let result = Self::try_from(key.to_vec()).map_err(|e| ClientError::Inner(e.to_string()));
+        passphrase.zeroize();
+
+        result
+    }
+
+    /// Creates a new [`KeyProvider`] from a passphrase, that will be hashed by `blake2b`.
+    ///
+    /// # Example
+    /// ```
+    /// use crypto::hashes::Digest;
+    /// use iota_stronghold::KeyProvider;
+    /// use std::ops::Deref;
+    ///
+    /// // some password and some associated salt.
+    /// let mut passphrase = b"passphrase".to_vec();
+    ///
+    /// // some expected value for the test
+    /// let mut blake2b = crypto::hashes::blake2b::Blake2b256::new();
+    /// blake2b.update(&passphrase);
+    /// let expected = blake2b.finalize();
+    ///
+    /// // create the keyprovider
+    /// let result = KeyProvider::with_passphrase_hashed_blake2b(passphrase);
+    ///
+    /// assert!(result.is_ok(), "Failed: {:?}", result);
+    ///
+    /// // unwrapping the keyprovider is safe here
+    /// let keyprovider = result.unwrap();
+    ///
+    /// // unlock the keyprovider
+    /// let buffer = keyprovider.try_unlock();
+    ///
+    /// assert!(
+    ///     buffer.is_ok(),
+    ///     "unlocking the inner buffer failed {:?}",
+    ///     buffer
+    /// );
+    ///
+    /// // unwrapping the buffer is safe here
+    /// let buffer = buffer.unwrap();
+    ///
+    /// // borrow the inner key
+    /// let buffer_ref = buffer.borrow();
+    ///
+    /// // deref the key
+    /// let key = buffer_ref.deref();
+    ///
+    /// assert_eq!(key, &expected.to_vec());
+    /// ```
+    pub fn with_passphrase_hashed_blake2b<P>(passphrase: P) -> Result<Self, ClientError>
+    where
+        P: AsRef<[u8]> + Zeroize,
+    {
+        Self::with_passphrase_hashed(passphrase, crypto::hashes::blake2b::Blake2b256::new())
+    }
+
+    /// Creates a new [``KeyProvider] from a passphrase, that will be hashed with `argon2`.
+    ///
+    /// # Example
+    /// ```no_run
+    /// use iota_stronghold::KeyProvider;
+    /// use std::ops::Deref;
+    ///
+    /// // some password and some associated salt.
+    /// let mut passphrase = b"passphrase".to_vec();
+    /// let mut salt = b"saltyvalue".to_vec();
+    ///
+    /// // some expected value for the test
+    /// let config = argon2::Config::default();
+    /// let expected = argon2::hash_raw(&passphrase, &salt, &config).expect("Failed to calculate hash");
+    ///
+    /// // create the keyprovider
+    /// let result = KeyProvider::with_passphrase_hashed_argon2(passphrase, salt);
+    ///
+    /// assert!(result.is_ok(), "Failed: {:?}", result);
+    ///
+    /// // unwrapping the keyprovider is safe here
+    /// let keyprovider = result.unwrap();
+    ///
+    /// // unlock the keyprovider
+    /// let buffer = keyprovider.try_unlock();
+    ///
+    /// assert!(
+    ///     buffer.is_ok(),
+    ///     "unlocking the inner buffer failed {:?}",
+    ///     buffer
+    /// );
+    ///
+    /// // unwrappeing the buffer is safe here
+    /// let buffer = buffer.unwrap();
+    ///
+    /// // borrow the inner key
+    /// let buffer_ref = buffer.borrow();
+    ///
+    /// // deref the key
+    /// let key = buffer_ref.deref();
+    ///
+    /// assert_eq!(key, expected);
+    /// ```
+    pub fn with_passphrase_hashed_argon2<P>(mut passphrase: P, mut salt: P) -> Result<Self, ClientError>
+    where
+        P: AsRef<[u8]> + Zeroize,
+    {
+        let config = argon2::Config::default();
+
+        let key = argon2::hash_raw(passphrase.as_ref(), salt.as_ref(), &config)
+            .map_err(|e| ClientError::Inner(e.to_string()))?;
+
+        let result = Self::try_from(key.to_vec()).map_err(|e| ClientError::Inner(e.to_string()));
+        passphrase.zeroize();
+        salt.zeroize();
+
+        result
     }
 }
 

--- a/client/src/tests/interface_tests.rs
+++ b/client/src/tests/interface_tests.rs
@@ -517,6 +517,7 @@ fn test_keyprovider_truncated_passphrase() {
 
     let passphrase = b"superlongpassphraseextrasecure";
     let mut expected: [u8; 32] = [0u8; 32];
+
     passphrase.as_ref().iter().enumerate().take(32).for_each(|(i, value)| {
         expected[i] = *value;
     });

--- a/client/src/types/error.rs
+++ b/client/src/types/error.rs
@@ -45,6 +45,9 @@ pub enum ClientError {
 
     #[error("Snapshot file is missing ({0})")]
     SnapshotFileMissing(String),
+
+    #[error("Illegal key size. Should be ({0})")]
+    IllegalKeySize(usize),
 }
 
 #[cfg(feature = "p2p")]


### PR DESCRIPTION
# Description of change

This PR extends `KeyProvider` with 4 functions to create either with a `truncated` passphrase, a hashed passphrase, a blake2b hashed passphrase, and for CPU incurred penalties also an argon2 hashed passphrase.  

## Links to any relevant issues

#410

## Type of change

- [x] Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Unit tests have been provided.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
