### PR TITLE
version: bump dev dependency of criterion to 0.4.0

### DIFF
--- a/.changes/dependencies.md
+++ b/.changes/dependencies.md
@@ -1,0 +1,8 @@
+---
+"iota-stronghold": patch
+"stronghold-rlu" : patch
+"stronghold-runtime" : patch
+"stronghold-engine" : patch
+---
+
+upgrade dev-dependency for criterion

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -48,7 +48,7 @@ rust-argon2 = { version = "=1.0.0" }
 
 [dev-dependencies]
 tokio = { version = "1.15.0", features = [ "full" ] }
-criterion = { version = "0.3", features = [ "async_tokio" ] }
+criterion = { version = "0.4", features = [ "async_tokio" ] }
 env_logger = { version = "0.9.0" }
 ctor = { version = "0.1.21" }
 rand = { version = "0.8.4" }

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -52,7 +52,7 @@ serde = { version = "1.0", features = [ "derive" ] }
 [dev-dependencies]
 tempfile = "3.1.0"
 proptest = "1.0.0"
-criterion = "0.3.3"
+criterion = "0.4"
 json = "0.12"
 
   [dev-dependencies.stronghold-utils]

--- a/engine/runtime/Cargo.toml
+++ b/engine/runtime/Cargo.toml
@@ -42,7 +42,7 @@ nix = { version = "0.24.1" }
 serde_json = { version = "1.0" }
 env_logger = { version = "0.9" }
 dhat = { version = "0.3" }
-criterion = "0.3.3"
+criterion = "0.4"
 
 [[bench]]
 name = "runtime_bench"

--- a/rlu/Cargo.toml
+++ b/rlu/Cargo.toml
@@ -25,7 +25,7 @@ atom = { version = "0.4.0" }
 
 [dev-dependencies]
 tokio = { version = "1.15.0", features = [ "full" ] }
-criterion = { version = "0.3", features = [ "async_tokio" ] }
+criterion = { version = "0.4", features = [ "async_tokio" ] }
 env_logger = { version = "0.9.0" }
 ctor = { version = "0.1.21" }
 rand = { version = "0.8.4" }


### PR DESCRIPTION
# Description of change

This PR removes the inherited dev-dependency of `serde_cbor` which is currently unmaintained.  

## Links to any relevant issues

#298 

## Type of change

- [x] Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

No additional tests have been supplied. 

## Change checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
