### PR TITLE
Expose the Runner API to allow for external procedures

### DIFF
--- a/client/src/procedures.rs
+++ b/client/src/procedures.rs
@@ -17,6 +17,6 @@ pub use primitives::{
     Slip10DeriveInput, Slip10Generate, StrongholdProcedure, WriteVault, X25519DiffieHellman,
 };
 pub use types::{
-    DeriveSecret, FatalProcedureError, GenerateSecret, Procedure, ProcedureError, ProcedureOutput, UseSecret,
+    DeriveSecret, FatalProcedureError, GenerateSecret, Procedure, ProcedureError, ProcedureOutput, Products, Runner,
+    UseSecret,
 };
-pub(crate) use types::{Products, Runner};

--- a/engine/runtime/Cargo.toml
+++ b/engine/runtime/Cargo.toml
@@ -19,7 +19,7 @@ name = "runtime"
 libc = { version = "0.2" }
 log = { version = "0.4.17" }
 zeroize = { version = "1.5.7", default-features = false, features = [ "zeroize_derive" ] }
-libsodium-sys = { version = "0.2" }
+libsodium-sys-stable = { version = "1.19.25" }
 serde = { version = "1.0", features = [ "derive" ] }
 random = { version = "0.8.4", package = "rand" }
 dirs = { version = "4.0.0" }


### PR DESCRIPTION
# Description of change

The main change here is just to expose the Runner API and also update the `libsodium-sys` library to the `libsodium-sys-stable` version which is being properly maintained  (the older version was achieved months ago).  Exposing the Runner API makes it easier for anyone to create their own procedures without having to make a PR to the stronghold repository.  This doesn't change the security of the library as anyone is able to create their own stronghold client even without these changes.  All this change does, is make it possible for a 3rd party to write their own extension procedures in a way that works with the existing APIs.  The security of these procedures is up to the author rather than the IF.   

## Type of change

Choose a type of change, and delete any options that are not relevant.

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested

Change is very simple, nothing to really test apart from the original tests in the system.  Even without exposing the runner, anyone can build their own stronghold client with the current API. 

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
