### PR TITLE
Add a method to access the store of a Stronghold instance

### DIFF
--- a/.changes/add_store_to_stronghold.md
+++ b/.changes/add_store_to_stronghold.md
@@ -1,0 +1,5 @@
+---
+"iota-stronghold" : minor
+---
+
+Add a method to access the store of a Stronghold instance

--- a/client/src/types/stronghold.rs
+++ b/client/src/types/stronghold.rs
@@ -45,6 +45,11 @@ impl Stronghold {
         Self::default()
     }
 
+    /// Returns an atomic reference to the [`Store`]
+    pub fn store(&self) -> Store {
+        self.store.clone()
+    }
+
     /// Load the state of a [`Snapshot`] at given `snapshot_path`.
     /// The [`Snapshot`] is secured in memory and may be used to load further
     /// clients with [`Stronghold::load_client`].


### PR DESCRIPTION
# Description of change

The [`Store`] of a [`Stronghold`] instance was not accessible before. 
Added a methore `store()` to have access to it

## Links to any relevant issues

Fixes issue #429 

## Type of change

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
