### PR TITLE
bump crypto to v0.22

### DIFF
--- a/.changes/pre.json
+++ b/.changes/pre.json
@@ -1,7 +1,6 @@
 {
   "tag": "rc",
   "changes": [
-    ".changes/secp256k1.md",
     ".changes/snapshot-migration-v3age-zeroize.md",
     ".changes/snapshot_encrypt_work_factor.md"
   ]

--- a/.changes/secp256k1.md
+++ b/.changes/secp256k1.md
@@ -5,4 +5,4 @@
 ---
 
 Secp256k1 ECDSA with SHA256/Keccak256 + SLIP-10 support added.
-Bump `iota-crypto` version to 0.22.
+Bump `iota-crypto` version to 0.22.1.

--- a/.changes/secp256k1.md
+++ b/.changes/secp256k1.md
@@ -4,5 +4,5 @@
 "stronghold-runtime": major
 ---
 
-Secp256k1 ECDSA + SLIP-10 support added.
-Bump `iota-crypto` version to 0.21.2.
+Secp256k1 ECDSA with SHA256/Keccak256 + SLIP-10 support added.
+Bump `iota-crypto` version to 0.22.

--- a/bindings/native/Cargo.toml
+++ b/bindings/native/Cargo.toml
@@ -23,7 +23,7 @@ iota_stronghold         = { package = "iota_stronghold",   path = "../../client/
 engine                  = { package = "stronghold_engine",  path = "../../engine", version = "2.0.0-rc.0" }
 tokio                   = { version = "1.15.0", features = ["full"] }
 base64                  = { version = "0.13.0" }
-iota-crypto = { version = "0.21.2", default-features = false, features = [
+iota-crypto = { version = "0.22", default-features = false, features = [
   "aes-gcm",
   "aes-kw",
   "random",

--- a/bindings/native/Cargo.toml
+++ b/bindings/native/Cargo.toml
@@ -23,7 +23,7 @@ iota_stronghold         = { package = "iota_stronghold",   path = "../../client/
 engine                  = { package = "stronghold_engine",  path = "../../engine", version = "2.0.0-rc.0" }
 tokio                   = { version = "1.15.0", features = ["full"] }
 base64                  = { version = "0.13.0" }
-iota-crypto = { version = "0.22", default-features = false, features = [
+iota-crypto = { version = "0.22.1", default-features = false, features = [
   "aes-gcm",
   "aes-kw",
   "random",

--- a/bindings/native/Cargo.toml
+++ b/bindings/native/Cargo.toml
@@ -32,6 +32,7 @@ iota-crypto = { version = "0.22", default-features = false, features = [
   "hmac",
   "bip39-en",
   "bip39-jp",
+  "bip44",
   "slip10",
   "chacha",
   "x25519"

--- a/bindings/native/src/wrapper.rs
+++ b/bindings/native/src/wrapper.rs
@@ -2,7 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //#![allow(unused_imports)]
-use crypto::keys::slip10::{self, Segment};
+use crypto::{
+    keys::{bip44, slip10},
+    signatures::ed25519,
+};
 use iota_stronghold::{
     procedures::{Curve, Ed25519Sign, GenerateKey, KeyType, PublicKey, Slip10Derive, Slip10Generate, WriteVault},
     Client, KeyProvider, Location, SnapshotPath, Stronghold,
@@ -183,15 +186,16 @@ impl StrongholdWrapper {
             vault_path: VAULT_PATH.as_bytes().to_vec(),
         };
 
-        let chain = [
-            44,   // BIP-0044
+        let chain = bip44::Bip44::from([
             4218, // IOTA coin type
             0,    // zero account id
             0,    // public
             address_index,
-        ]
-        .into_iter()
-        .map(|s| s.harden().into())
+        ])
+        .to_chain::<ed25519::SecretKey>()
+        .iter()
+        .cloned()
+        .map(Into::into)
         .collect();
 
         log::info!("[Rust] Deriving Seed procedure started");

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -20,7 +20,7 @@ insecure = [ ]
 thiserror = { version = "1.0.30" }
 zeroize = { version = "1.5.7", default-features = false, features = [ "zeroize_derive", "serde" ] }
 serde = { version = "1.0", features = [ "derive" ] }
-iota-crypto = { version = "0.22", default-features = false, features = [
+iota-crypto = { version = "0.22.1", default-features = false, features = [
   "aes-gcm",
   "blake2b",
   "aes-kw",

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -20,7 +20,7 @@ insecure = [ ]
 thiserror = { version = "1.0.30" }
 zeroize = { version = "1.5.7", default-features = false, features = [ "zeroize_derive", "serde" ] }
 serde = { version = "1.0", features = [ "derive" ] }
-iota-crypto = { version = "0.21.2", default-features = false, features = [
+iota-crypto = { version = "0.22", default-features = false, features = [
   "aes-gcm",
   "blake2b",
   "aes-kw",
@@ -28,6 +28,7 @@ iota-crypto = { version = "0.21.2", default-features = false, features = [
   "rand",
   "ed25519",
   "secp256k1",
+  "keccak",
   "sha",
   "hmac",
   "bip39-en",

--- a/client/examples/cli/main.rs
+++ b/client/examples/cli/main.rs
@@ -39,9 +39,8 @@ impl FromStr for ChainInput {
         let chain: Vec<u32> = re
             .captures_iter(input)
             .map(|cap| cap["chain_id"].to_string())
-            .map(|s: String| s.parse().unwrap())
-            .map(|s: u32| s.harden().into())
-            .collect();
+            .map(|s: String| s.parse().map(|s: u32| s.harden().into()))
+            .collect::<Result<_, _>>()?;
 
         Ok(Self { chain })
     }

--- a/client/src/procedures.rs
+++ b/client/src/procedures.rs
@@ -13,9 +13,9 @@ pub use primitives::CompareSecret;
 pub use primitives::{
     AeadCipher, AeadDecrypt, AeadEncrypt, AesKeyWrapCipher, AesKeyWrapDecrypt, AesKeyWrapEncrypt, BIP39Generate,
     BIP39Recover, ConcatKdf, ConcatSecret, CopyRecord, Curve, Ed25519Sign, GarbageCollect, GenerateKey, GetEvmAddress,
-    Hkdf, Hmac, KeyType, MnemonicLanguage, Pbkdf2Hmac, PublicKey, RevokeData, Secp256k1EcdsaSign, Sha2Hash,
-    Slip10Chain, Slip10ChainCode, Slip10Derive, Slip10DeriveInput, Slip10Generate, StrongholdProcedure, WriteVault,
-    X25519DiffieHellman,
+    Hkdf, Hmac, KeyType, MnemonicLanguage, Pbkdf2Hmac, PublicKey, RevokeData, Secp256k1EcdsaFlavor, Secp256k1EcdsaSign,
+    Sha2Hash, Slip10Chain, Slip10ChainCode, Slip10Derive, Slip10DeriveInput, Slip10Generate, StrongholdProcedure,
+    WriteVault, X25519DiffieHellman,
 };
 pub use types::{
     DeriveSecret, FatalProcedureError, GenerateSecret, Procedure, ProcedureError, ProcedureOutput, UseSecret,

--- a/client/src/procedures/primitives.rs
+++ b/client/src/procedures/primitives.rs
@@ -678,7 +678,7 @@ impl UseSecret<1> for GetEvmAddress {
 
     fn use_secret(self, guards: [Buffer<u8>; 1]) -> Result<Self::Output, FatalProcedureError> {
         let sk = secp256k1_ecdsa_secret_key(guards[0].borrow())?;
-        Ok(sk.public_key().to_evm_address().into())
+        Ok(sk.public_key().evm_address().into())
     }
 
     fn source(&self) -> [Location; 1] {
@@ -711,19 +711,31 @@ impl UseSecret<1> for Ed25519Sign {
     }
 }
 
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+pub enum Secp256k1EcdsaFlavor {
+    Secp256k1EcdsaKeccak256,
+    Secp256k1EcdsaSha256,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Secp256k1EcdsaSign {
+    pub flavor: Secp256k1EcdsaFlavor,
+
     pub msg: Vec<u8>,
 
     pub private_key: Location,
 }
 
 impl UseSecret<1> for Secp256k1EcdsaSign {
-    type Output = [u8; secp256k1_ecdsa::Signature::LENGTH];
+    type Output = [u8; secp256k1_ecdsa::RecoverableSignature::LENGTH];
 
     fn use_secret(self, guards: [Buffer<u8>; 1]) -> Result<Self::Output, FatalProcedureError> {
+        use Secp256k1EcdsaFlavor::*;
         let sk = secp256k1_ecdsa_secret_key(guards[0].borrow())?;
-        let sig = sk.sign(&self.msg);
+        let sig = match self.flavor {
+            Secp256k1EcdsaKeccak256 => sk.try_sign_keccak256(&self.msg)?,
+            Secp256k1EcdsaSha256 => sk.try_sign_sha256(&self.msg)?,
+        };
         Ok(sig.to_bytes())
     }
 

--- a/client/src/procedures/primitives.rs
+++ b/client/src/procedures/primitives.rs
@@ -713,8 +713,8 @@ impl UseSecret<1> for Ed25519Sign {
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 pub enum Secp256k1EcdsaFlavor {
-    Secp256k1EcdsaKeccak256,
-    Secp256k1EcdsaSha256,
+    Keccak256,
+    Sha256,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -730,11 +730,10 @@ impl UseSecret<1> for Secp256k1EcdsaSign {
     type Output = [u8; secp256k1_ecdsa::RecoverableSignature::LENGTH];
 
     fn use_secret(self, guards: [Buffer<u8>; 1]) -> Result<Self::Output, FatalProcedureError> {
-        use Secp256k1EcdsaFlavor::*;
         let sk = secp256k1_ecdsa_secret_key(guards[0].borrow())?;
         let sig = match self.flavor {
-            Secp256k1EcdsaKeccak256 => sk.try_sign_keccak256(&self.msg)?,
-            Secp256k1EcdsaSha256 => sk.try_sign_sha256(&self.msg)?,
+            Secp256k1EcdsaFlavor::Keccak256 => sk.try_sign_keccak256(&self.msg)?,
+            Secp256k1EcdsaFlavor::Sha256 => sk.try_sign_sha256(&self.msg)?,
         };
         Ok(sig.to_bytes())
     }

--- a/client/src/tests/procedure_tests.rs
+++ b/client/src/tests/procedure_tests.rs
@@ -10,8 +10,8 @@ use crate::{
     procedures::{
         AeadCipher, AeadDecrypt, AeadEncrypt, AesKeyWrapCipher, AesKeyWrapDecrypt, AesKeyWrapEncrypt, BIP39Generate,
         BIP39Recover, ConcatKdf, CopyRecord, Curve, DeriveSecret, Ed25519Sign, GenerateKey, GenerateSecret,
-        GetEvmAddress, Hkdf, KeyType, MnemonicLanguage, PublicKey, Secp256k1EcdsaSign, Sha2Hash, Slip10Derive,
-        Slip10DeriveInput, Slip10Generate, StrongholdProcedure, WriteVault, X25519DiffieHellman,
+        GetEvmAddress, Hkdf, KeyType, MnemonicLanguage, PublicKey, Secp256k1EcdsaFlavor, Secp256k1EcdsaSign, Sha2Hash,
+        Slip10Derive, Slip10DeriveInput, Slip10Generate, StrongholdProcedure, WriteVault, X25519DiffieHellman,
     },
     tests::fresh,
     Client, Location, Stronghold,
@@ -398,24 +398,26 @@ async fn usecase_secp256k1() -> Result<(), Box<dyn std::error::Error>> {
         };
         let evm_addr = client.execute_procedure(evm_address).unwrap();
 
-        assert_eq!(&evm_addr, pk.to_evm_address().as_ref());
+        assert_eq!(&evm_addr, pk.evm_address().as_ref());
 
         let msg = fresh::variable_bytestring(4096);
 
         let secp256k1_ecdsa_sign = Secp256k1EcdsaSign {
+            flavor: Secp256k1EcdsaFlavor::Secp256k1EcdsaKeccak256,
             private_key: sk,
             msg: msg.clone(),
         };
-        let mut sig_bytes: [u8; secp256k1_ecdsa::Signature::LENGTH] =
+        let mut sig_bytes: [u8; secp256k1_ecdsa::RecoverableSignature::LENGTH] =
             client.execute_procedure(secp256k1_ecdsa_sign).unwrap();
 
-        let sig = secp256k1_ecdsa::Signature::try_from_bytes(&sig_bytes).unwrap();
-        assert!(pk.verify(&sig, &msg));
-        assert_eq!(pk, sig.verify_recover(&msg).unwrap());
+        let sig = secp256k1_ecdsa::RecoverableSignature::try_from_bytes(&sig_bytes).unwrap();
+        // assert!(pk.verify(&sig, &msg));
+        assert_eq!(pk, sig.recover_keccak256(&msg).unwrap());
 
         sig_bytes[0] ^= 1;
-        let sig_bad = secp256k1_ecdsa::Signature::try_from_bytes(&sig_bytes).unwrap();
-        assert!(!pk.verify(&sig_bad, &msg));
+        let sig_bad = secp256k1_ecdsa::RecoverableSignature::try_from_bytes(&sig_bytes).unwrap();
+        // assert!(!pk.verify(&sig_bad, &msg));
+        assert!(!sig_bad.recover_keccak256(&msg).map(|rk| pk == rk).unwrap_or(false));
     };
 
     run(sk);

--- a/client/src/tests/procedure_tests.rs
+++ b/client/src/tests/procedure_tests.rs
@@ -403,7 +403,7 @@ async fn usecase_secp256k1() -> Result<(), Box<dyn std::error::Error>> {
         let msg = fresh::variable_bytestring(4096);
 
         let secp256k1_ecdsa_sign = Secp256k1EcdsaSign {
-            flavor: Secp256k1EcdsaFlavor::Secp256k1EcdsaKeccak256,
+            flavor: Secp256k1EcdsaFlavor::Keccak256,
             private_key: sk,
             msg: msg.clone(),
         };

--- a/client/src/tests/procedure_tests.rs
+++ b/client/src/tests/procedure_tests.rs
@@ -411,12 +411,12 @@ async fn usecase_secp256k1() -> Result<(), Box<dyn std::error::Error>> {
             client.execute_procedure(secp256k1_ecdsa_sign).unwrap();
 
         let sig = secp256k1_ecdsa::RecoverableSignature::try_from_bytes(&sig_bytes).unwrap();
-        // assert!(pk.verify(&sig, &msg));
+        assert!(pk.verify_keccak256(sig.as_ref(), &msg));
         assert_eq!(pk, sig.recover_keccak256(&msg).unwrap());
 
         sig_bytes[0] ^= 1;
         let sig_bad = secp256k1_ecdsa::RecoverableSignature::try_from_bytes(&sig_bytes).unwrap();
-        // assert!(!pk.verify(&sig_bad, &msg));
+        assert!(!pk.verify_keccak256(sig_bad.as_ref(), &msg));
         assert!(!sig_bad.recover_keccak256(&msg).map(|rk| pk == rk).unwrap_or(false));
     };
 

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -28,7 +28,7 @@ zeroize = { version = "1.5.7", features = [ "zeroize_derive" ] }
 serde = { version = "1.0", features = [ "derive" ] }
 stronghold-runtime = { version = "2.0.0-rc.0", path = "runtime" }
 digest = { version = "0.10.1", optional = true, default-features = false }
-iota-crypto = { version = "0.22", features = [ "age", "pbkdf2", "random", "chacha", "hmac", "sha", "x25519", "blake2b", "std" ], default-features = false }
+iota-crypto = { version = "0.22.1", features = [ "age", "pbkdf2", "random", "chacha", "hmac", "sha", "x25519", "blake2b", "std" ], default-features = false }
 
 [dev-dependencies]
 tempfile = "3.1.0"

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -28,7 +28,7 @@ zeroize = { version = "1.5.7", features = [ "zeroize_derive" ] }
 serde = { version = "1.0", features = [ "derive" ] }
 stronghold-runtime = { version = "2.0.0-rc.0", path = "runtime" }
 digest = { version = "0.10.1", optional = true, default-features = false }
-iota-crypto = { version = "0.21.2", features = [ "age", "pbkdf2", "random", "chacha", "hmac", "sha", "x25519", "blake2b", "std" ], default-features = false }
+iota-crypto = { version = "0.22", features = [ "age", "pbkdf2", "random", "chacha", "hmac", "sha", "x25519", "blake2b", "std" ], default-features = false }
 
 [dev-dependencies]
 tempfile = "3.1.0"

--- a/engine/fuzz/Cargo.toml
+++ b/engine/fuzz/Cargo.toml
@@ -18,7 +18,7 @@ path = "../"
 version = "0.4"
 
 [dependencies.iota-crypto]
-version = "0.21.2"
+version = "0.22"
 features = [ "random", "chacha" ]
 default-features= false
 

--- a/engine/fuzz/Cargo.toml
+++ b/engine/fuzz/Cargo.toml
@@ -18,7 +18,7 @@ path = "../"
 version = "0.4"
 
 [dependencies.iota-crypto]
-version = "0.22"
+version = "0.22.1"
 features = [ "random", "chacha" ]
 default-features= false
 

--- a/engine/runtime/Cargo.toml
+++ b/engine/runtime/Cargo.toml
@@ -24,7 +24,7 @@ serde = { version = "1.0", features = [ "derive" ] }
 random = { version = "0.8.4", package = "rand" }
 dirs = { version = "4.0.0" }
 thiserror = { version = "1.0" }
-iota-crypto = { version = "0.21.2", default-features = false, features = [ "blake2b" ] }
+iota-crypto = { version = "0.22", default-features = false, features = [ "blake2b" ] }
 
 [target."cfg(windows)".dependencies]
 windows = { version = "0.36.0", features = [

--- a/engine/runtime/Cargo.toml
+++ b/engine/runtime/Cargo.toml
@@ -24,7 +24,7 @@ serde = { version = "1.0", features = [ "derive" ] }
 random = { version = "0.8.4", package = "rand" }
 dirs = { version = "4.0.0" }
 thiserror = { version = "1.0" }
-iota-crypto = { version = "0.22", default-features = false, features = [ "blake2b" ] }
+iota-crypto = { version = "0.22.1", default-features = false, features = [ "blake2b" ] }
 
 [target."cfg(windows)".dependencies]
 windows = { version = "0.36.0", features = [


### PR DESCRIPTION
# Description of change

Bump iota-crypto to v0.22. Add Secp256k1EcdsaFlavor enum to primitives/procedures to distinguish between SHA256 and Keccak256 variants. Use BIP44 in cli example.

## Links to any relevant issues

Be sure to reference any related issues by adding `fixes issue #`.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
