### PR TITLE
Access Store from stronghold

### DIFF
--- a/.changes/store.md
+++ b/.changes/store.md
@@ -1,0 +1,5 @@
+---
+"iota-stronghold" : minor
+---
+
+add Store access from Stronghold type

--- a/client/src/tests/interface_tests.rs
+++ b/client/src/tests/interface_tests.rs
@@ -661,3 +661,21 @@ fn test_stronghold_with_key_location_for_snapshot() {
 
     assert!(client2.is_ok());
 }
+
+#[test]
+fn test_access_store_from_stronghold_type() {
+    let stronghold = Stronghold::default();
+
+    let store = stronghold.store();
+    let key = fixed_random_bytes(32);
+    let value = fixed_random_bytes(32);
+
+    let _ = store.insert(key.clone(), value.clone(), None);
+
+    let store2 = stronghold.store();
+    let result = store2.get(&key);
+    assert!(result.is_ok());
+
+    let r2 = result.unwrap();
+    assert_eq!(r2.unwrap(), value);
+}

--- a/client/src/types/stronghold.rs
+++ b/client/src/types/stronghold.rs
@@ -38,6 +38,12 @@ pub struct Stronghold {
 }
 
 impl Stronghold {
+    /// Returns an atomic reference to the [`Store`]. Access and modifications
+    /// to the Store is session based.
+    pub fn store(&self) -> Store {
+        self.store.clone()
+    }
+
     /// Drop all references
     ///
     /// # Example


### PR DESCRIPTION
# Description of change

This PR gives session based access to the **insecure** `Store` of a running Stronghold instance. 

## Links to any relevant issues

#429 

## Type of change
- [x] Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Integration tests have been provided.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
