### PR TITLE
Encrypt work factor

### DIFF
--- a/.changes/snapshot_encrypt_work_factor.md
+++ b/.changes/snapshot_encrypt_work_factor.md
@@ -1,0 +1,5 @@
+---
+"stronghold-engine": patch
+---
+
+Added snapshot encryption work factor public access. It should only be used in tests to decrease snapshot encryption/decryption times. It must not be used in production as low values of work factor might lead to secrets/seeds leakage.

--- a/client/src/procedures/primitives.rs
+++ b/client/src/procedures/primitives.rs
@@ -500,16 +500,18 @@ impl DeriveSecret<1> for Slip10Derive {
             Slip10DeriveInput::Key(_) => {
                 let r = &*guards[0].borrow();
                 if r.len() != 64 {
-                    return Err(FatalProcedureError::from("bad slip10 extended secret key size".to_owned()));
+                    return Err(FatalProcedureError::from(
+                        "bad slip10 extended secret key size".to_owned(),
+                    ));
                 }
                 let mut ext_bytes = Zeroizing::new([0_u8; 65]);
-                ext_bytes.as_mut()[1..].copy_from_slice(&r);
+                ext_bytes.as_mut()[1..].copy_from_slice(r);
                 match self.curve {
-                    Curve::Ed25519 => slip10::Slip10::<ed25519::SecretKey>::try_from_extended_bytes(&*ext_bytes)
+                    Curve::Ed25519 => slip10::Slip10::<ed25519::SecretKey>::try_from_extended_bytes(&ext_bytes)
                         .and_then(|parent| parent.derive(&self.chain))
                         .map(|dk| (Zeroizing::new(dk.extended_bytes()[1..].into()), *dk.chain_code())),
                     Curve::Secp256k1 => {
-                        slip10::Slip10::<secp256k1_ecdsa::SecretKey>::try_from_extended_bytes(&*ext_bytes)
+                        slip10::Slip10::<secp256k1_ecdsa::SecretKey>::try_from_extended_bytes(&ext_bytes)
                             .and_then(|parent| parent.derive(&self.chain))
                             .map(|dk| (Zeroizing::new((dk.extended_bytes()[1..]).into()), *dk.chain_code()))
                     }

--- a/client/src/tests/interface_tests.rs
+++ b/client/src/tests/interface_tests.rs
@@ -194,6 +194,7 @@ fn test_stronghold_purge_client() {
 
 #[test]
 fn purge_client() {
+    engine::snapshot::try_set_encrypt_work_factor(0).unwrap();
     // This test will create a client, write secret data into the vault, commit
     // the state into a snapshot. Then purge the client, commit the purged state
     // and reload the client, with an empty state
@@ -254,6 +255,7 @@ fn purge_client() {
 
 #[test]
 fn write_client_to_snapshot() {
+    engine::snapshot::try_set_encrypt_work_factor(0).unwrap();
     let stronghold = Stronghold::default();
 
     let snapshot_path = {
@@ -298,6 +300,7 @@ fn write_client_to_snapshot() {
 
 #[test]
 fn test_load_client_from_snapshot() {
+    engine::snapshot::try_set_encrypt_work_factor(0).unwrap();
     let client_path = fixed_random_bytes(1024);
     let vault_path = fixed_random_bytes(1024);
     let record_path = fixed_random_bytes(1024);
@@ -346,6 +349,7 @@ fn test_load_client_from_snapshot() {
 
 #[test]
 fn test_load_multiple_clients_from_snapshot() {
+    engine::snapshot::try_set_encrypt_work_factor(0).unwrap();
     let number_of_clients = 10;
     let client_path_vec: Vec<Vec<u8>> = (0..number_of_clients).map(|_| fixed_random_bytes(256)).collect();
     let mut clients = vec![];
@@ -449,6 +453,7 @@ fn test_create_snapshot_file_in_custom_directory() {
 
 #[test]
 fn test_clear_stronghold_state() {
+    engine::snapshot::try_set_encrypt_work_factor(0).unwrap();
     // pre-requisites
     let client_path = "my-awesome-client-path";
     let vault_path = b"vault_path".to_vec();
@@ -581,6 +586,7 @@ fn test_keyprovider_hashed_passphrase_blake2b() {
 
 #[test]
 fn test_stronghold_with_key_location_for_snapshot() {
+    engine::snapshot::try_set_encrypt_work_factor(0).unwrap();
     let client_path = "my-awesome-client-path";
     let vault_path = b"vault_path".to_vec();
     let record_path = b"record_path".to_vec();
@@ -636,6 +642,7 @@ fn test_stronghold_with_key_location_for_snapshot() {
 
 #[test]
 fn test_load_unload_client() {
+    engine::snapshot::try_set_encrypt_work_factor(0).unwrap();
     let stronghold = Stronghold::default();
     let client_path = "my-awesome-client-path";
     let client = stronghold.create_client(client_path).expect("Failed to create client");

--- a/client/src/tests/procedure_tests.rs
+++ b/client/src/tests/procedure_tests.rs
@@ -344,7 +344,7 @@ async fn usecase_secp256k1_slip10_derive_key() -> Result<(), Box<dyn std::error:
     let chain_code = client.execute_procedure(slip10_derive).unwrap();
 
     let secp256k1_ecdsa_pk = PublicKey {
-        private_key: key.clone(),
+        private_key: key,
         ty: KeyType::Secp256k1Ecdsa,
     };
     let pk = client.execute_procedure(secp256k1_ecdsa_pk).unwrap();

--- a/client/tests/test_multithreaded.rs
+++ b/client/tests/test_multithreaded.rs
@@ -59,6 +59,7 @@ fn test_stronghold_multithreaded_safety() {
 // - Check that all the secrets that were generated concurrently before are present in the saved state
 #[test]
 fn test_full_stronghold_access_multithreaded() {
+    engine::snapshot::try_set_encrypt_work_factor(0).unwrap();
     const NB_INPUTS: usize = 100;
     let pool = ThreadPool::new(NB_THREADS);
 

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -55,7 +55,7 @@ pub fn permissions(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
             }
         }
         Data::Struct(_) | Data::Union(_) => {
-            let ident = derive_input.ident.clone();
+            let ident = derive_input.ident;
             quote! {
                 impl VariantPermission for #ident {
                     fn permission(&self) -> PermissionValue {

--- a/engine/runtime/Cargo.toml
+++ b/engine/runtime/Cargo.toml
@@ -18,7 +18,7 @@ name = "runtime"
 [dependencies]
 libc = { version = "0.2" }
 log = { version = "0.4.17" }
-zeroize = { version = "1.5.7", default-features = false, features = [ "zeroize_derive" ] }
+zeroize = { version = "1.5.7", default-features = false, features = [ "alloc", "zeroize_derive" ] }
 libsodium-sys = { version = "0.2" }
 serde = { version = "1.0", features = [ "derive" ] }
 random = { version = "0.8.4", package = "rand" }

--- a/engine/runtime/src/boxed.rs
+++ b/engine/runtime/src/boxed.rs
@@ -397,6 +397,7 @@ mod test {
         boxed.lock();
     }
 
+    #[allow(clippy::redundant_clone)]
     #[test]
     fn test_eq() {
         let boxed_a = Boxed::<u8>::random(1);

--- a/engine/runtime/src/memories/buffer.rs
+++ b/engine/runtime/src/memories/buffer.rs
@@ -337,6 +337,7 @@ mod tests {
         assert_eq!(borrow, clone);
     }
 
+    #[allow(clippy::redundant_clone)]
     #[test]
     fn buffer_comparisons() {
         let guard = Buffer::<u8>::from(&mut [1, 2, 3][..]);

--- a/engine/src/snapshot/logic.rs
+++ b/engine/src/snapshot/logic.rs
@@ -106,9 +106,6 @@ pub fn try_set_encrypt_work_factor(work_factor: u8) -> Result<(), WriteError> {
 /// In this case it is recommended to use `encrypt_content_with_work_factor` with small/zero work factor.
 pub fn encrypt_content<O: Write>(plain: &[u8], output: &mut O, key: &Key) -> Result<(), WriteError> {
     let work_factor = get_encrypt_work_factor();
-    // let work_factor = age::RECOMMENDED_MINIMUM_ENCRYPT_WORK_FACTOR;
-    // `work_factor = 1` is intentionally just for development.
-    // let work_factor = 1;
     encrypt_content_with_work_factor(plain, output, key, work_factor)
 }
 


### PR DESCRIPTION
# Description of change

The changes introduce public access to the default snapshot encryption work factor. This is a workaround to make tests run faster at the cost of resetting work factor to zero during testing. In production this feature must not be used, and the default work factor must not be modified as it will lead to security compromise and potential leaks of secrets, including seed.

## Links to any relevant issues

Be sure to reference any related issues by adding `fixes issue #`.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
