### PR TITLE
Force client to be able to be loaded only once

### DIFF
--- a/client/src/types/error.rs
+++ b/client/src/types/error.rs
@@ -5,7 +5,9 @@ use std::{any::Any, convert::Infallible, fmt::Debug, sync::TryLockError};
 
 use engine::{
     snapshot::{ReadError as EngineReadError, WriteError as EngineWriteError},
-    vault::{BoxProvider, RecordError as EngineRecordError, RecordId, VaultError as EngineVaultError, VaultId},
+    vault::{
+        BoxProvider, ClientId, RecordError as EngineRecordError, RecordId, VaultError as EngineVaultError, VaultId,
+    },
 };
 use serde::{de::Error, Deserialize, Serialize};
 use thiserror::Error as DeriveError;
@@ -51,6 +53,9 @@ pub enum ClientError {
 
     #[error("Key Location for Snapshot not present")]
     SnapshotKeyLocationMissing,
+
+    #[error("Client with id {0:?} has already been loaded before. Can not be loaded twice.")]
+    ClientAlreadyLoaded(ClientId),
 }
 
 impl<T> From<TryLockError<T>> for ClientError {


### PR DESCRIPTION
# Description of change
!!! This change breaks the API behaviour

- `load_client` and `load_client_from_snapshot` returns an error if client was already loaded
- add `unload_client` function to clear a client from the clients managed by a Stronghold instance 
- adapt the tests to this new behaviour
- add test for new behaviour and new function

## Links to any relevant issues

fixes issue #430 

## Type of change

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested

Check for errors when clients are loaded twice, unload client and load them again successfully 

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
