### PR TITLE
Secp256k1

### DIFF
--- a/.changes/secp256k1.md
+++ b/.changes/secp256k1.md
@@ -1,6 +1,7 @@
 ---
 "iota-stronghold": minor
 "stronghold-engine": patch
+"stronghold-runtime": patch
 ---
 
 Secp256k1 ECDSA + SLIP-10 support added.

--- a/.changes/secp256k1.md
+++ b/.changes/secp256k1.md
@@ -1,5 +1,7 @@
 ---
 "iota-stronghold": minor
+"stronghold-engine": patch
 ---
 
 Secp256k1 ECDSA + SLIP-10 support added.
+Bump `iota-crypto` version to 0.19.0.

--- a/.changes/secp256k1.md
+++ b/.changes/secp256k1.md
@@ -1,0 +1,5 @@
+---
+"iota-stronghold": minor
+---
+
+Secp256k1 ECDSA + SLIP-10 support added.

--- a/.changes/secp256k1.md
+++ b/.changes/secp256k1.md
@@ -1,5 +1,5 @@
 ---
-"iota-stronghold": minor
+"iota-stronghold": major
 "stronghold-engine": patch
 "stronghold-runtime": patch
 ---

--- a/.changes/secp256k1.md
+++ b/.changes/secp256k1.md
@@ -1,7 +1,7 @@
 ---
 "iota-stronghold": major
-"stronghold-engine": patch
-"stronghold-runtime": patch
+"stronghold-engine": major
+"stronghold-runtime": major
 ---
 
 Secp256k1 ECDSA + SLIP-10 support added.

