### PR TITLE
Fix compilation for armv7-unknown-linux-gnueabihf target

### DIFF
--- a/.changes/armv7-unknown-linux-gnueabihf-compatibility.md
+++ b/.changes/armv7-unknown-linux-gnueabihf-compatibility.md
@@ -1,4 +1,6 @@
 ---
+"iota-stronghold": patch
+"stronghold-engine": patch
 "stronghold-runtime": patch
 ---
 

--- a/.changes/armv7-unknown-linux-gnueabihf-compatibility.md
+++ b/.changes/armv7-unknown-linux-gnueabihf-compatibility.md
@@ -1,0 +1,5 @@
+---
+"stronghold-runtime": patch
+---
+
+Fixed compilation for armv7-unknown-linux-gnueabihf target.

--- a/engine/runtime/src/memories/frag.rs
+++ b/engine/runtime/src/memories/frag.rs
@@ -25,6 +25,7 @@ use zeroize::Zeroize;
 // This is the page size for most linux systems
 pub static FRAG_MIN_DISTANCE: usize = 0x1000;
 const MAX_RETRY_ATTEMPTS: usize = 10;
+const DEFAULT_MEMORY_PAGE_SIZE: nix::libc::c_long = 0x1000;
 
 /// Fragmenting strategy to allocate memory at random addresses.
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
@@ -216,12 +217,9 @@ where
         use random::{thread_rng, Rng};
         let mut rng = thread_rng();
 
-        let default_page_size = 0x1000i64;
-
         #[allow(clippy::useless_conversion)]
         let pagesize = nix::unistd::sysconf(nix::unistd::SysconfVar::PAGE_SIZE)
-            // Safe to unwrap, because the value of default_page_size fits into i32 and i64.
-            .unwrap_or(Some(default_page_size.try_into().unwrap()))
+            .unwrap_or(Some(DEFAULT_MEMORY_PAGE_SIZE))
             .unwrap() as usize;
 
         info!("Using page size {}", pagesize);
@@ -373,13 +371,9 @@ where
         let min = 0xFFFF;
         let max = 0xFFFF_FFFF;
 
-        // pick a default, if system api call is not successful
-        let default_page_size = 0x1000i64;
-
         #[allow(clippy::useless_conversion)]
         let _pagesize = nix::unistd::sysconf(nix::unistd::SysconfVar::PAGE_SIZE)
-            // Safe to unwrap, because the value of default_page_size fits into i32 and i64.
-            .unwrap_or(Some(default_page_size.try_into().unwrap()))
+            .unwrap_or(Some(DEFAULT_MEMORY_PAGE_SIZE))
             .unwrap() as usize;
 
         // We allocate a sufficiently "large" chunk of memory. A random

--- a/engine/runtime/src/memories/frag.rs
+++ b/engine/runtime/src/memories/frag.rs
@@ -211,11 +211,12 @@ where
         let hr = "-".repeat(20);
         info!("{0}Mapping Allocator{0}", hr);
 
-        const DEFAULT_MEMORY_PAGE_SIZE: nix::libc::c_long = 0x1000;
         let size = std::mem::size_of::<T>();
 
         use random::{thread_rng, Rng};
         let mut rng = thread_rng();
+
+        const DEFAULT_MEMORY_PAGE_SIZE: nix::libc::c_long = 0x1000;
 
         let pagesize = nix::unistd::sysconf(nix::unistd::SysconfVar::PAGE_SIZE)
             .unwrap_or(Some(DEFAULT_MEMORY_PAGE_SIZE))

--- a/engine/runtime/src/memories/frag.rs
+++ b/engine/runtime/src/memories/frag.rs
@@ -25,7 +25,6 @@ use zeroize::Zeroize;
 // This is the page size for most linux systems
 pub static FRAG_MIN_DISTANCE: usize = 0x1000;
 const MAX_RETRY_ATTEMPTS: usize = 10;
-const DEFAULT_MEMORY_PAGE_SIZE: nix::libc::c_long = 0x1000;
 
 /// Fragmenting strategy to allocate memory at random addresses.
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
@@ -212,12 +211,12 @@ where
         let hr = "-".repeat(20);
         info!("{0}Mapping Allocator{0}", hr);
 
