### PR TITLE
Slip10Derive extended bytes fix

### DIFF
--- a/.changes/secp256k1.md
+++ b/.changes/secp256k1.md
@@ -5,4 +5,4 @@
 ---
 
 Secp256k1 ECDSA + SLIP-10 support added.
-Bump `iota-crypto` version to 0.20.0.
+Bump `iota-crypto` version to 0.20.1.

--- a/bindings/native/Cargo.toml
+++ b/bindings/native/Cargo.toml
@@ -23,7 +23,7 @@ iota_stronghold         = { package = "iota_stronghold",   path = "../../client/
 engine                  = { package = "stronghold_engine",  path = "../../engine", version = "1.0.0" }
 tokio                   = { version = "1.15.0", features = ["full"] }
 base64                  = { version = "0.13.0" }
-iota-crypto = { version = "0.20.0", default-features = false, features = [
+iota-crypto = { version = "0.20.1", default-features = false, features = [
   "aes-gcm",
   "aes-kw",
   "random",

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -20,7 +20,7 @@ insecure = [ ]
 thiserror = { version = "1.0.30" }
 zeroize = { version = "1.5.7", default-features = false, features = [ "zeroize_derive", "serde" ] }
 serde = { version = "1.0", features = [ "derive" ] }
-iota-crypto = { version = "0.20.0", default-features = false, features = [
+iota-crypto = { version = "0.20.1", default-features = false, features = [
   "aes-gcm",
   "blake2b",
   "aes-kw",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -37,7 +37,7 @@ serde = { version = "1.0", features = [ "derive" ] }
   default-features = false
 
   [dependencies.iota-crypto]
-  version = "0.20.0"
+  version = "0.20.1"
   features = [
   "age",
   "pbkdf2",

--- a/engine/fuzz/Cargo.toml
+++ b/engine/fuzz/Cargo.toml
@@ -18,7 +18,7 @@ path = "../"
 version = "0.4"
 
 [dependencies.iota-crypto]
-version = "0.20.0"
+version = "0.20.1"
 features = [ "random", "chacha" ]
 default-features= false
 

--- a/engine/runtime/Cargo.toml
+++ b/engine/runtime/Cargo.toml
@@ -24,7 +24,7 @@ serde = { version = "1.0", features = [ "derive" ] }
 random = { version = "0.8.4", package = "rand" }
 dirs = { version = "4.0.0" }
 thiserror = { version = "1.0" }
-iota-crypto = { version = "0.20.0", default-features = false, features = [ "blake2b" ] }
+iota-crypto = { version = "0.20.1", default-features = false, features = [ "blake2b" ] }
 
 [target."cfg(windows)".dependencies]
 windows = { version = "0.36.0", features = [


### PR DESCRIPTION
# Description of change

Store/accept 64-byte SLIP10 extended secret bytes. The leading byte (of a full 65-byte extended bytes) is zero, so we skip it. The next 32 bytes are secret keys. This allows to use (64-byte) extended secret bytes as a secret key directly in other operations such as PublicKey, Sign, etc..

## Links to any relevant issues

Be sure to reference any related issues by adding `fixes issue #`.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested

Stronghold doesn't have a mechanism to run a fixed-value tests. `usecase_secp256k1_slip10_derive_key` detects inconsistencies with slip10 key derivation indirectly via extended public key derivation using stronghold and crypto and comparing the two results. It may not catch all issues with extended secret key derivation.

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
