### PR TITLE
Add ConcatSecret as Procedure

### DIFF
--- a/.changes/concat.md
+++ b/.changes/concat.md
@@ -1,0 +1,5 @@
+---
+"iota-stronghold":  minor
+---
+
+Add ConcatSecret as procedure to concatenate secrets from different locations together

--- a/.changes/keyprovider.md
+++ b/.changes/keyprovider.md
@@ -1,5 +1,0 @@
----
-"iota-stronghold" : minor
----
-
-Extend `KeyProvider` to create from truncated, or hashed passphrase

--- a/client/src/procedures.rs
+++ b/client/src/procedures.rs
@@ -12,9 +12,9 @@ pub use primitives::CompareSecret;
 
 pub use primitives::{
     AeadCipher, AeadDecrypt, AeadEncrypt, AesKeyWrapCipher, AesKeyWrapDecrypt, AesKeyWrapEncrypt, BIP39Generate,
-    BIP39Recover, Chain, ChainCode, ConcatKdf, CopyRecord, Ed25519Sign, GarbageCollect, GenerateKey, Hkdf, Hmac,
-    KeyType, MnemonicLanguage, Pbkdf2Hmac, PublicKey, RevokeData, Sha2Hash, Slip10Derive, Slip10DeriveInput,
-    Slip10Generate, StrongholdProcedure, WriteVault, X25519DiffieHellman,
+    BIP39Recover, Chain, ChainCode, ConcatKdf, ConcatSecret, CopyRecord, Ed25519Sign, GarbageCollect, GenerateKey,
+    Hkdf, Hmac, KeyType, MnemonicLanguage, Pbkdf2Hmac, PublicKey, RevokeData, Sha2Hash, Slip10Derive,
+    Slip10DeriveInput, Slip10Generate, StrongholdProcedure, WriteVault, X25519DiffieHellman,
 };
 pub use types::{
     DeriveSecret, FatalProcedureError, GenerateSecret, Procedure, ProcedureError, ProcedureOutput, UseSecret,


### PR DESCRIPTION
# Description of change
This PR adds a procedure `ConcatSecret` to concatenate the secrets of two locations and store it into a new location. 

## Links to any relevant issues

#339 

## Type of change

Choose a type of change, and delete any options that are not relevant.
- [x] Enhancement (a non-breaking change which adds functionality)

## How the change has been tested
Unit tests have been provided.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