--- a/bindings/native/Cargo.toml
+++ b/bindings/native/Cargo.toml
@@ -23,7 +23,7 @@ iota_stronghold         = { package = "iota_stronghold",   path = "../../client/
 engine                  = { package = "stronghold_engine",  path = "../../engine", version = "1.0.0" }
 tokio                   = { version = "1.15.0", features = ["full"] }
 base64                  = { version = "0.13.0" }
-iota-crypto = { version = "0.18.0", default-features = false, features = [
+iota-crypto = { version = "0.19.0", default-features = false, features = [
   "aes-gcm",
   "aes-kw",
   "random",

--- a/bindings/native/src/wrapper.rs
+++ b/bindings/native/src/wrapper.rs
@@ -4,7 +4,7 @@
 //#![allow(unused_imports)]
 use crypto::keys::slip10::ChainCode;
 use iota_stronghold::{
-    procedures::{Chain, Ed25519Sign, GenerateKey, KeyType, PublicKey, Slip10Derive, Slip10Generate, WriteVault},
+    procedures::{Chain, Curve, Ed25519Sign, GenerateKey, KeyType, PublicKey, Slip10Derive, Slip10Generate, WriteVault},
     Client, KeyProvider, Location, SnapshotPath, Stronghold,
 };
 use log::*;
@@ -199,6 +199,7 @@ impl StrongholdWrapper {
         log::info!("[Rust] Deriving Seed procedure started");
 
         let slip10_derive = Slip10Derive {
+            curve: Curve::Ed25519,
             chain,
             input: iota_stronghold::procedures::Slip10DeriveInput::Seed(seed_location),
             output: seed_derived_location,

--- a/bindings/native/src/wrapper.rs
+++ b/bindings/native/src/wrapper.rs
@@ -4,7 +4,9 @@
 //#![allow(unused_imports)]
 use crypto::keys::slip10::ChainCode;
 use iota_stronghold::{
-    procedures::{Chain, Curve, Ed25519Sign, GenerateKey, KeyType, PublicKey, Slip10Derive, Slip10Generate, WriteVault},
+    procedures::{
+        Chain, Curve, Ed25519Sign, GenerateKey, KeyType, PublicKey, Slip10Derive, Slip10Generate, WriteVault,
+    },
     Client, KeyProvider, Location, SnapshotPath, Stronghold,
 };
 use log::*;
@@ -131,7 +133,7 @@ impl StrongholdWrapper {
             Err(_err) => return Err(WrapperError::ExecuteProcedure(format!("{:?}", _err))),
         };
 
-        let output: Vec<u8> = procedure_result.into();
+        let output: Vec<u8> = procedure_result;
 
         Ok(output)
     }

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -20,12 +20,14 @@ insecure = [ ]
 thiserror = { version = "1.0.30" }
 zeroize = { version = "1.5.7", default-features = false, features = [ "zeroize_derive" ] }
 serde = { version = "1.0", features = [ "derive" ] }
-iota-crypto = { version = "0.18.0", default-features = false, features = [
+iota-crypto = { version = "0.19.0", default-features = false, features = [
   "aes-gcm",
   "blake2b",
   "aes-kw",
   "random",
+  "rand",
   "ed25519",
+  "secp256k1",
   "sha",
   "hmac",
   "bip39-en",

--- a/client/examples/cli/main.rs
+++ b/client/examples/cli/main.rs
@@ -11,7 +11,7 @@ use iota_stronghold as stronghold;
 use log::*;
 use stronghold::{
     procedures::{
-        BIP39Generate, Chain, GenerateKey, KeyType, MnemonicLanguage, Slip10Derive, Slip10DeriveInput, Slip10Generate,
+        BIP39Generate, Chain, Curve, GenerateKey, KeyType, MnemonicLanguage, Slip10Derive, Slip10DeriveInput, Slip10Generate,
         StrongholdProcedure,
     },
     Client, ClientError, ClientVault, KeyProvider, Location, SnapshotPath, Store, Stronghold,
@@ -330,6 +330,7 @@ async fn command_slip10_derive(chain: ChainInput, input: VaultLocation, output: 
 
     info!("Deriving SLIP10 Child Secret");
     let slip10_derive = Slip10Derive {
+        curve: Curve::Ed25519,
         chain: chain.chain,
         input: Slip10DeriveInput::Seed(output_location),
         output: output.to_location(),

--- a/client/examples/cli/main.rs
+++ b/client/examples/cli/main.rs
@@ -11,8 +11,8 @@ use iota_stronghold as stronghold;
 use log::*;
 use stronghold::{
     procedures::{
-        BIP39Generate, Chain, Curve, GenerateKey, KeyType, MnemonicLanguage, Slip10Derive, Slip10DeriveInput, Slip10Generate,
-        StrongholdProcedure,
+        BIP39Generate, Chain, Curve, GenerateKey, KeyType, MnemonicLanguage, Slip10Derive, Slip10DeriveInput,
+        Slip10Generate, StrongholdProcedure,
     },
     Client, ClientError, ClientVault, KeyProvider, Location, SnapshotPath, Store, Stronghold,
 };

--- a/client/examples/repl/command.rs
+++ b/client/examples/repl/command.rs
@@ -9,7 +9,9 @@ use crate::{
     Command, State, TermAction, HELP_MESSAGE,
 };
 use iota_stronghold::{
-    procedures::{BIP39Generate, BIP39Recover, Chain, Curve, GenerateKey, Slip10Derive, Slip10DeriveInput, Slip10Generate},
+    procedures::{
+        BIP39Generate, BIP39Recover, Chain, Curve, GenerateKey, Slip10Derive, Slip10DeriveInput, Slip10Generate,
+    },
     KeyProvider, Location, SnapshotPath, Stronghold,
 };
 

--- a/client/examples/repl/command.rs
+++ b/client/examples/repl/command.rs
@@ -9,7 +9,7 @@ use crate::{
     Command, State, TermAction, HELP_MESSAGE,
 };
 use iota_stronghold::{
-    procedures::{BIP39Generate, BIP39Recover, Chain, GenerateKey, Slip10Derive, Slip10DeriveInput, Slip10Generate},
+    procedures::{BIP39Generate, BIP39Recover, Chain, Curve, GenerateKey, Slip10Derive, Slip10DeriveInput, Slip10Generate},
     KeyProvider, Location, SnapshotPath, Stronghold,
 };
 
@@ -285,6 +285,7 @@ impl Command for Slip10DeriveCommand {
         let record_path_new = &parameters[4];
 
         client.execute_procedure(Slip10Derive {
+            curve: Curve::Ed25519,
             chain: Chain::from_u32_hardened(chain_code.parse()),
             input: Slip10DeriveInput::Seed(Location::const_generic(
                 vault_path_old.clone().into_bytes(),

--- a/client/src/procedures.rs
+++ b/client/src/procedures.rs
@@ -13,7 +13,7 @@ pub use primitives::CompareSecret;
 pub use primitives::{
     AeadCipher, AeadDecrypt, AeadEncrypt, AesKeyWrapCipher, AesKeyWrapDecrypt, AesKeyWrapEncrypt, BIP39Generate,
     BIP39Recover, Chain, ChainCode, ConcatKdf, ConcatSecret, CopyRecord, Ed25519Sign, GarbageCollect, GenerateKey,
-    Hkdf, Hmac, KeyType, MnemonicLanguage, Pbkdf2Hmac, PublicKey, RevokeData, Sha2Hash, Slip10Derive,
+    Hkdf, Hmac, KeyType, MnemonicLanguage, Pbkdf2Hmac, PublicKey, GetEvmAddress, RevokeData, Sha2Hash, Slip10Derive,
     Slip10DeriveInput, Slip10Generate, StrongholdProcedure, WriteVault, X25519DiffieHellman,
 };
 pub use types::{

--- a/client/src/procedures.rs
+++ b/client/src/procedures.rs
@@ -12,7 +12,7 @@ pub use primitives::CompareSecret;
 
 pub use primitives::{
     AeadCipher, AeadDecrypt, AeadEncrypt, AesKeyWrapCipher, AesKeyWrapDecrypt, AesKeyWrapEncrypt, BIP39Generate,
-    BIP39Recover, Chain, ChainCode, ConcatKdf, ConcatSecret, CopyRecord, Ed25519Sign, Secp256k1EcdsaSign, GarbageCollect, GenerateKey,
+    BIP39Recover, Chain, ChainCode, Curve, ConcatKdf, ConcatSecret, CopyRecord, Ed25519Sign, Secp256k1EcdsaSign, GarbageCollect, GenerateKey,
     Hkdf, Hmac, KeyType, MnemonicLanguage, Pbkdf2Hmac, PublicKey, GetEvmAddress, RevokeData, Sha2Hash, Slip10Derive,
     Slip10DeriveInput, Slip10Generate, StrongholdProcedure, WriteVault, X25519DiffieHellman,
 };

--- a/client/src/procedures.rs
+++ b/client/src/procedures.rs
@@ -12,9 +12,10 @@ pub use primitives::CompareSecret;
 
 pub use primitives::{
     AeadCipher, AeadDecrypt, AeadEncrypt, AesKeyWrapCipher, AesKeyWrapDecrypt, AesKeyWrapEncrypt, BIP39Generate,
-    BIP39Recover, Chain, ChainCode, Curve, ConcatKdf, ConcatSecret, CopyRecord, Ed25519Sign, Secp256k1EcdsaSign, GarbageCollect, GenerateKey,
-    Hkdf, Hmac, KeyType, MnemonicLanguage, Pbkdf2Hmac, PublicKey, GetEvmAddress, RevokeData, Sha2Hash, Slip10Derive,
-    Slip10DeriveInput, Slip10Generate, StrongholdProcedure, WriteVault, X25519DiffieHellman,
+    BIP39Recover, Chain, ChainCode, ConcatKdf, ConcatSecret, CopyRecord, Curve, Ed25519Sign, GarbageCollect,
+    GenerateKey, GetEvmAddress, Hkdf, Hmac, KeyType, MnemonicLanguage, Pbkdf2Hmac, PublicKey, RevokeData,
+    Secp256k1EcdsaSign, Sha2Hash, Slip10Derive, Slip10DeriveInput, Slip10Generate, StrongholdProcedure, WriteVault,
+    X25519DiffieHellman,
 };
 pub use types::{
     DeriveSecret, FatalProcedureError, GenerateSecret, Procedure, ProcedureError, ProcedureOutput, UseSecret,

--- a/client/src/procedures.rs
+++ b/client/src/procedures.rs
@@ -12,7 +12,7 @@ pub use primitives::CompareSecret;
 
 pub use primitives::{
     AeadCipher, AeadDecrypt, AeadEncrypt, AesKeyWrapCipher, AesKeyWrapDecrypt, AesKeyWrapEncrypt, BIP39Generate,
-    BIP39Recover, Chain, ChainCode, ConcatKdf, ConcatSecret, CopyRecord, Ed25519Sign, GarbageCollect, GenerateKey,
+    BIP39Recover, Chain, ChainCode, ConcatKdf, ConcatSecret, CopyRecord, Ed25519Sign, Secp256k1EcdsaSign, GarbageCollect, GenerateKey,
     Hkdf, Hmac, KeyType, MnemonicLanguage, Pbkdf2Hmac, PublicKey, GetEvmAddress, RevokeData, Sha2Hash, Slip10Derive,
     Slip10DeriveInput, Slip10Generate, StrongholdProcedure, WriteVault, X25519DiffieHellman,
 };

--- a/client/src/procedures/primitives.rs
+++ b/client/src/procedures/primitives.rs
@@ -490,7 +490,6 @@ impl DeriveSecret<1> for Slip10Derive {
         let dk = match self.input {
             Slip10DeriveInput::Key(_) => {
                 let r = &*guards[0].borrow();
-                dbg!(r.len());
                 let ext_bytes: &[u8; 64] = r
                     .try_into()
                     .map_err(|_| FatalProcedureError::from("bad slip10 extended secret key size".to_owned()))?;
@@ -523,7 +522,7 @@ fn x25519_secret_key(raw: Ref<u8>) -> Result<x25519::SecretKey, crypto::Error> {
         let e = crypto::Error::BufferSize {
             has: raw.len(),
             needs: x25519::SECRET_KEY_LENGTH,
-            name: "data buffer",
+            name: "x25519 data buffer",
         };
         return Err(e);
     }
@@ -536,7 +535,7 @@ fn ed25519_secret_key(raw: Ref<u8>) -> Result<ed25519::SecretKey, crypto::Error>
         let e = crypto::Error::BufferSize {
             has: raw.len(),
             needs: ed25519::SecretKey::LENGTH,
-            name: "data buffer",
+            name: "ed25519 data buffer",
         };
         return Err(e);
     }
@@ -553,7 +552,7 @@ fn secp256k1_ecdsa_secret_key(raw: Ref<u8>) -> Result<secp256k1_ecdsa::SecretKey
         let e = crypto::Error::BufferSize {
             has: raw_slice.len(),
             needs: secp256k1_ecdsa::SecretKey::LENGTH,
-            name: "data buffer",
+            name: "secp256k1 data buffer",
         };
         return Err(e);
     }

--- a/client/src/procedures/primitives.rs
+++ b/client/src/procedures/primitives.rs
@@ -585,20 +585,21 @@ pub struct PublicKey {
 }
 
 impl UseSecret<1> for PublicKey {
-    type Output = [u8; 32];
+    type Output = Vec<u8>;
 
     fn use_secret(self, guards: [Buffer<u8>; 1]) -> Result<Self::Output, FatalProcedureError> {
         match self.ty {
             KeyType::Ed25519 => {
                 let sk = ed25519_secret_key(guards[0].borrow())?;
-                Ok(sk.public_key().to_bytes())
+                Ok(sk.public_key().to_bytes().to_vec())
             }
             KeyType::X25519 => {
                 let sk = x25519_secret_key(guards[0].borrow())?;
-                Ok(sk.public_key().to_bytes())
+                Ok(sk.public_key().to_bytes().to_vec())
             }
             KeyType::Secp256k1Ecdsa => {
-                Err(FatalProcedureError::from("Invalid key type".to_owned()))
+                let sk = secp256k1_ecdsa_secret_key(guards[0].borrow())?;
+                Ok(sk.public_key().to_bytes().to_vec())
             }
         }
     }

--- a/client/src/tests/procedure_tests.rs
+++ b/client/src/tests/procedure_tests.rs
@@ -10,7 +10,7 @@ use crate::{
     procedures::{
         AeadCipher, AeadDecrypt, AeadEncrypt, AesKeyWrapCipher, AesKeyWrapDecrypt, AesKeyWrapEncrypt, BIP39Generate,
         BIP39Recover, ConcatKdf, CopyRecord, DeriveSecret, Ed25519Sign, GenerateKey, GenerateSecret, Hkdf, KeyType,
-        MnemonicLanguage, PublicKey, Sha2Hash, Slip10Derive, Slip10DeriveInput, Slip10Generate, StrongholdProcedure,
+        MnemonicLanguage, PublicKey, GetEvmAddress, Sha2Hash, Slip10Derive, Slip10DeriveInput, Slip10Generate, StrongholdProcedure,
         WriteVault, X25519DiffieHellman,
     },
     tests::fresh,
@@ -20,7 +20,7 @@ use crate::{
 use crypto::{
     ciphers::{aes_gcm::Aes256Gcm, chacha::XChaCha20Poly1305},
     keys::slip10::ChainCode,
-    signatures::ed25519,
+    signatures::{ed25519, secp256k1_ecdsa},
 };
 use stronghold_utils::random;
 
@@ -293,59 +293,18 @@ async fn usecase_secp256k1() -> Result<(), Box<dyn std::error::Error>> {
     let client: Client = stronghold.create_client(b"client_path").unwrap();
 
     let vault_path = random::variable_bytestring(1024);
-    let seed = Location::generic(vault_path.clone(), random::variable_bytestring(1024));
+    let key = Location::generic(vault_path.clone(), random::variable_bytestring(1024));
 
-    if fresh::coinflip() {
-        let size_bytes = if fresh::coinflip() {
-            Some(fresh::usize(1024))
-        } else {
-            None
-        };
-        // TODO: Bip32Generate
-        let slip10_generate = Slip10Generate {
-            size_bytes,
-            output: seed.clone(),
-        };
-
-        assert!(client.execute_procedure(slip10_generate).is_ok());
-    } else {
-        let bip32_gen = BIP39Generate {
-            // TODO: key_type
-            passphrase: random::passphrase(),
-            output: seed.clone(),
-            language: MnemonicLanguage::English,
-        };
-        assert!(client.execute_procedure(bip32_gen).is_ok());
-    }
-
-    let (_path, chain) = fresh::hd_path();
-    let key = Location::generic(vault_path, random::variable_bytestring(1024));
-
-    // TODO: Bip32Derive
-    let slip10_derive = Slip10Derive {
-        chain,
-        input: Slip10DeriveInput::Seed(seed),
+    let secp256k1_ecdsa_generate = GenerateKey {
+        ty: KeyType::Secp256k1Ecdsa,
         output: key.clone(),
     };
-    assert!(client.execute_procedure(slip10_derive).is_ok());
+    assert!(client.execute_procedure(secp256k1_ecdsa_generate).is_ok());
 
-    let ed25519_pk = PublicKey {
+    let evm_address = GetEvmAddress {
         private_key: key.clone(),
-        ty: KeyType::Ed25519,
     };
-    let pk: [u8; ed25519::PUBLIC_KEY_LENGTH] = client.execute_procedure(ed25519_pk).unwrap();
-
-    let msg = fresh::variable_bytestring(4096);
-
-    let ed25519_sign = Ed25519Sign {
-        private_key: key,
-        msg: msg.clone(),
-    };
-    let sig: [u8; ed25519::SIGNATURE_LENGTH] = client.execute_procedure(ed25519_sign).unwrap();
-
-    let pk = ed25519::PublicKey::try_from_bytes(pk).unwrap();
-    let sig = ed25519::Signature::from_bytes(sig);
-    assert!(pk.verify(&sig, &msg));
+    let evm_addr: [u8; secp256k1_ecdsa::ADDRESS_LENGTH] = client.execute_procedure(evm_address).unwrap();
 
     Ok(())
 }

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -37,7 +37,7 @@ serde = { version = "1.0", features = [ "derive" ] }
   default-features = false
 
   [dependencies.iota-crypto]
-  version = "0.18.0"
+  version = "0.19.0"
   features = [
   "random",
   "chacha",

--- a/engine/fuzz/Cargo.toml
+++ b/engine/fuzz/Cargo.toml
@@ -18,7 +18,7 @@ path = "../"
 version = "0.4"
 
 [dependencies.iota-crypto]
-version = "0.18.0"
+version = "0.19.0"
 features = [ "random", "chacha" ]
 default-features= false
 

--- a/engine/runtime/Cargo.toml
+++ b/engine/runtime/Cargo.toml
@@ -24,7 +24,7 @@ serde = { version = "1.0", features = [ "derive" ] }
 random = { version = "0.8.4", package = "rand" }
 dirs = { version = "4.0.0" }
 thiserror = { version = "1.0" }
-iota-crypto = { version = "0.18.0", default-features = false, features = [ "blake2b" ] }
+iota-crypto = { version = "0.19.0", default-features = false, features = [ "blake2b" ] }
 
 [target."cfg(windows)".dependencies]
 windows = { version = "0.36.0", features = [


### PR DESCRIPTION
# Description of change

Add Secp256k1 ECDSA support: key generation (`GenerateKey`), SLIP-10 key derivation (`Slip10Generate`, `Slip10Derive`), signing (`Secp256k1EcdsaSign`), EVM address generation (`GetEvmAddress`).

## Links to any relevant issues

Be sure to reference any related issues by adding `fixes issue #`.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested

[Main test case](https://github.com/iotaledger/stronghold.rs/blob/secp256k1/client/src/tests/procedure_tests.rs#L292).

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