+        const DEFAULT_MEMORY_PAGE_SIZE: nix::libc::c_long = 0x1000;
         let size = std::mem::size_of::<T>();
 
         use random::{thread_rng, Rng};
         let mut rng = thread_rng();
 
-        #[allow(clippy::useless_conversion)]
         let pagesize = nix::unistd::sysconf(nix::unistd::SysconfVar::PAGE_SIZE)
             .unwrap_or(Some(DEFAULT_MEMORY_PAGE_SIZE))
             .unwrap() as usize;
@@ -370,11 +369,6 @@ where
 
         let min = 0xFFFF;
         let max = 0xFFFF_FFFF;
-
-        #[allow(clippy::useless_conversion)]
-        let _pagesize = nix::unistd::sysconf(nix::unistd::SysconfVar::PAGE_SIZE)
-            .unwrap_or(Some(DEFAULT_MEMORY_PAGE_SIZE))
-            .unwrap() as usize;
 
         // We allocate a sufficiently "large" chunk of memory. A random
         // offset will be added to the returned pointer and the object will be written.

--- a/engine/runtime/src/memories/frag.rs
+++ b/engine/runtime/src/memories/frag.rs
@@ -220,6 +220,7 @@ where
 
         #[allow(clippy::useless_conversion)]
         let pagesize = nix::unistd::sysconf(nix::unistd::SysconfVar::PAGE_SIZE)
+            // Safe to unwrap, because the value of default_page_size fits into i32 and i64.
             .unwrap_or(Some(default_page_size.try_into().unwrap()))
             .unwrap() as usize;
 
@@ -377,6 +378,7 @@ where
 
         #[allow(clippy::useless_conversion)]
         let _pagesize = nix::unistd::sysconf(nix::unistd::SysconfVar::PAGE_SIZE)
+            // Safe to unwrap, because the value of default_page_size fits into i32 and i64.
             .unwrap_or(Some(default_page_size.try_into().unwrap()))
             .unwrap() as usize;
 

--- a/engine/runtime/src/memories/frag.rs
+++ b/engine/runtime/src/memories/frag.rs
@@ -218,8 +218,9 @@ where
 
         let default_page_size = 0x1000i64;
 
+        #[allow(clippy::useless_conversion)]
         let pagesize = nix::unistd::sysconf(nix::unistd::SysconfVar::PAGE_SIZE)
-            .unwrap_or(Some(default_page_size))
+            .unwrap_or(Some(default_page_size.try_into().unwrap()))
             .unwrap() as usize;
 
         info!("Using page size {}", pagesize);
@@ -257,7 +258,7 @@ where
                 return Err(MemoryError::Allocation("Memory mapping failed".to_string()));
             }
 
-            #[cfg(any(target_os = "macos"))]
+            #[cfg(target_os = "macos")]
             {
                 // on linux this isn't required to commit memory
                 let error = libc::madvise(&mut addr as *mut usize as *mut libc::c_void, size, libc::MADV_WILLNEED);
@@ -374,8 +375,9 @@ where
         // pick a default, if system api call is not successful
         let default_page_size = 0x1000i64;
 
+        #[allow(clippy::useless_conversion)]
         let _pagesize = nix::unistd::sysconf(nix::unistd::SysconfVar::PAGE_SIZE)
-            .unwrap_or(Some(default_page_size))
+            .unwrap_or(Some(default_page_size.try_into().unwrap()))
             .unwrap() as usize;
 
         // We allocate a sufficiently "large" chunk of memory. A random
@@ -420,7 +422,7 @@ where
 
     #[cfg(any(target_os = "linux", target_os = "macos"))]
     fn dealloc(frag: &mut Frag<T>) -> Result<(), Self::Error> {
-        dealloc_direct(frag.info.0 as *mut libc::c_void)
+        dealloc_direct(frag.info.0)
     }
 
     #[cfg(target_os = "windows")]


### PR DESCRIPTION
# Description of change

Fix compilation for armv7-unknown-linux-gnueabihf target.
`nix::unistd::sysconf(nix::unistd::SysconfVar::PAGE_SIZE)` returns i32 instead of i64 there, that's why the conversion is needed.
Also applied two Clippy suggestions.

## Links to any relevant issues

https://github.com/iotaledger/iota-sdk/issues/1161

## Type of change

- [ ] Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

`cargo check --target armv7-unknown-linux-gnueabihf`
